### PR TITLE
Fixes ugly background text in pre/code blocks

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -43,6 +43,7 @@
      
 
         > code {
+            background-color: $gray-100;
             padding: 0;
             margin: 0;
             font-size: 100%;


### PR DESCRIPTION
Currently there's strange looking grey background behind the text in code blocks on the kubernetes.io site, e.g.

![image](https://user-images.githubusercontent.com/14982936/86478114-aa8b4800-bd41-11ea-89d3-6f1a5ef7b242.png)

This crops up in any code block (of which there are hundreds in the Kubernetes docs) e.g.
https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#creating-a-deployment
And countless other places
