### PR TITLE
Add a shortcode to template for single-source content

### DIFF
--- a/layouts/shortcodes/readfile.md
+++ b/layouts/shortcodes/readfile.md
@@ -1,0 +1,8 @@
+{{$file := .Get "file"}}
+{{- if eq (.Get "markdown") "true" -}}
+{{- $file  | readFile | markdownify -}}
+{{- else if  (.Get "highlight") -}}
+{{-  highlight ($file  | readFile) (.Get "highlight") "" -}}
+{{- else -}}
+{{ $file  | readFile | safeHTML }}
+{{- end -}}


### PR DESCRIPTION
Add shortcode to help reduce unnecessary content duplication and enable the Docsy template to handle single-source content.

Copied from https://github.com/gohugoio/hugo/tree/master/docs/layouts/shortcodes

Usage: 
To copy all content from 'shared' file_1, into another file_2, add the following line to file_ 2:

HTML
{{% readfile file="/path/from/site-root/file_1.md" %}}
{{% readfile file="/path/from/site-root/file_1.html" %}}

Markdown
{{% readfile file="/path/from/site-root/file_1.md" markdown="true" %}}