### PR TITLE
Add link to create project issue

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -36,6 +36,8 @@ other = "Last modified"
 [post_edit_this]
 other = "Edit this page"
 [post_create_issue]
-other = "Create issue"
+other = "Create documentation issue"
+[post_create_project_issue]
+other = "Create project issue"
 [post_posts_in]
 other = "Posts in"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -36,6 +36,8 @@ other = "Sist endret"
 [post_edit_this]
 other = "Endre denne siden"
 [post_create_issue]
-other = "Opprett sak"
+other = "Opprett dokumentasjon sak"
+[post_create_project_issue]
+other = "Opprett prosjekt sak"
 [post_posts_in]
 other = "Poster i"

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -9,7 +9,7 @@
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $issuesURL }}" target="_blank"><i class="fas fa-book fa-fw"></i> {{ T "post_create_issue" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -12,9 +12,7 @@
 <a href="{{ $issuesURL }}" target="_blank"><i class="fas fa-book fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
-{{ if $project_issueURL }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-{{ end }}
 {{ end }}
 </div>
 {{ end }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,5 +1,6 @@
 {{ if .Path }}
 {{ $gh_repo := ($.Param "github_repo") }}
+{{ $gh_project_repo := ($.Param "github_project_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
@@ -8,7 +9,13 @@
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+<a href="{{ $issuesURL }}" target="_blank"><i class="fas fa-book fa-fw"></i> {{ T "post_create_issue" }}</a>
+{{ if $gh_project_repo }}
+{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+{{ if $project_issueURL }}
+<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+{{ end }}
+{{ end }}
 </div>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Updates `layouts/partials/page-meta-links.html` to add a link to create project issues.

For background context, see https://github.com/google/docsy/issues/88

I did consider using `params.links.developer` from `config.toml`, but on balance it seemed to me like some projects might prefer the flexibility to independently disable either the new **Create project issue** button or the repo link in the footer. Because **Create project issue** is just a link, it could point at any service to collect and manage customer feedback, not necessarily GitHub or a similar Git hosting service, although this would require overriding `page-meta-link.html`. (Not a great example, but think something like Google Forms)

By default, Docsy will just ignore these changes. To test them, you need to update `config.toml` to look something like the following configuration:

```toml
[params]
copyright = "Copyright Contributors to the XYZ Project"
privacy_policy = "<someurl>"
github_repo = "https://github.com/<path/to/docs/repo>"
github_project_repo = "https://github.com/<path/to/project/repo>"
```

Also, I suggested some changes to the icons for the buttons to offer some visual distinction, but I can revert to GitHub icons if that's preferred as the default.

Finally, I used Google Translate to update the Norwegian  strings in `no.toml`.