### PR TITLE
Add "Create child page" link

### DIFF
--- a/assets/stubs/new-page-template.md
+++ b/assets/stubs/new-page-template.md
@@ -1,0 +1,16 @@
+---
+title: "Long Page Title"
+linkTitle: "Short Nav Title"
+weight: 100
+description: >-
+     Page description for heading and indexes.
+---
+
+## Heading
+
+Edit this template to create your new page.
+
+* Give it a good name, ending in `.md` - e.g. `getting-started.md`
+* Edit the "front matter" section at the top of the page (weight controls how its ordered amongst other pages in the same directory; lowest number first).
+* Add a good commit message at the bottom of the page (<80 characters; use the extended description field for more detail).
+* Create a new branch so you can preview your new file and request a review via Pull Request.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -35,6 +35,8 @@ other = "Created"
 other = "Last modified"
 [post_edit_this]
 other = "Edit this page"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Create documentation issue"
 [post_create_project_issue]

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -6,16 +6,23 @@
 {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $pathFormatted }}
+{{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
 {{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $editURL = printf "%s/edit/%s/%s/content/%s/%s" $gh_repo $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
+{{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
 {{ else if .Site.Language.Lang }}
-{{ $editURL = printf "%s/edit/%s/content/%s/%s" $gh_repo $gh_branch ($.Site.Language.Lang) $pathFormatted }}
+{{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
 {{ else if $gh_subdir }}
-{{ $editURL = printf "%s/edit/%s/%s/content/%s" $gh_repo $gh_branch $gh_subdir $pathFormatted }}
+{{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
 {{ end }}
+{{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+{{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+{{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
+{{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
+{{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+<a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
 {{ if $gh_project_repo }}
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}

--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -9,6 +9,7 @@ description: >
 The Docsy [docs and blog layouts](/docs/adding-content/content/#adding-docs-and-blog-posts) include links for readers to edit the page or create issues for your docs or project via your site's source repository. The current generated links for each docs or blog page are:
 
 * **Edit this page**: Brings the user to an editable version of the page content in their fork (if available) of your docs repo. If the user doesn't have a current fork of your docs repo, they are invited to create one before making their edit. The user can then create a pull request for your docs.
+* **Create child page**: Brings the user to a create new file form in their fork of your docs repo.  The new file will be located as a child of the page they clicked the link on.  The form will be pre-populated with a template the user can edit to create their page.  You can change this by adding `assets/stubs/new-page-template.md` to your own project.
 * **Create documentation issue**: Brings the user to a new issue form in your docs repo with the name of the current page as the issue's title.
 * **Create project issue** (optional): Brings the user to a new issue form in your project repo. This can be useful if you have separate project and docs repos and your users want to file issues against the project feature being discussed rather than your docs.
 
@@ -22,7 +23,7 @@ There are three variables you can configure in `config.toml` to set up links:
 
 ### `github_repo`
 
-The URL for your site's source repository. This is used to generate the **Edit this page** and **Create documentation issue** links.
+The URL for your site's source repository. This is used to generate the **Edit this page**, **Create child page**, and **Create documentation issue** links.
 
 ```toml
 github_repo = "https://github.com/google/docsy"


### PR DESCRIPTION
The "Edit this page" link is great, but a member of my team suggested yesterday that a "Create child page" button would be useful too as it could find the right spot in the repo for them to quickly add a new page, and they wouldn't then have to copy and paste markdown from another existing page to remember what the front matter was supposed to look like.

Seemed like a good idea, and was easy to add, hence a PR :-) 

There's only an `en` translation in this PR - not sure how other translations for other languages are generated.