### PR TITLE
add footer-about switch

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,7 +19,9 @@
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
         {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
-        {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+	{{ if not .Site.Params.ui.footer_about_disable }}
+		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+	{{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Now:
![image](https://user-images.githubusercontent.com/4488261/52849849-fa696f00-314c-11e9-9d31-f3b6107aabb2.png)

I don't want to display `about`, but I want to display page tile: `About | Gin`.

So add the switch, the default value is `false`.

Thanks!