### PR TITLE
Apply link hover color in link-variant mixin

### DIFF
--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -10,6 +10,10 @@
     #{$parent} {
         color: $color;
 
+        &:hover {
+            color: $hover-color;
+        }
+
         @if $underline {
             text-decoration: underline;
         }


### PR DESCRIPTION
Currently the desired link hover color is passed to the mixin, but
not set. Fix it.