### PR TITLE
Add reading time:

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,6 +1,9 @@
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
-	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+    {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+        {{ partial "reading-time.html" . }}
+    {{ end }}       
 	{{ .Content }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,7 +1,10 @@
 {{ define "main" }}
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
-	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+        {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+            {{ partial "reading-time.html" . }}
+        {{ end }}
 	{{ .Content }}
         {{ partial "section-index.html" . }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,0 +1,1 @@
+<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i> {{ .ReadingTime }} minute read</p>

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -149,6 +149,12 @@ enable = true
 yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
 
+# Adds a reading time to the top of each doc.
+# If you want this feature, but occasionally need to remove the Reading time from a single page, 
+# add "hide_readingtime: true" to the page's front matter
+[params.ui.readingtime]
+enable = true
+
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
  [[params.links.user]]

--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -1,7 +1,6 @@
 ---
 title: "Look and Feel"
 linkTitle: "Look and Feel"
-hide_readingtime: true
 date: 2017-01-05
 weight: 2
 description: >

--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -1,6 +1,7 @@
 ---
 title: "Look and Feel"
 linkTitle: "Look and Feel"
+hide_readingtime: true
 date: 2017-01-05
 weight: 2
 description: >


### PR DESCRIPTION
This PR fixes #122 

This is what I've changed:
* Add new reading time partial
* Add conditional block for reading time in content layout
* Add new config param in userguide config.toml
* Remove reading time from specific page using front matter field (as a test) (see https://deploy-preview-209--docsydocs.netlify.com/docs/adding-content/lookandfeel/)

I've gone for a more minimal look than the one proposed in the discussion on #122, and am showing only minutes (not seconds). I'm also using the build in Hugo variable for reading time instead of calculating it manually.

There is one issue with this PR in that the reading time is not appearing on the index pages but only on all other pages.

E.g. it appears fine on https://deploy-preview-209--docsydocs.netlify.com/docs/adding-content/content/ but not on https://deploy-preview-209--docsydocs.netlify.com/docs/getting-started/ 

I've implemented this in the same way as the feedback widget (which appears on all doc pages) so can't understand why this is not showing on all pages?