### PR TITLE
Allow adding byline to blocks/cover

### DIFF
--- a/assets/scss/blocks/_cover.scss
+++ b/assets/scss/blocks/_cover.scss
@@ -16,4 +16,9 @@
         size: cover;
     };
 
+    & > .byline {
+        position: absolute;
+        bottom: 2px;
+        right: 4px;
+    }
 }

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -6,7 +6,8 @@
 {{ $image_anchor := .Get "image_anchor" | default "smart" }}
 {{ $logo_anchor := .Get "logo_anchor" | default "smart" }}
 {{/* Height can be one of: auto, min, med, max, full. */}}
-{{ $height := .Get "height" | default "max"  }}
+{{ $height := .Get "height" | default "max" }}
+{{ $byline := .Get "byline" | default "" }}
 {{ with $promo_image }}
 {{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) }}
 {{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) }}
@@ -37,4 +38,9 @@
       </div>
     </div>
   </div>
+  {{ if $byline }}
+  <div class="byline">
+    <small>{{ $byline }}</small>
+  </div>
+  {{ end }}
 </section>

--- a/userguide/content/en/docs/Adding content/Shortcodes/index.md
+++ b/userguide/content/en/docs/Adding content/Shortcodes/index.md
@@ -59,6 +59,7 @@ Note that the relevant shortcode parameters above will have sensible defaults, b
 | image_anchor | |
 | height | | See above.
 | color | | See above. 
+| byline | Byline text on featured image. |
 
 
 To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/master/content/en), in the same directory.


### PR DESCRIPTION
I stumbled upon the need to put a byline on cover photo. I was able to do it for my use-case and decided to share my proposition of how to achieve that with everyone.

## Usage:
Simply specify byline attribute with the text you want to show. It will appear in the right bottom corner.

```
{{< blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" color="orange" byline="Photo by John Doe from example.com" >}}
```

## How does it look like
Please look at the right bottom corner of the screenshot.

### PC
![byline-example](https://user-images.githubusercontent.com/11832884/76081097-b2f88f80-5fa8-11ea-8b45-7df50e6374be.png)

### Mobile

![byline-example-mobile](https://user-images.githubusercontent.com/11832884/76081257-079c0a80-5fa9-11ea-9162-f1b6abf6dcc3.png)
