### PR TITLE
limit offline search max result count

### DIFF
--- a/static/js/offline-search.js
+++ b/static/js/offline-search.js
@@ -58,7 +58,7 @@ $(window).on('load', function() {
 function registerSearchHandler() {
     $searchInput.oninput = function(event) {
     var query = event.target.value;
-      var results = search(query);  // Perform the search
+      var results = search(query).slice(0, 10);  // Perform the search
 
       // Render search results
     renderSearchResults(results);


### PR DESCRIPTION
The offline search engine (lunr.js) does not provide offset/limit feature, always returns entire results.
Thus, in order to hide unnecessary results, we should truncate the result.

This change shows only the first 10 results at offline search.