### PR TITLE
Fix warning on bg-gradient-variant mixin

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -34,7 +34,7 @@
     @include link-variant("#{$parent}--#{$color-name} p > a", $link-color, $link-hover-color, false);
 
     @if $enable-gradients {
-        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value);
+        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value,true);
     }
 }
 

--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -1,6 +1,6 @@
 // Some simple mixins.
 
-@mixin bg-gradient-variant($parent, $color) {
+@mixin bg-gradient-variant($parent, $color,$ignore-warning: false) {
     #{$parent} {
         background: $color linear-gradient(180deg, mix($body-bg, $color, 15%), $color) repeat-x !important;
     }


### PR DESCRIPTION
Hi,
Since i updated my modules i sadly have this error that spam my console:
```
WARNING: The `bg-gradient-variant` mixin has been deprecated as of v4.5.0. It will be removed entirely in v5.
         on line 8:5 of themes/docsy/assets/vendor/bootstrap/scss/mixins/_deprecate.scss, in mixin `deprecate`
         from line 22:12 of themes/docsy/assets/vendor/bootstrap/scss/mixins/_background-variant.scss, in mixin `bg-gradient-variant`
         from line 37:18 of themes/docsy/assets/scss/_boxes.scss, in mixin `box-variant`
         from line 126:14 of themes/docsy/assets/scss/_boxes.scss
         from line 14:9 of stdin
```
Would it be possible to switch to the new format which is :
`The official @mixin for bg-variant and bg-gradient-variant in bootstrap 4.5.0 is now @mixin bg-variant($parent, $color, $ignore-warning: false) and @mixin bg-gradient-variant($parent, $color, $ignore-warning: false).`

Also in 5.0 bootstrap is moving away from it `The bg-gradient-variant() mixin is removed since the .bg-gradient class can now be used to add gradients to elements instead of the .bg-gradient-* classes.` see https://github.com/twbs/bootstrap/blob/main/site/content/docs/5.0/migration.md

related deprecated pr: twbs/bootstrap#30594

Fix #327