### PR TITLE
add github_branch parameter

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -3,15 +3,16 @@
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ $gh_subdir := ($.Param "github_subdir") }}
 {{ $gh_project_repo := ($.Param "github_project_repo") }}
+{{ $gh_branch := (default "master" ($.Param "github_branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/master/content/%s" $gh_repo $pathFormatted }}
+{{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $pathFormatted }}
 {{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
+{{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
 {{ else if .Site.Language.Lang }}
-{{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) $pathFormatted }}
+{{ $editURL = printf "%s/edit/%s/content/%s/%s" $gh_repo $gh_branch ($.Site.Language.Lang) $pathFormatted }}
 {{ else if $gh_subdir }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $pathFormatted }}
+{{ $editURL = printf "%s/edit/%s/%s/content/%s" $gh_repo $gh_branch $gh_subdir $pathFormatted }}
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>

--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -44,4 +44,12 @@ Specify a value here if you have a separate project repo and you'd like your use
 github_project_repo = "https://github.com/google/docsy"
 ```
 
+### `github_branch` (optional)
+
+Specify a value here if you have would like to reference a different branch for the other github settings like **Edit this page** or **Create project isssue**.
+
+```toml
+github_brach = "release"
+```
+
 


### PR DESCRIPTION
Add github_branch parameter to use another branch
then master within the github edit (page-meta) links.

Fixes #176