### PR TITLE
Accessibility: Add aria-label to footer icons that have a tooltip

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -29,7 +29,7 @@
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
     <a class="text-white" target="_blank" href="{{ .url }}">
       <i class="{{ .icon }}"></i>
     </a>


### PR DESCRIPTION
Due to the way bootstrap.js removes the content of the title attribute on elements that have tooltips, and because there is no other content that is readable by assistive technology, the icons in the footer are not currently accessible.

Adding an aria-label that ingests the name of the icon ensures that screen readers and other assistive technology will have a static reference to read, and also saves having to define a new config property just for the aria-label attribute.

We could add a new property to config.toml if that was preferred, which would let the content of the aria-label attribute be defined separately.

This could also be considered a temporary fix until the bootstrap tooltips are updated to be more accessible. If we want to treat it as temporary, probably better to stick with aria-label storing the .name, so no rework is needed in the future if someone wanted to update their template and we remove the aria-label.