### PR TITLE
Improve offline search result style (enlarge the result)

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -129,7 +129,9 @@
 
             const $searchResultBody = $('<div>').css({
                 maxHeight: `calc(100vh - ${
-                    $targetSearchInput.offset().top + 180
+                    $targetSearchInput.offset().top -
+                    $(window).scrollTop() +
+                    180
                 }px)`,
                 overflowY: 'auto',
             });

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -1,9 +1,9 @@
 // Adapted from code by Matt Walters https://www.mattwalters.net/posts/hugo-and-lunr/
 
-(function($) {
+(function ($) {
     'use strict';
 
-    $(document).ready(function() {
+    $(document).ready(function () {
         const $searchInput = $('.td-search-input');
 
         //
@@ -17,7 +17,7 @@
         // Register handler
         //
 
-        $searchInput.on('change', event => {
+        $searchInput.on('change', (event) => {
             render($(event.target));
 
             // Hide keyboard on mobile browser
@@ -38,18 +38,18 @@
 
         // Set up for an Ajax call to request the JSON data file that is created by Hugo's build process
         $.ajax($searchInput.data('offline-search-index-json-src')).then(
-            data => {
-                idx = lunr(function() {
+            (data) => {
+                idx = lunr(function () {
                     this.ref('ref');
                     this.field('title', { boost: 2 });
                     this.field('body');
 
-                    data.forEach(doc => {
+                    data.forEach((doc) => {
                         this.add(doc);
 
                         resultDetails.set(doc.ref, {
                             title: doc.title,
-                            excerpt: doc.excerpt
+                            excerpt: doc.excerpt,
                         });
                     });
                 });
@@ -58,7 +58,7 @@
             }
         );
 
-        const render = $targetSearchInput => {
+        const render = ($targetSearchInput) => {
             // Dispose the previous result
             $targetSearchInput.popover('dispose');
 
@@ -76,21 +76,21 @@
             }
 
             const results = idx
-                .query(q => {
+                .query((q) => {
                     const tokens = lunr.tokenizer(searchQuery.toLowerCase());
-                    tokens.forEach(token => {
+                    tokens.forEach((token) => {
                         const queryString = token.toString();
                         q.term(queryString, {
-                            boost: 100
+                            boost: 100,
                         });
                         q.term(queryString, {
                             wildcard:
                                 lunr.Query.wildcard.LEADING |
                                 lunr.Query.wildcard.TRAILING,
-                            boost: 10
+                            boost: 10,
                         });
                         q.term(queryString, {
-                            editDistance: 2
+                            editDistance: 2,
                         });
                     });
                 })
@@ -107,7 +107,7 @@
                     .css({
                         display: 'flex',
                         justifyContent: 'space-between',
-                        marginBottom: '1em'
+                        marginBottom: '1em',
                     })
                     .append(
                         $('<span>')
@@ -118,15 +118,16 @@
                         $('<i>')
                             .addClass('fas fa-times search-result-close-button')
                             .css({
-                                cursor: 'pointer'
+                                cursor: 'pointer',
                             })
                     )
             );
 
             const $searchResultBody = $('<div>').css({
-                maxHeight: `calc(100vh - ${$targetSearchInput.offset().top +
-                    180}px)`,
-                overflowY: 'auto'
+                maxHeight: `calc(100vh - ${
+                    $targetSearchInput.offset().top + 180
+                }px)`,
+                overflowY: 'auto',
             });
             $html.append($searchResultBody);
 
@@ -135,7 +136,7 @@
                     $('<p>').text(`No results found for query "${searchQuery}"`)
                 );
             } else {
-                results.forEach(r => {
+                results.forEach((r) => {
                     const $cardHeader = $('<div>').addClass('card-header');
                     const doc = resultDetails.get(r.ref);
                     const href =
@@ -143,9 +144,7 @@
                         r.ref.replace(/^\//, '');
 
                     $cardHeader.append(
-                        $('<a>')
-                            .attr('href', href)
-                            .text(doc.title)
+                        $('<a>').attr('href', href).text(doc.title)
                     );
 
                     const $cardBody = $('<div>').addClass('card-body');

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -12,6 +12,10 @@
 
         $searchInput.data('html', true);
         $searchInput.data('placement', 'bottom');
+        $searchInput.data(
+            'template',
+            '<div class="popover offline-search-result" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+        );
 
         //
         // Register handler

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -14,3 +14,16 @@
 
     font-family: "Font Awesome 5 Free", $font-family-base;
 }
+
+.popover.offline-search-result {
+    // Override bootstrap default style (max-width: $popover-max-width;)
+    max-width: 90%;
+
+    .card {
+        margin-bottom: $spacer * .5;
+
+        .card-header {
+            font-weight: bold;
+        }
+    }
+}

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -186,3 +186,29 @@ Once you've completed these steps, local search is enabled for your site and res
 {{% alert title="Tip" %}}
 If you're [testing this locally](/docs/deployment/#serving-your-site-locally) using Hugo’s local server functionality, you need to build your `offline-search-index.xxx.json` file first by running `hugo`. If you have the Hugo server running while you build `offline-search-index.xxx.json`, you may need to stop the server and restart it in order to see your search results.
 {{% /alert %}}
+
+### Changing the width of the local search results popover
+
+The width of the search results popover will automatically widen according to the content.
+
+If you want to limit the width, add the following scss into `assets/scss/_variables_project.scss`.
+
+```scss
+body {
+    .popover.offline-search-result {
+        max-width: 460px;
+    }
+}
+```
+
+### Excluding pages from local search results
+
+To exclude pages from local search results, add `exclude_search: true` to the the frontmatter of each page:
+
+```yaml
+---
+title: "Index"
+weight: 10
+exclude_search: true
+---
+```


### PR DESCRIPTION
Enlarge the offline search result by append .offline-search-result class to offline search result popover and disable bootstrap default style (max-width) for the popover.

Before:
<img width="1028" alt="Screen Shot 2020-04-06 at 22 25 10" src="https://user-images.githubusercontent.com/659178/78563202-8e1c6400-7855-11ea-9036-6a4e5c57ed8d.png">

After:
<img width="1026" alt="Screen Shot 2020-04-06 at 22 24 13" src="https://user-images.githubusercontent.com/659178/78563231-983e6280-7855-11ea-8c1a-bcd46328b513.png">
