### PR TITLE
Fix a offline search issue that escaped HTML entities is shown

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -98,7 +98,7 @@
                         });
                     });
                 })
-                .slice(0, 10);
+                .slice(0, $targetSearchInput.data('offlnie-search-max-results'));
 
             //
             // Make result html

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -98,7 +98,10 @@
                         });
                     });
                 })
-                .slice(0, $targetSearchInput.data('offlnie-search-max-results'));
+                .slice(
+                    0,
+                    $targetSearchInput.data('offlnie-search-max-results')
+                );
 
             //
             // Make result html

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,5 +1,6 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
-{{- $.Scratch.Add "offline-search-index" (dict "title" (.Title | htmlUnescape) "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Plain | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70))) -}}
+{{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
+{{- $.Scratch.Add "offline-search-index" (dict "title" .Title "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Plain | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,5 +1,5 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
-{{- $.Scratch.Add "offline-search-index" (dict "title" .Title "ref" .RelPermalink "body" .Plain "excerpt" (.Summary | truncate 100)) -}}
+{{- $.Scratch.Add "offline-search-index" (dict "title" (.Title | htmlUnescape) "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Summary | htmlUnescape | truncate 100)) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,5 +1,5 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
-{{- $.Scratch.Add "offline-search-index" (dict "title" (.Title | htmlUnescape) "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Summary | htmlUnescape | truncate 100)) -}}
+{{- $.Scratch.Add "offline-search-index" (dict "title" (.Title | htmlUnescape) "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Plain | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70))) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -18,5 +18,6 @@
   */}}
   data-offline-search-index-json-src="{{ $offlineSearchIndexFingerprint.RelPermalink }}"
   data-offline-search-base-href="/"
+  data-offlnie-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
 >
 {{ end }}

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -127,6 +127,7 @@ algolia_docsearch = false
 
 #Enable offline search with Lunr.js
 offlineSearch = false
+offlineSearchSummaryLength = 70
 
 # User interface configuration
 [params.ui]
@@ -188,5 +189,3 @@ enable = false
 	# url = "https://example.org/mail"
 	# icon = "fa fa-envelope"
         # desc = "Discuss development issues around the project"
-
-

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -128,6 +128,7 @@ algolia_docsearch = false
 #Enable offline search with Lunr.js
 offlineSearch = false
 offlineSearchSummaryLength = 70
+offlineSearchMaxResults = 10
 
 # User interface configuration
 [params.ui]

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -197,6 +197,16 @@ offlineSearch = true
 offlineSearchSummaryLength = 200
 ```
 
+### Changing the maximum result count of the local search
+
+You can customize the maximum result count by setting `offlineSearchMaxResults` in `config.toml`.
+
+```
+#Enable offline search with Lunr.js
+offlineSearch = true
+offlineSearchMaxResults = 25
+```
+
 ### Changing the width of the local search results popover
 
 The width of the search results popover will automatically widen according to the content.

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -187,6 +187,16 @@ Once you've completed these steps, local search is enabled for your site and res
 If you're [testing this locally](/docs/deployment/#serving-your-site-locally) using Hugo’s local server functionality, you need to build your `offline-search-index.xxx.json` file first by running `hugo`. If you have the Hugo server running while you build `offline-search-index.xxx.json`, you may need to stop the server and restart it in order to see your search results.
 {{% /alert %}}
 
+### Changing the summary length of the local search results
+
+You can customize the summary length by setting `offlineSearchSummaryLength` in `config.toml`.
+
+```
+#Enable offline search with Lunr.js
+offlineSearch = true
+offlineSearchSummaryLength = 200
+```
+
 ### Changing the width of the local search results popover
 
 The width of the search results popover will automatically widen according to the content.


### PR DESCRIPTION
This PR fixes a offline search issue that escaped HTML entities is shown as follows, and adds two configuration options.

## Fix an issue

Before:
<img width="842" alt="Screen Shot 2020-05-23 at 14 14 37" src="https://user-images.githubusercontent.com/659178/82725833-c6e79e00-9d1a-11ea-9693-4235a17f5c65.png">

After:
<img width="866" alt="Screen Shot 2020-05-23 at 14 17 34" src="https://user-images.githubusercontent.com/659178/82725834-c8b16180-9d1a-11ea-9ec9-6935ffe42d77.png">

## Add configuration options

- `offlineSearchSummaryLength` which changes the summary length.
- `offlineSearchMaxResults` which changes the maximum result count.
