### PR TITLE
Boosting title field at offline search

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -38,7 +38,7 @@
             data => {
                 idx = lunr(function() {
                     this.ref('ref');
-                    this.field('title');
+                    this.field('title', { boost: 2 });
                     this.field('body');
 
                     data.forEach(doc => {


### PR DESCRIPTION
This change increase title field priority at offline search.
(Pages which contains search keywords in title are given priority than keywords in body.)