### PR TITLE
Fix color contrast for inlined code

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -21,6 +21,7 @@
 
     // Inline code
     p code {
+        color: inherit;
         padding: 0.2em 0.4em;
         margin: 0;
         font-size: 85%;


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/402

Inline code color before fix:
[![Screenshot from Gyazo](https://gyazo.com/c2a7f8da50e91c171ee10a22d10def10/raw)](https://gyazo.com/c2a7f8da50e91c171ee10a22d10def10)

Inline code color after fix:
[![Screenshot from Gyazo](https://gyazo.com/4638c5fc0c439b599f368e277e501007/raw)](https://gyazo.com/4638c5fc0c439b599f368e277e501007)