### PR TITLE
Added link to contribution guidelines in user guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,9 @@ information on using pull requests.
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
+
+## How to contribute
+
+See the [contribution
+guidelines](https://www.docsy.dev/docs/contribution-guidelines/)
+in the Docsy user guide.


### PR DESCRIPTION
It took me a while to find the info on how to contribute, so I've added link to the guide from the contrib readme in the repo.