### PR TITLE
Add support for Algolia DocSearch

### DIFF
--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,0 +1,9 @@
+<!-- scripts for algolia docsearch -->
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
+indexName: 'axway-open-docs',
+inputSelector: '.td-search-input',
+debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script> 

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,10 +1,3 @@
 {{ with .Site.Params.algolia_docsearch }}
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-<script type="text/javascript"> docsearch({
-apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
-indexName: 'axway-open-docs',
-inputSelector: '.td-search-input',
-debug: false // Set debug to true if you want to inspect the dropdown
-});
-</script> 
+<!-- scripts for algolia docsearch -->
 {{ end }}

--- a/layouts/partials/hooks/body-end.html
+++ b/layouts/partials/hooks/body-end.html
@@ -1,4 +1,4 @@
-<!-- scripts for algolia docsearch -->
+{{ with .Site.Params.algolia_docsearch }}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
 apiKey: '0fe272b76fcdd3184f3bc193bd96ca15',
@@ -7,3 +7,4 @@ inputSelector: '.td-search-input',
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script> 
+{{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,4 +1,3 @@
 {{ with .Site.Params.algolia_docsearch }}
 <!-- stylesheet for algolia docsearch -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 {{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,2 +1,4 @@
-<!-- code for algolia docsearch -->
+{{ with .Site.Params.algolia_docsearch }}
+<!-- stylesheet for algolia docsearch -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+{{ end }}

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,2 @@
+<!-- code for algolia docsearch -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,6 +1,3 @@
-{{ with .Site.Params.gcs_engine_id }}
- <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
-{{ end }}
-{{ with .Site.Params.algolia_docsearch }}
+{{ with or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
  <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ end }}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,3 +1,6 @@
 {{ with .Site.Params.gcs_engine_id }}
  <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ end }}
+{{ with .Site.Params.algolia_docsearch }}
+ <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+{{ end }}

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -97,7 +97,10 @@ time_format_default = "January 2, 2006"
 rss_sections = ["blog"]
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "011217106833237091527:la2vtv2emlw"
+#gcs_engine_id = "011217106833237091527:la2vtv2emlw"
+
+# Enable Algolia DocSearch
+algolia_docsearch = true
 
 # User interface configuration
 [params.ui]
@@ -105,6 +108,8 @@ gcs_engine_id = "011217106833237091527:la2vtv2emlw"
 sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
+#  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
+sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -97,10 +97,10 @@ time_format_default = "January 2, 2006"
 rss_sections = ["blog"]
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-#gcs_engine_id = "011217106833237091527:la2vtv2emlw"
+gcs_engine_id = "011217106833237091527:la2vtv2emlw"
 
 # Enable Algolia DocSearch
-algolia_docsearch = true
+algolia_docsearch = false
 
 # User interface configuration
 [params.ui]
@@ -109,7 +109,7 @@ sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
-sidebar_search_disable = true
+sidebar_search_disable = false
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -92,7 +92,7 @@ By default, the section menu will show the current section fully expanded all th
 
 Breadcrumb navigation is enabled by default. To disable breadcrumb navigation, set site param `ui.breadcrumb_disable = true` in `config.toml`.
 
-## Configure search
+## Configure GCSE search
 
 By default Docsy uses a [Google Custom Search Engine](https://cse.google.com/cse/all) to search your site. To enable this feature, you'll first need to make sure that you have built a public production version of your site, as otherwise your site won't be crawled and indexed.
 
@@ -132,7 +132,7 @@ Once you have your search engine set up, you can add the feature to your site:
     gcs_engine_id = "011737558837375720776:fsdu1nryfng"
     ```
 
-### Disabling search
+### Disabling GCSE search
 
 If you don't specify a Google Custom Search Engine ID for your project, the search box won't appear in your site. If you're using the default `config.toml` from the example site and want to disable search, just comment out or remove the relevant line.
 
@@ -143,3 +143,32 @@ By default, the search box appears in both the top navigation bar and at the top
 ```
 sidebar_search_disable = true
 ```
+
+## Configure Algolia DocSearch
+
+As an alternative to GCSE, you can use [Algolia DocSearch](https://community.algolia.com/docsearch/) with this theme. Algolia DocSearch is free for public documentation sites.
+
+### Sign up for Algolia DocSearch
+
+Complete the form at [https://community.algolia.com/docsearch/#join-docsearch-program](https://community.algolia.com/docsearch/#join-docsearch-program).
+
+If you are accepted to the program, you will receive the JavaScript code to add to your documentation site from Algolia by email.
+
+### Adding Algolia DocSearch
+
+1. Enable Algolia DocSearch in `config.toml`.
+
+    ```
+    # Enable Algolia DocSearch
+    algolia_docsearch = true
+    ```
+
+2. Remove or comment out any GCSE ID in `config.toml` as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
+
+3. Disable the sidebar search in `config.toml` as this is not currently supported for Algolia DocSearch. See [Disabling the sidebar search box](#disabling-the-sidebar-search-box).
+
+3. Add the JavaScript code provided to you by Algolia to the head and body of every page on your site. See [Add code to head or before body end](/docs/adding-content/lookandfeel/#add-code-to-head-or-before-body-end) for details.
+
+4. Update the `inputSelector` field in the body end Javascript with the appropriate CSS selector (e.g. `.td-search-input` to use the default CSS from this theme).
+
+When you've completed these steps the Algolia search should be enabled on your site. Search results are displayed as a drop-down under the search box, so you don't need to add any search results page.


### PR DESCRIPTION
As discussed in #126 this is a PR for using Algolia DocSearch as an alternative to GCSE.

To test that the search displays correctly for the Docsy user guide I've used the Algolia Javascript from my site in the Docsy head end and body end. I've verified this works locally, but of course it display search results from my site. **These changes will need to be removed before this PR is merged.**

Similarly the config.toml changes are added here only for testing purposes and **need to be removed before merging**. I guess the new param needs to be added in the Docsy example project instead?

The change I've made to search-input.html works but is probably not the best way to do it? I'd appreciate any guidance here :)



