### PR TITLE
fixed disqus integration, changing to .Site.Params.DisqusShortname

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -9,7 +9,7 @@
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
 		<br />
 	{{ end }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (.Site.Params.DisqusShortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -6,7 +6,7 @@
 		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
 	{{ .Content }}
-	{{ if (.Site.DisqusShortname) }}
+	{{ if (.Site.Params.DisqusShortname) }}
 		<br />
 		{{ partial "disqus-comment.html" . }}
 		<br />


### PR DESCRIPTION
In both content.html files, in _default and blog, the Disqus Paramenter was wrong:

{{ .Content }}
{{ if (.Site.DisqusShortname) }}  - **should be "Site.Params.DisqusShortname"
	<br />**
	{{ partial "disqus-comment.html" . }}
	<br />
{{ end }}
Fixed and verified in my environment.