### PR TITLE
Fixed build error when pagination is used with an empty collection

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -4,33 +4,35 @@
 {{ else }}
 {{$.Scratch.Set "blog-pages" .Pages }}
 {{ end }}
-{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006")}}
-{{ $pageGroups := $pag.PageGroups}}
-{{ if eq $pag.PageNumber 1 }}
-{{ end }}
+
 <div class="row">
 	<div class="col-12">
-		{{ range $pageGroups }}
-		<h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
-		<ul class="list-unstyled mt-4">
-			{{ range .Pages }}
-			<li class="media mb-4">
-				<div class="media-body">
-					<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
-					<p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
-					{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
-					<p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
-					<p class="pt-0"><a href="{{ .RelPermalink }}">{{ T "ui_read_more"}}</a></p>
-				</div>
-			</li>
+		{{- if .Pages -}}
+		{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006")}}
+			{{ range $pag.PageGroups }}
+			<h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
+			<ul class="list-unstyled mt-4">
+				{{ range .Pages }}
+				<li class="media mb-4">
+					<div class="media-body">
+						<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h5>
+						<p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+						{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
+						<p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+						<p class="pt-0"><a href="{{ .RelPermalink }}">{{ T "ui_read_more"}}</a></p>
+					</div>
+				</li>
+				{{ end }}
+			</ul>
 			{{ end }}
-		</ul>
 		{{ end }}
 	</div>
 </div>
 <div class="row pl-2 pt-2">
 	<div class="col">
-		{{ template "_internal/pagination.html" . }}
+		{{ if .Pages }}
+			{{ template "_internal/pagination.html" . }}
+		{{ end }}
 	</div>
 </div>
 {{ end }}


### PR DESCRIPTION
This PR fixes build error when some directory contains no articles to be published(no articles or only drafts).
Just checking if `.Pages` exist before evaluate `.PageGroups`.
Also, lines 9 to 10 on the original code seem to be unused so removed it.

Maybe related to https://github.com/google/docsy-example/issues/56

A similar issue and solution for the reference
https://github.com/dillonzq/LoveIt/issues/347
https://github.com/dillonzq/LoveIt/pull/350

As mentioned in the issue above, the problem should be fixed by Hugo but just for a temporary solution...