### PR TITLE
Forces sidebar search to hide on desktop but show on mobile, when enabled

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -129,4 +129,13 @@
             width: 100%;
         }
     }
+
+    #content-desktop {display: block;}
+    #content-mobile {display: none;}
+
+    @media screen and (max-width: 990px) {
+
+    #content-desktop {display: none;}
+    #content-mobile {display: block;}
+    }
 }

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -133,7 +133,7 @@
     #content-desktop {display: block;}
     #content-mobile {display: none;}
 
-    @media screen and (max-width: 990px) {
+    @include media-breakpoint-down(md) {
 
     #content-desktop {display: none;}
     #content-mobile {display: block;}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -2,6 +2,12 @@
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
+  <form class="td-sidebar__search d-flex align-items-center">
+    {{ partial "search-input.html" . }}
+    <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
+    </button>
+  </form>
+  {{ else }}
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -2,11 +2,14 @@
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
+  <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>
   </form>
+  </div>
+  <div id="content-desktop"></div>
   {{ end }}
   <nav class="collapse td-sidebar-nav pt-2 pl-4" id="td-section-nav">
     {{ if  (gt (len .Site.Home.Translations) 0) }}


### PR DESCRIPTION
I am using the Docsy theme on a project for work. Our goal was to have search enabled but only have 1 search box displayed at a time. This can be accomplished by hiding the sidebar search in `config.toml`, but this also hides it for mobile users. This creates a problem since the search box on the main menu at the top of the page is hidden on mobile. 

To fix this, I modified `assets/scss/_sidebar-tree.scss` and `layouts/partials/sidebar-tree.html`. The changes are trivial, but now the sidebar search box is hidden on desktop and shows on mobile - when it's enabled in `config.toml`.

There may be a better or more elegant way to do this so please feel free to implement it in whatever way makes sense for the project. 

Thanks!