### PR TITLE
Fix shortcodes for 0.55

### DIFF
--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -30,7 +30,7 @@
           {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
           {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
           <div class="pt-3 lead">
-            {{ .Inner }}
+            {{ .Inner | markdownify}}
           </div>
         </div>
       </div>

--- a/layouts/shortcodes/blocks/lead.html
+++ b/layouts/shortcodes/blocks/lead.html
@@ -5,7 +5,7 @@
 <section class="row td-box td-box--{{ $col_id }} position-relative td-box--gradient td-box--height-{{ $height }}">
 	<div class="container text-center td-arrow-down">
 		<span class="h4 mb-0">
-			{{ .Inner }}
+			{{ .Inner | markdownify }}
 		</span>
 	</div>
 </section>

--- a/layouts/shortcodes/blocks/section.html
+++ b/layouts/shortcodes/blocks/section.html
@@ -5,7 +5,7 @@
 <section class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}">
 	<div class="col">
 		<div class="row {{ $type }}">
-			{{ .Inner }}
+			{{ .Inner | markdownify}}
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
Hugo 0.55 renders shortcodes with Markdown and HTML in them differently, need to explicitly call to markdownify inner content provided by user.