### PR TITLE
add rel attribute to prevent clickjacking

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
 <ul class="list-inline mb-0">
   {{ range . }}
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
-    <a class="text-white" target="_blank" href="{{ .url }}">
+    <a class="text-white" target="_blank" rel="noopener noreferrer" href="{{ .url }}">
       <i class="{{ .icon }}"></i>
     </a>
   </li>


### PR DESCRIPTION
`noopener` and `noreferrer` both address clickjacking vulnerabilities on `target="_blank"`, though `noopener` isn't supported in some legacy browsers, while `noreferrer` is supported, and is ignored by more recent browsers. So adding both is currently the easiest way to support everything.