### PR TITLE
Update prereqs and install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See the
 [Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for a complete list of the
 prerequisites and details about the various installation options.
 
-To use the Docsy theme in your site, you must meet the following prerequisites:
+To use the Docsy theme in your site:
 
 - Install a recent release of the Hugo "extended" version (we recommend version 0.53 or later). If you install from the 
   [release page](https://github.com/gohugoio/hugo/releases), you must ensure to download the `hugo_extended` version 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docsy is a [Hugo](https://gohugo.io/) theme for technical documentation sets, pr
 This is not an officially supported Google product. This project is actively being maintained.
 
 
-## Prerequisites and installation overview
+## Prerequisites and installation
 
 The following high-level list includes the basic prerequisites for using Docsy in your site. 
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,13 @@ Docsy is a [Hugo](https://gohugo.io/) theme for technical documentation sets, pr
 
 This is not an officially supported Google product. This project is actively being maintained.
 
-
-## Prerequisites and installation
+## Prerequisites
 
 The following are basic prerequisites for using Docsy in your site:
-
-<!-- TODO: Update to docsy.dev URL -->
-See the 
-[Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for 
-details about the various installation options.
-
-To use the Docsy theme in your site:
 
 - Install a recent release of the Hugo "extended" version (we recommend version 0.53 or later). If you install from the 
   [release page](https://github.com/gohugoio/hugo/releases), make sure you download the `_extended` version 
   which supports SCSS.
-
-- Get the Docsy theme:
-
-  - (Recommended) Copy the [Docsy Example](https://github.com/google/docsy-example)
-￼	   project, which includes the Docsy theme as a submodule.
-    You can customize this pre-configured basic site into your own Docsy themed site. 
-    [Learn more...](https://github.com/google/docsy-example)
-  
-  - Add Docsy to your existing Hugo site repo's `themes` directory. You can either add Docsy as a Git submodule, or 
-    clone the Docsy theme into your project. See the complete list of 
-    [Docsy installation options](https://docsydocs.netlify.com/docs/getting-started/).
 
 - Install `PostCSS` so that the site build can create the final CSS assets. You can install it locally by running 
   the following commands from the root directory of your project:
@@ -39,19 +20,29 @@ To use the Docsy theme in your site:
   sudo npm install -D --save postcss-cli
   ```
 
-## Usage and documentation
+## Example and usage
 
 <!-- TODO: Update to docsy.dev URL -->
 You can find an example project that uses Docsy in the [Docsy Example Project repo](https://github.com/google/docsy-example). The Docsy Example Project is hosted at [https://goldydocs.netlify.com/](https://goldydocs.netlify.com/).
 
-To use the Docsy theme, you can either:
+To use the Docsy theme for your own site:
 
-* Copy and edit the example project’s repo, which will also give you a skeleton structure for your top-level and documentation sections, or
-* Specify the Docsy theme like any other [Hugo theme](https://gohugo.io/themes/installing-and-using-themes/)
- when creating or updating your site. This gives you all the theme-y goodness but you’ll need to specify your own site structure.
+  - (Recommended) Copy the [example project](https://github.com/google/docsy-example),
+￼	   which includes the Docsy theme as a submodule.
+    You can customize this pre-configured basic site into your own Docsy themed site. 
+    [Learn more...](https://github.com/google/docsy-example)
+  
+  - Add Docsy to your existing Hugo site repo's `themes` directory. You can either add Docsy as a Git submodule, or 
+    clone the Docsy theme into your project.
 
 <!-- TODO: Update to docsy.dev URL -->
-Docsy also has its own user guide (using Docsy, of course!), which you can find at [https://docsydocs.netlify.com/](https://docsydocs.netlify.com/). Alternatively you can use Hugo to generate and serve a local copy (also useful for testing local theme changes), making sure you have installed all the prerequisites listed below:
+See the [Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for 
+details about the various usage options.
+
+## Documentation
+
+<!-- TODO: Update to docsy.dev URL -->
+Docsy has its own user guide (using Docsy, of course!) with lots more information about using the theme, which you can find at [https://docsydocs.netlify.com/](https://docsydocs.netlify.com/). Alternatively you can use Hugo to generate and serve a local copy of the guide (also useful for testing local theme changes), making sure you have installed all the prerequisites listed above:
 
 ```
 git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git
@@ -60,7 +51,3 @@ hugo server --themesDir ../..
 ```
 
 Note that you need the `themesDir` flag because the site files are inside the theme repo.
-
-<!-- TODO: Update to docsy.dev URL -->
-You can find out much more about using Docsy in the [user guide](https://docsydocs.netlify.com/).
-

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The following are basic prerequisites for using Docsy in your site:
 
 <!-- TODO: Update to docsy.dev URL -->
 See the 
-[Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for a complete list of the
-prerequisites and details about the various installation options.
+[Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for 
+details about the various installation options.
 
 To use the Docsy theme in your site:
 
@@ -23,19 +23,13 @@ To use the Docsy theme in your site:
 - Get the Docsy theme:
 
   - (Recommended) Copy the [Docsy Example](https://github.com/google/docsy-example)
-￼	 project, which has the Docsy theme as a submodule.
+￼	   project, which includes the Docsy theme as a submodule.
     You can customize this pre-configured basic site into your own Docsy themed site. 
     [Learn more...](https://github.com/google/docsy-example)
   
-  - Add Docsy to your existing Hugo site repo's `themes` directory. You can either add Docsy as a Git submodule, or clone the Docsy theme into your project.
-    See the complete list of [Docsy installation options](https://docsydocs.netlify.com/docs/getting-started/) .
-  
-    For example, to clone Docsy into the `theme` directory of your project, you run the following command from 
-    your project's root directory:
-    
-    ```
-    git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git themes/docsy
-    ```
+  - Add Docsy to your existing Hugo site repo's `themes` directory. You can either add Docsy as a Git submodule, or 
+    clone the Docsy theme into your project. See the complete list of 
+    [Docsy installation options](https://docsydocs.netlify.com/docs/getting-started/).
 
 - Install `PostCSS` so that the site build can create the final CSS assets. You can install it locally by running 
   the following commands from the root directory of your project:
@@ -47,7 +41,6 @@ To use the Docsy theme in your site:
 
 ## Usage and documentation
 
-
 <!-- TODO: Update to docsy.dev URL -->
 You can find an example project that uses Docsy in the [Docsy Example Project repo](https://github.com/google/docsy-example). The Docsy Example Project is hosted at [https://goldydocs.netlify.com/](https://goldydocs.netlify.com/).
 
@@ -56,7 +49,6 @@ To use the Docsy theme, you can either:
 * Copy and edit the example project’s repo, which will also give you a skeleton structure for your top-level and documentation sections, or
 * Specify the Docsy theme like any other [Hugo theme](https://gohugo.io/themes/installing-and-using-themes/)
  when creating or updating your site. This gives you all the theme-y goodness but you’ll need to specify your own site structure.
-
 
 <!-- TODO: Update to docsy.dev URL -->
 Docsy also has its own user guide (using Docsy, of course!), which you can find at [https://docsydocs.netlify.com/](https://docsydocs.netlify.com/). Alternatively you can use Hugo to generate and serve a local copy (also useful for testing local theme changes), making sure you have installed all the prerequisites listed below:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ To use the Docsy theme in your site:
 
 - Get the Docsy theme:
 
-  - (Recommended) Start with the Docsy Example project and use Docsy as a submodule. If you clone the Docsy Example site, 
+  - (Recommended) Copy the [Docsy Example](https://github.com/google/docsy-example)
+￼	 project, which has the Docsy theme as a submodule.
     you can modify and customize a pre-configured site, into your own Docsy themed site. 
     [Learn more...](https://github.com/google/docsy-example)
   

--- a/README.md
+++ b/README.md
@@ -2,28 +2,52 @@
 
 Docsy is a [Hugo](https://gohugo.io/) theme for technical documentation sets, providing simple navigation, site structure, and more.
 
-This is not an officially supported Google product. This project is currently maintained.
+This is not an officially supported Google product. This project is actively being maintained.
 
 
-## Installation and prerequisites
+## Prerequisites and installation overview
 
-You need a recent version of Hugo to build sites using this theme (preferably 0.45+). If you install from the [release page](https://github.com/gohugoio/hugo/releases), make sure to get the `extended` Hugo version which supports SCSS. Alternatively, on macOS you can install Hugo via Brew.
+The following high-level list includes the basic prerequisites for using Docsy in your site. 
 
-You'll also need `PostCSS` to create the final CSS assets when building your site. You can install it locally with:
+<!-- TODO: Update to docsy.dev URL -->
+See the 
+[Docsy Getting Started Guide](https://docsydocs.netlify.com/docs/getting-started/) for a complete list of the
+prerequisites and details about the various installation options.
 
-```
-npm install
-````
+To use the Docsy theme in your site, you must meet the following prerequisites:
 
-To use a local version of the theme files, clone the repo using:
+- Install a recent release of the Hugo "extended" version (we recommend version 0.53 or later). If you install from the 
+  [release page](https://github.com/gohugoio/hugo/releases), you must ensure to download the `hugo_extended` version 
+  which supports SCSS.
 
-```
-git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git
-```
+- Get the Docsy theme:
 
+  - (Recommended) Start with the Docsy Example project and use Docsy as a submodule. If you clone the Docsy Example site, 
+    you can modify and customize a pre-configured site, into your own Docsy themed site. 
+    [Learn more...](https://github.com/google/docsy-example)
+  
+  - Add docsy to your exsiting site. You can either add Docsy as a submodule, or clone the Docsy repo into your site.
+    See the complete list of [Docsy installation options](https://docsydocs.netlify.com/docs/getting-started/) .
+  
+    For example, to clone Docsy into the `theme` directory of your project, you run the following command from 
+    your project's root directory:
+    
+    ```
+    git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git themes/docsy
+    ```
+
+- Install `PostCSS` so that the site build can create the final CSS assets. You can install it locally by running 
+  the following commands from the root directory of your project:
+
+  ```
+  sudo npm install -D --save autoprefixer
+  sudo npm install -D --save postcss-cli
+  ```
 
 ## Usage and documentation
 
+
+<!-- TODO: Update to docsy.dev URL -->
 You can find an example project that uses Docsy in the [Docsy Example Project repo](https://github.com/google/docsy-example). The Docsy Example Project is hosted at [https://goldydocs.netlify.com/](https://goldydocs.netlify.com/).
 
 To use the Docsy theme, you can either:
@@ -32,6 +56,8 @@ To use the Docsy theme, you can either:
 * Specify the Docsy theme like any other [Hugo theme](https://gohugo.io/themes/installing-and-using-themes/)
  when creating or updating your site. This gives you all the theme-y goodness but you’ll need to specify your own site structure.
 
+
+<!-- TODO: Update to docsy.dev URL -->
 Docsy also has its own user guide (using Docsy, of course!), which you can find at [https://docsydocs.netlify.com/](https://docsydocs.netlify.com/). Alternatively you can use Hugo to generate and serve a local copy (also useful for testing local theme changes), making sure you have installed all the prerequisites listed below:
 
 ```
@@ -42,5 +68,6 @@ hugo server --themesDir ../..
 
 Note that you need the `themesDir` flag because the site files are inside the theme repo.
 
+<!-- TODO: Update to docsy.dev URL -->
 You can find out much more about using Docsy in the [user guide](https://docsydocs.netlify.com/).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ prerequisites and details about the various installation options.
 To use the Docsy theme in your site:
 
 - Install a recent release of the Hugo "extended" version (we recommend version 0.53 or later). If you install from the 
-  [release page](https://github.com/gohugoio/hugo/releases), you must ensure to download the `hugo_extended` version 
+  [release page](https://github.com/gohugoio/hugo/releases), make sure you download the `_extended` version 
   which supports SCSS.
 
 - Get the Docsy theme:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use the Docsy theme in your site:
 
   - (Recommended) Copy the [Docsy Example](https://github.com/google/docsy-example)
 ￼	 project, which has the Docsy theme as a submodule.
-    you can modify and customize a pre-configured site, into your own Docsy themed site. 
+    You can customize this pre-configured basic site into your own Docsy themed site. 
     [Learn more...](https://github.com/google/docsy-example)
   
   - Add docsy to your exsiting site. You can either add Docsy as a submodule, or clone the Docsy repo into your site.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To use the Docsy theme in your site:
     You can customize this pre-configured basic site into your own Docsy themed site. 
     [Learn more...](https://github.com/google/docsy-example)
   
-  - Add docsy to your exsiting site. You can either add Docsy as a submodule, or clone the Docsy repo into your site.
+  - Add Docsy to your existing Hugo site repo's `themes` directory. You can either add Docsy as a Git submodule, or clone the Docsy theme into your project.
     See the complete list of [Docsy installation options](https://docsydocs.netlify.com/docs/getting-started/) .
   
     For example, to clone Docsy into the `theme` directory of your project, you run the following command from 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is not an officially supported Google product. This project is actively bei
 
 ## Prerequisites and installation
 
-The following high-level list includes the basic prerequisites for using Docsy in your site. 
+The following are basic prerequisites for using Docsy in your site:
 
 <!-- TODO: Update to docsy.dev URL -->
 See the 


### PR DESCRIPTION
- (spell out postcss and autoprefixer) in order to run just `npm install`, the packages.json must exist (ie need to clone Docsy-example).
- clarify what the options are to "use Docsy" (submodule vs clone)