### PR TITLE
Add bootstrap, jquery and popper options

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,17 @@ time_format_default = "January 2, 2006"
 # Sections to publish in the main RSS feed.
 rss_sections = ["blog"]
 
+[params.bootstrap]
+src = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+hash = "sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+
+[params.popper]
+src = "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+hash = "sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+
+[params.jquery]
+src = "https://code.jquery.com/jquery-3.3.1.min.js"
+hash = "sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
 
 # For a full list of parameters used in Docsy sites, see:
 # https://github.com/google/docsy-example/blob/master/config.toml

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,8 +20,8 @@
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}
 <script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+  src="{{ $.Site.Params.jquery.src }}"
+  integrity="{{ $.Site.Params.jquery.hash }}"
   crossorigin="anonymous"></script>
 {{ if .Site.Params.offlineSearch }}
 <script

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,6 +1,6 @@
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+<script src="{{ $.Site.Params.popper.src }}" integrity="{{ $.Site.Params.popper.hash }}" crossorigin="anonymous"></script>
+<script src="{{ $.Site.Params.bootstrap.src }}" integrity="{{ $.Site.Params.bootstrap.hash }}" crossorigin="anonymous"></script>
 {{ $jsBase := resources.Get "js/base.js" }}
 {{ $jsAnchor := resources.Get "js/anchor.js" }}
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}


### PR DESCRIPTION
Because code.jquery.com is too slow for loading(1.6 - 2s), this PR provides options to change the CDN provider of the static resources, such as jsdelivr(100ms):

```toml
[params.jquery]
  src = "https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"
  hash = "sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
```