### PR TITLE
Make bootstrap variables overwritable

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -7,9 +7,9 @@ See https://github.com/twbs/bootstrap/pull/23260
 @fa-font-path :        "../webfonts";
 
 // Bootstrap flags. For more, see https://getbootstrap.com/docs/4.0/getting-started/theming/
-$enable-gradients: true;
-$enable-rounded: true;
-$enable-shadows: true;
+$enable-gradients: true !default;
+$enable-rounded: true !default;
+$enable-shadows: true !default;
 
 // Theme flags.
 


### PR DESCRIPTION
The documentation claims these can be overwritten[1][]. This is however
not possible at present due to the fact that `_variables.scss` is loaded
_after_ `_variables_project.scss`, while the declared variables in
the former file lack a `!default` flag. The result is that the values in
`_variables.scss` always take precedence over any project configured
value.

This commits simply adds the `!default` flag to the values, so that they
can be overwritten again with ease.

[1]: https://www.docsy.dev/docs/adding-content/lookandfeel/#color-palette-and-other-styles