### PR TITLE
Correct copyright attribution

### DIFF
--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -80,7 +80,7 @@ weight = 1
 # Everything below this are Site Params
 
 [params]
-copyright = "Global Inc"
+copyright = "The Docsy Authors"
 privacy_policy = "https://policies.google.com/privacy"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.


### PR DESCRIPTION
"Global Inc" is presumably a placeholder for a demo project. However, the privacy policy in this project is for Google, and of course, https://www.docsy.dev/ itself appears to show "Global Inc" as the copyright, though it should, in actuality, presumably say Google Inc.

I noticed https://example.docsy.dev/ utilizes "The Docsy Authors" as it's copyright attribution though, so presumably that would be the best copyright here as well.