### PR TITLE
Added code styling within tables

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -20,7 +20,7 @@
     }
 
     // Inline code
-    p code, li > code {
+    p code, li > code, td > code, th > code {
         color: inherit;
         padding: 0.2em 0.4em;
         margin: 0;


### PR DESCRIPTION
Fixes https://github.com/kubeflow/website/issues/730

Code formatting embedded in text within a table is hard to read - the colour is too light. This change makes the inline code style within a table the same as the style outside a table.

**Before:**
![without-style-fix](https://user-images.githubusercontent.com/6138251/58441844-e3152700-8128-11e9-837e-3975c5812fda.png)

**After:**
![with-style-fix](https://user-images.githubusercontent.com/6138251/58441848-ec05f880-8128-11e9-8a70-180b63eaa16d.png)
