### PR TITLE
Offline search improvements

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "tabWidth": 4
+}

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -1,169 +1,171 @@
 // Adapted from code by Matt Walters https://www.mattwalters.net/posts/hugo-and-lunr/
 
-var idx = null;         // Lunr index
-var resultDetails = []; // Will hold the data for the search results (titles and summaries)
-var $searchInput;       // The search box element in the navbar
-
-$(window).on('load', function() {
-
+(function($) {
     'use strict';
 
-    $searchInput = $('.td-search-input');
+    $(document).ready(function() {
+        const $searchInput = $('.td-search-input');
 
-    //
-    // Options for popover
-    //
+        //
+        // Options for popover
+        //
 
-    $searchInput.data('html', true);
-    $searchInput.data('placement', 'bottom');
+        $searchInput.data('html', true);
+        $searchInput.data('placement', 'bottom');
 
-    //
-    // Register handler
-    //
+        //
+        // Register handler
+        //
 
-    // Prevent showing `/search` page by enter key.
-    $searchInput.closest('form').on('submit', () => {
-        return false;
-    });
-
-    // Set up for an Ajax call to request the JSON data file that is created by
-    // Hugo's build process, with the template we added above
-    var request = new XMLHttpRequest();
-
-    request.overrideMimeType("application/json");
-    request.open("GET", $searchInput.data('offline-search-index-json-url'), true); // Request the JSON file created during build
-    request.onload = function() {
-    if (request.status >= 200 && request.status < 400) {
-        // Success response received in requesting the search-index file
-        var searchDocuments = JSON.parse(request.responseText);
-
-        // Build the index so Lunr can search it.  The `ref` field will hold the URL
-        // to the page/post.  title, excerpt, and body will be fields searched.
-        idx = lunr(function lunrIndex() {
-        this.ref('ref');
-        this.field('title');
-        this.field('body');
-
-          // Loop through all the items in the JSON file and add them to the index
-          // so they can be searched.
-        searchDocuments.forEach(function(doc) {
-            this.add(doc);
-            resultDetails[doc.ref] = {
-                'title': doc.title,
-                'excerpt': doc.excerpt,
-            };
-        }, this);
+        $searchInput.on('change', event => {
+            render($(event.target));
         });
-    }
-    };
 
-    // Send the request to load the JSON
-    request.send();
+        // Prevent reloading page by enter key on sidebar search.
+        $searchInput.closest('form').on('submit', () => {
+            return false;
+        });
 
-    // Register handler for the search input field
-    registerSearchHandler();
-});
+        //
+        // Lunr
+        //
 
-function registerSearchHandler() {
-    $searchInput.on('change', function(event) {
-    var query = event.target.value;
-      var results = search(query).slice(0, 10);  // Perform the search
+        let idx = null; // Lunr index
+        const resultDetails = new Map(); // Will hold the data for the search results (titles and summaries)
 
-      // Render search results
-    renderSearchResults(results, $(event.target));
-    });
-}
+        // Set up for an Ajax call to request the JSON data file that is created by Hugo's build process
+        $.ajax($searchInput.data('offline-search-index-json-url')).then(
+            data => {
+                idx = lunr(function() {
+                    this.ref('ref');
+                    this.field('title');
+                    this.field('body');
 
-function renderSearchResults(results, $targetSearchInput) {
-    $targetSearchInput.popover('dispose');
-    if ($targetSearchInput.val() === '') {
-        return;
-    }
+                    data.forEach(doc => {
+                        this.add(doc);
 
-    const $html = $('<div>');
+                        resultDetails.set(doc.ref, {
+                            title: doc.title,
+                            excerpt: doc.excerpt
+                        });
+                    });
+                });
 
-    $html.append(
-        $('<div>')
-            .css({
-                display: 'flex',
-                justifyContent: 'space-between',
-                marginBottom: '1em'
-            })
-            .append(
-                $('<span>')
-                    .text('Search results')
-                    .css({ fontWeight: 'bold' })
-            )
-            .append(
-                $('<i>')
-                    .addClass('fas fa-times search-result-close-button')
-                    .css({
-                        cursor: 'pointer'
-                    })
-            )
-    );
-
-    const $searchResultBody = $('<div>').css({
-        maxHeight: `calc(100vh - ${$targetSearchInput.offset().top + 180}px)`,
-        overflowY: 'auto'
-    });
-    $html.append($searchResultBody);
-
-    if (results.length === 0) {
-        $searchResultBody.append(
-            $('<p>').text(`No results found for query "${$targetSearchInput.val()}"`)
+                $searchInput.trigger('change');
+            }
         );
-    } else {
-        results.forEach(r => {
-            const $cardHeader = $('<div>').addClass('card-header');
-            const doc = resultDetails[r.ref];
 
-            $cardHeader.append(
-                $('<a>')
-                    .attr('href', r.ref)
-                    .text(doc.title)
+        const render = $targetSearchInput => {
+            // Dispose the previous result
+            $targetSearchInput.popover('dispose');
+
+            //
+            // Search
+            //
+
+            if (idx === null) {
+                return;
+            }
+
+            const searchQuery = $targetSearchInput.val();
+            if (searchQuery === '') {
+                return;
+            }
+
+            const results = idx
+                .query(q => {
+                    const tokens = lunr.tokenizer(searchQuery.toLowerCase());
+                    tokens.forEach(token => {
+                        const queryString = token.toString();
+                        q.term(queryString, {
+                            boost: 100
+                        });
+                        q.term(queryString, {
+                            wildcard:
+                                lunr.Query.wildcard.LEADING |
+                                lunr.Query.wildcard.TRAILING,
+                            boost: 10
+                        });
+                        q.term(queryString, {
+                            editDistance: 2
+                        });
+                    });
+                })
+                .slice(0, 10);
+
+            //
+            // Make result html
+            //
+
+            const $html = $('<div>');
+
+            $html.append(
+                $('<div>')
+                    .css({
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        marginBottom: '1em'
+                    })
+                    .append(
+                        $('<span>')
+                            .text('Search results')
+                            .css({ fontWeight: 'bold' })
+                    )
+                    .append(
+                        $('<i>')
+                            .addClass('fas fa-times search-result-close-button')
+                            .css({
+                                cursor: 'pointer'
+                            })
+                    )
             );
 
-            const $cardBody = $('<div>').addClass('card-body');
-            $cardBody.append(
-                $('<p>')
-                    .addClass('card-text text-muted')
-                    .text(doc.excerpt)
-            );
+            const $searchResultBody = $('<div>').css({
+                maxHeight: `calc(100vh - ${$targetSearchInput.offset().top +
+                    180}px)`,
+                overflowY: 'auto'
+            });
+            $html.append($searchResultBody);
 
-            const $card = $('<div>').addClass('card');
-            $card.append($cardHeader).append($cardBody);
+            if (results.length === 0) {
+                $searchResultBody.append(
+                    $('<p>').text(`No results found for query "${searchQuery}"`)
+                );
+            } else {
+                results.forEach(r => {
+                    const $cardHeader = $('<div>').addClass('card-header');
+                    const doc = resultDetails.get(r.ref);
 
-            $searchResultBody.append($card);
-        });
-    }
+                    $cardHeader.append(
+                        $('<a>')
+                            .attr('href', r.ref)
+                            .text(doc.title)
+                    );
 
-    $targetSearchInput.on('shown.bs.popover', () => {
-        $('.search-result-close-button').on('click', () => {
-            $targetSearchInput.val('');
-            $targetSearchInput.trigger('change');
-        });
+                    const $cardBody = $('<div>').addClass('card-body');
+                    $cardBody.append(
+                        $('<p>')
+                            .addClass('card-text text-muted')
+                            .text(doc.excerpt)
+                    );
+
+                    const $card = $('<div>').addClass('card');
+                    $card.append($cardHeader).append($cardBody);
+
+                    $searchResultBody.append($card);
+                });
+            }
+
+            $targetSearchInput.on('shown.bs.popover', () => {
+                $('.search-result-close-button').on('click', () => {
+                    $targetSearchInput.val('');
+                    $targetSearchInput.trigger('change');
+                });
+            });
+
+            $targetSearchInput
+                .data('content', $html[0].outerHTML)
+                .popover('show');
+        };
     });
-
-    $targetSearchInput.data('content', $html[0].outerHTML).popover('show');
-}
-
-function search(query) {
-    return idx.query(q => {
-        const tokens = lunr.tokenizer(query);
-        tokens.forEach(token => {
-            const tokenString = token.toString();
-            q.term(tokenString, {
-                boost: 100
-            });
-            q.term(tokenString, {
-                wildcard:
-                    lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING,
-                boost: 10
-            });
-            q.term(tokenString, {
-                editDistance: 2
-            });
-        });
-    });
-}
+})(jQuery);

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -21,11 +21,6 @@ $(window).on('load', function() {
     // Register handler
     //
 
-    // Disable keydown event handler on `search.js`.
-    $(document).ready(function() {
-        $(document).off('keypress', '.td-search-input')
-    });
-
     // Prevent showing `/search` page by enter key.
     $searchInput.closest('form').on('submit', () => {
         return false;

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,0 +1,5 @@
+{{- $.Scratch.Add "offline-search-index" slice -}}
+{{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
+{{- $.Scratch.Add "offline-search-index" (dict "title" .Title "ref" .Permalink "body" .Plain "excerpt" (.Summary | truncate 100)) -}}
+{{- end -}}
+{{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,10 @@
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
 {{ if and (.Site.Params.offlineSearch) (not .Site.Params.gcs_engine_id) }}
-<script src="https://unpkg.com/lunr@2.1.6/lunr.js"></script>
-<script src="{{ "js/offline-search.js"| relURL }}"></script>
+<script
+  src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
+  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
+  crossorigin="anonymous"></script>
+  <script src="{{ "js/offline-search.js"| relURL }}"></script>
 {{end}}
 {{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -23,11 +23,10 @@
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
-{{ if and (.Site.Params.offlineSearch) (not .Site.Params.gcs_engine_id) }}
+{{ if .Site.Params.offlineSearch }}
 <script
   src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
   integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
   crossorigin="anonymous"></script>
-  <script src="{{ "js/offline-search.js"| relURL }}"></script>
 {{end}}
 {{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -4,6 +4,9 @@
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
+{{ if .Site.Params.offlineSearch }}
+{{ $jsSearch = resources.Get "js/offline-search.js" }}
+{{ end }}
 {{ $js := (slice $jsBase $jsAnchor $jsSearch) | resources.Concat "js/main.js" }}
 {{ if .Site.IsServer }}
 <script src="{{ $js.RelPermalink }}"></script>

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,12 +1,14 @@
 {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
 <input type="search" class="form-control td-search-input" placeholder="&#xf002 {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ else if .Site.Params.offlineSearch }}
+{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "/offline-search-index.json" . }}
+{{ $offlineSearchIndexFingerprint := $offlineSearchIndex | resources.Fingerprint "sha512" }}
 <input
   type="search"
   class="form-control td-search-input"
   placeholder="&#xf002; {{ T "ui_search" }}"
   aria-label="{{ T "ui_search" }}"
   autocomplete="off"
-  data-offline-search-index-json-url="{{ "index.json"| relURL }}"
+  data-offline-search-index-json-url="{{ $offlineSearchIndexFingerprint.Permalink }}"
 >
 {{ end }}

--- a/layouts/search-index/single.html
+++ b/layouts/search-index/single.html
@@ -1,5 +1,0 @@
-{{- $.Scratch.Add "index" slice -}}
-{{- range where .Site.Pages ".Params.exclude_search" "!=" true -}}
-{{- $.Scratch.Add "index" (dict "title" .Title "ref" .Permalink "body" .Plain "excerpt" (.Summary | truncate 100)) -}}
-{{- end -}}
-{{- $.Scratch.Get "index" | jsonify -}}

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -203,17 +203,8 @@ To add Lunr search to your Docsy site:
 
 2. Remove or comment out any GCSE ID in `config.toml` and ensure Algolia DocSearch is set to `false`, as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
 
-3. Ensure you have a Markdown file in `content/en/search-index.md` (and one per other languages if needed) for your search index. It only needs the following frontmatter:
-
-    ```
-    ---
-    type: "search-index"
-    url: "index.json"
-    ---
-    ```
-
 Once you've completed these steps, local search is enabled for your site and results appear in a drop down when you use the search box.
 
 {{% alert title="Tip" %}}
-If you're [testing this locally](/docs/deployment/#serving-your-site-locally) using Hugo’s local server functionality, you need to build your `index.json` file first by running `hugo`. If you have the Hugo server running while you build `index.json`, you may need to stop the server and restart it in order to see your search results.
+If you're [testing this locally](/docs/deployment/#serving-your-site-locally) using Hugo’s local server functionality, you need to build your `offline-search-index.xxx.json` file first by running `hugo`. If you have the Hugo server running while you build `offline-search-index.xxx.json`, you may need to stop the server and restart it in order to see your search results.
 {{% /alert %}}

--- a/userguide/content/en/search-index.md
+++ b/userguide/content/en/search-index.md
@@ -1,4 +1,0 @@
----
-type: "search-index"
-url: "index.json"
----


### PR DESCRIPTION
This change improves offline search:

- Update lunr.js to v2.3.8.
- Use lunr.min.js.
- Multi-language Support on offline search.
  (eg., searching "TechOS" on docsy-example matches Norsk pages.)
- Add fingerprint to offline search index json file name to prevent use old index file after site contents are updated.
- There is no need to provide search-index.md file to generate offline-search-index.json file.
- Fix an issue that search does not work when query is input before lunr indexing is finished.

And code refactoring:

- Remove global variables from offline-search.js.
- Apply code formatter (prettier) to offline-search.js.
- Load search.js only if offline search is disabled since search.js and offline-search.js are conflicting around enter key handling. (Removed a workaround code from offline-search.js for this conflicting.)
