### PR TITLE
Add reading time to blog posts

### DIFF
--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -5,6 +5,9 @@
 		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
 		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
+	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+	    {{ partial "reading-time.html" . }}
+	{{ end }}
 	{{ .Content }}
 	{{ if (.Site.Params.DisqusShortname) }}
 		<br />


### PR DESCRIPTION
The reading time was not displayed for blog posts before. This change shows it if enabled.

Example:
![image](https://user-images.githubusercontent.com/720821/89303897-16c4d880-d66d-11ea-9889-4f8db71058d9.png)


