### PR TITLE
Add fix for Windows formatted path values

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,16 +1,17 @@
 {{ if .Path }}
+{{ $pathFormatted := replace .Path "\\" "/" }}
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ $gh_subdir := ($.Param "github_subdir") }}
 {{ $gh_project_repo := ($.Param "github_project_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
+{{ $editURL := printf "%s/edit/master/content/%s" $gh_repo $pathFormatted }}
 {{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
+{{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
 {{ else if .Site.Language.Lang }}
-{{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) $pathFormatted }}
 {{ else if $gh_subdir }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}
+{{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $pathFormatted }}
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>


### PR DESCRIPTION
Unfortunately, if you render docsy under Hugo for Windows it renders the .Path value with backslashes, which translates to `%5c` values in the resulting github URL. 

This change aims to replace those with forward slashes to make the URLs work correctly.