### PR TITLE
Allow td-box-colors to be overridden

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -52,7 +52,7 @@ $td-sidebar-border-color: $border-color !default;
 // Background colors for the sections on home page etc. It is a paint by number system, starting at 0, where the number is taken from the shortcode's ordinal
 // if not provided by the user.
 // These colors are all part of the theme palette, but the mix is fairly random to create variation. This can be overridden by the project if needed.
-$td-box-colors: $dark, $primary, $secondary, $info, $primary-light, $gray-600, $success, $warning, $dark, $danger, $primary, $secondary, $primary-light, $info;
+$td-box-colors: $dark, $primary, $secondary, $info, $primary-light, $gray-600, $success, $warning, $dark, $danger, $primary, $secondary, $primary-light, $info !default;
 
 $link-color: darken($blue, 15%) !default;
 $link-decoration: none !default;


### PR DESCRIPTION
While the comment says the color list for "paint by numbers" can be overriden, this didn't actually work for me and I suspect it's because of the missing !default annotation.
So after adding it, I was able to override it as expected in my variables file, here's the corresponding change.