### PR TITLE
Add support for a logo in cover block

### DIFF
--- a/assets/scss/blocks/_cover.scss
+++ b/assets/scss/blocks/_cover.scss
@@ -2,6 +2,10 @@
 
 @include td-box-height-modifiers(".td-cover-block");
 
+.td-cover-logo {
+    margin-right: 0.5em;
+}
+
 .td-cover-block {
     position: relative;
     padding-top: 5rem;

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -1,7 +1,9 @@
 {{ $blockID := printf "td-cover-block-%d" .Ordinal }}
 {{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**background*" }}
+{{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" }}
 {{ $col_id := .Get "color" | default "dark" }}
 {{ $image_anchor := .Get "image_anchor" | default "smart" }}
+{{ $logo_anchor := .Get "logo_anchor" | default "smart" }}
 {{/* Height can be one of: auto, min, med, max, full. */}}
 {{ $height := .Get "height" | default "max"  }}
 {{ with $promo_image }}
@@ -10,11 +12,11 @@
 <link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
 <link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
 <style>
-#{{ $blockID }} { 
+#{{ $blockID }} {
     background-image: url({{ $promo_image_small.RelPermalink }}); 
 }
 @media only screen and (min-width: 1200px) {
-    #{{ $blockID }} { 
+    #{{ $blockID }} {
         background-image: url({{ $promo_image_big.RelPermalink }}); 
     }
 }
@@ -25,7 +27,7 @@
     <div class="row">
       <div class="col-12">
         <div class="text-center">
-          {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ . | html }}</h1>{{ end }}
+          {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
           {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
           <div class="pt-3 lead">
             {{ .Inner }}


### PR DESCRIPTION
Allows for a logo image to be placed to the left of the title in the cover block. The logo image is taken from the content directory using a similar method to the background image. Any image file in a content directory matching *logo* will be used as the logo image.