### PR TITLE
Remove duplicate title tag on docs and blog

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }} td-blog">
     <header>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -2,7 +2,6 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
   </head>
   <body class="td-{{ .Kind }}">
     <header>


### PR DESCRIPTION
This PR fixes #239 by removing the title tags from the `baseof.html` files of `docs` and `blog`.
