### PR TITLE
Remove href if no previous/next item

### DIFF
--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,11 +1,7 @@
 <ul class="list-unstyled d-flex justify-content-between align-items-center mb-0 pt-5">
   <li>
-    <a href="{{if .PrevInSection}}{{.PrevInSection.RelPermalink}}{{end}}" class="btn btn-primary {{if not .PrevInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
+    <a {{if .PrevInSection}}href="{{.PrevInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .PrevInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
   </li>
- 
-    <a href="{{if .NextInSection}}{{.NextInSection.RelPermalink}}{{end}}" class="btn btn-primary {{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }} <span class="ml-1">→</span></a>
+    <a {{if .NextInSection}}href="{{.NextInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }} <span class="ml-1">→</span></a>
   </li>
 </ul>
-
-
-


### PR DESCRIPTION
"" could well be a broken link, so when using a linkchecker, this comes up as a false positive.

(I recently switched to https://github.com/wjdp/htmltest which is brutally stringent, but finds WAY more things than [linkchecker](https://wummel.github.io/linkchecker/) ever did)

Another option could be to point this to `#` if this is not an acceptable solution.