### PR TITLE
Remove browsers from PostCSS Config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -16,17 +16,6 @@ limitations under the License.
 
 module.exports = {
     plugins: {
-        autoprefixer: {
-            browsers: [
-                "Android 2.3",
-                "Android >= 4",
-                "Chrome >= 20",
-                "Firefox >= 24",
-                "Explorer >= 8",
-                "iOS >= 6",
-                "Opera >= 12",
-                "Safari >= 6"
-            ]
-        }
+        autoprefixer: {}
     },
 }


### PR DESCRIPTION
Specifying browsers via this config is not recommended. The best way to provide browsers is a .browserslistrc file in your project root, or by adding a browserslist key to your package.json. (see: https://github.com/postcss/autoprefixer). However, if you don't define the supported browsers the default browsers option will be used (which is a great setup).
REF: https://github.com/browserslist/browserslist#full-list