### PR TITLE
Markdownify section description

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -21,7 +21,7 @@
                     <h5>
                         <a href="{{ .RelPermalink }}">{{- .Title -}}</a>
                     </h5>
-                    <p>{{ .Description }}</p>
+                    <p>{{ .Description | markdownify }}</p>
                 </div>
             {{ end }}
         {{ end }}


### PR DESCRIPTION
The description for a section can contain markdown content, so this adds `markdownify`so it will be rendered correctly.