### PR TITLE
adding Hungarian toml

### DIFF
--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -1,0 +1,47 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "Előző"
+
+[ui_pager_next]
+other = "Következő"
+
+[ui_read_more]
+other = "További olvasnivaló"
+
+[ui_search]
+other = "Keresés ezen az oldalon…"
+
+# Used in sentences such as "Posted in News"
+# TODO: this structure will not work in Hungarian
+#   so I left it as is
+[ui_in]
+other = "in"
+
+# Footer text
+[footer_all_rights_reserved]
+other = "Minden jog fenntartva"
+
+[footer_privacy_policy]
+other = "Adatvédelmi szabályzat"
+
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "Készítette"
+[post_created]
+other = "Elkészítve"
+[post_last_mod]
+other = "Utolsó módosítás"
+[post_edit_this]
+other = "Oldal szerkesztése"
+[post_create_issue]
+other = "Dokumentáció issue létrehozása"
+[post_create_project_issue]
+other = "Projekt issue létrehozása"
+# TODO: this structure will not work in Hungarian
+#   so I left it as is
+[post_posts_in]
+other = "Posts in"


### PR DESCRIPTION
I needed to make this for Regolith's Hungarian landing page, so I thought I'd drop the pull here as well.

There is one problem though, which I left unsolved for now: the "X in Y" constructions in Hungarian are "X Y-ban" (or "X Y-ben" depending on vowel harmony), so I saw no real way to squeeze this in, so I left these two string untranslated for now.