### PR TITLE
Add pageinfo shortcode

### DIFF
--- a/assets/scss/_pageinfo.scss
+++ b/assets/scss/_pageinfo.scss
@@ -1,0 +1,18 @@
+.pageinfo {
+    font-weight: $font-weight-medium;
+    background: $gray-100;
+    color: inherit;
+    border-radius: 0;
+    margin: 2rem;
+    padding: 1.5rem;
+    padding-bottom: 0.5rem;
+
+    @each $color, $value in $theme-colors {
+        &-#{$color} {
+
+            border-style: solid;
+            border-color: $value;
+        }
+    }
+   
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -24,6 +24,8 @@
 @import "search";
 @import "main-container";
 @import "blocks/blocks";
+@import "pageinfo";
+
 
 @if $td-enable-google-fonts {
     @import url($web-font-path);

--- a/layouts/shortcodes/pageinfo.html
+++ b/layouts/shortcodes/pageinfo.html
@@ -1,0 +1,4 @@
+{{ $color := .Get "color" | default "primary" }}
+<div class="pageinfo pageinfo-{{ $color }}">
+{{ .Inner }}
+</div>


### PR DESCRIPTION
A shortcode that lets you add a text box with a border (with configurable color!) - useful for things like beta banners, flagging that pages are placeholder text, etc.

Demo: https://goldydocs.netlify.com/docs/contribution-guidelines/