### PR TITLE
.Hugo fix

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}
 {{ if eq (getenv "HUGO_ENV") "production" }}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 {{ else }}


### PR DESCRIPTION
.Hugo has been deprecated, should now be the global hugo

https://discourse.gohugo.io/t/pages-hugo-is-deprecated-as-of-0-55-0/17991