### PR TITLE
Add "print entire section" feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ resources/
 node_modules/
 tech-doc-hugo
 
+# vim temporary files
+*~
+*.sw?

--- a/config.toml
+++ b/config.toml
@@ -15,5 +15,10 @@ rss_sections = ["blog"]
 # https://github.com/google/docsy-example/blob/master/config.toml
 
 
-
-
+[outputFormats]
+[outputFormats.PRINT]
+baseName = "index"
+isHTML = true
+mediaType = "text/html"
+path = "_print"
+permalinkable = false

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -43,3 +43,13 @@ other = "Problem zu dieser Seite melden"
 other = "Problem melden"
 [post_posts_in]
 other = "Einträge in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -43,3 +43,13 @@ other = "Create documentation issue"
 other = "Create project issue"
 [post_posts_in]
 other = "Posts in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -43,3 +43,13 @@ other = "Notificar una incidencia con la documentanción"
 other = "Notificar una incidencia en un proyecto"
 [post_posts_in]
 other = "Añadir entrada"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -43,3 +43,13 @@ other = "Créer un problème dans la documentation"
 other = "Créer un problème dans le projet"
 [post_posts_in]
 other = "Messages dans"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -47,3 +47,13 @@ other = "Projekt issue létrehozása"
 #   so I left it as is
 [post_posts_in]
 other = "Posts in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -43,3 +43,13 @@ other = "Crea issue di documentazione"
 other = "Crea issue di progetto"
 [post_posts_in]
 other = "Post in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -43,3 +43,13 @@ other = "ドキュメントのissueを作成"
 other = "プロジェクトのissueを作成"
 [post_posts_in]
 other = "記事一覧"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -43,3 +43,13 @@ other = "문서에 이슈 생성"
 other = "프로젝트에 이슈 생성"
 [post_posts_in]
 other = "Posts in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -43,3 +43,13 @@ other = "Opprett dokumentasjon sak"
 other = "Opprett prosjekt sak"
 [post_posts_in]
 other = "Poster i"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -43,3 +43,13 @@ other = "Relatar um problema de documentação"
 other = "Relatar um problema no projeto"
 [post_posts_in]
 other = "Posts em"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -43,3 +43,13 @@ other = "Предложить изменения документации"
 other = "Предложить доработки по проекту"
 [post_posts_in]
 other = "Публикации в"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -43,3 +43,13 @@ other = "提交文档问题"
 other = "提交项目问题"
 [post_posts_in]
 other = "Posts in"
+
+# Print support
+[print_printable_section]
+other = "This the multi-page printable view of this section."
+[print_click_to_print]
+other = "Click here to print"
+[print_show_regular]
+other = "Return to the regular view of this page"
+[print_entire_section]
+other = "Print entire section"

--- a/layouts/blog/baseof.print.html
+++ b/layouts/blog/baseof.print.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }} td-blog">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+          </div>
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+          </div>
+          <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/blog/section.print.html
+++ b/layouts/blog/section.print.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "print/render"  . }}
+{{ end }}

--- a/layouts/docs/baseof.print.html
+++ b/layouts/docs/baseof.print.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}" class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}">
+    <header>
+      {{ partial "navbar.html" . }}
+    </header>
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <div class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+          </div>
+          <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
+          </div>
+          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/docs/list.print.html
+++ b/layouts/docs/list.print.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+{{ partial "print/render"  . }}
+{{ end }}

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -13,6 +13,7 @@
     display: block;
   }
 </style>
+<div class="d-print-none">
 <h2 class="feedback--title">Feedback</h2>
 <p class="feedback--question">Was this page helpful?</p>
 <button class="feedback--answer feedback--answer-yes">Yes</button>
@@ -23,6 +24,7 @@
 <p class="feedback--response feedback--response-no">
   {{ .no | safeHTML }}
 </p>
+</div>
 <script>
   const yesButton = document.querySelector('.feedback--answer-yes');
   const noButton = document.querySelector('.feedback--answer-no');

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,14 +1,18 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ hugo.Generator }}
-{{ if eq (getenv "HUGO_ENV") "production" }}
-<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
-{{ else }}
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
-{{ end }}
+{{- $outputFormat := partial "outputformat.html" . -}}
+
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
+
+{{ if and (eq (getenv "HUGO_ENV") "production") (ne $outputFormat "print") -}}
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+{{ else -}}
+<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+{{ end -}}
+
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
 {{- template "_internal/opengraph.html" . -}}

--- a/layouts/partials/outputformat.html
+++ b/layouts/partials/outputformat.html
@@ -1,0 +1,12 @@
+{{/* Return the current page outputformat */}}
+{{ $alts := newScratch }}
+{{ $format := "unknown" }}
+{{ range .AlternativeOutputFormats }}
+    {{ $alts.Set .Name true }}
+{{ end }}
+{{ range .OutputFormats }}
+    {{ if not ($alts.Get .Name) }}
+        {{ $format = .Name }}
+    {{ end }}
+{{ end }}
+{{ return $format }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -28,6 +28,12 @@
 {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
 <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
 {{ end }}
+
+{{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}
+<a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+{{ end }}
+
+
 </div>
 {{ end }}
 {{ end }}

--- a/layouts/partials/print/content-blog.html
+++ b/layouts/partials/print/content-blog.html
@@ -1,0 +1,14 @@
+{{ $break := cond .DoPageBreak "page-break-before: always" "" }}
+{{ with .Page }}
+<div class="td-content" style="{{ $break }}">
+    <h1 id="pg-{{ .Page.File.UniqueID }}">{{ .Title }}</h1>
+	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	<div class="td-byline mb-4">
+		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
+        {{if .Date }}
+		<time datetime="{{  .Date.Format "2006-01-02" }}" class="text-muted">{{ .Date.Format .Site.Params.time_format_blog  }}</time>
+        {{ end }}
+	</div>
+	{{ .Content }}
+</div>
+{{ end }}

--- a/layouts/partials/print/content.html
+++ b/layouts/partials/print/content.html
@@ -1,0 +1,13 @@
+{{ $tpl := printf "partials/print/content-%s.html" .Page.Type }}
+
+{{ if templates.Exists $tpl }}
+  {{ partial $tpl . }}
+{{ else -}}
+{{ $break := cond .DoPageBreak "page-break-before: always" "" -}}
+<div class="td-content" style="{{ $break }}">
+    {{ $break := cond .DoPageBreak "page-break-before: always" "" }}
+	<h1 id="pg-{{ .Page.File.UniqueID }}">{{ .PageNum }} - {{ .Page.Title }}</h1>
+    {{ with .Page.Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+	{{ .Page.Content }}
+</div>
+{{ end }}

--- a/layouts/partials/print/page-heading.html
+++ b/layouts/partials/print/page-heading.html
@@ -1,0 +1,9 @@
+{{/* Use the title and description of the first page to begin the document */}}
+
+{{ $tpl := printf "partials/print/page-heading-%s.html" .Page.Type }}
+{{ if templates.Exists $tpl }}
+  {{ partial $tpl . }}
+{{ else -}}
+<h1 class="title">{{ .Title }}</h1>
+{{ with .Page.Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
+{{ end }}

--- a/layouts/partials/print/render.html
+++ b/layouts/partials/print/render.html
@@ -1,0 +1,63 @@
+{{ define "recurse-toc" }}
+  {{ $s := .section }}
+  {{ $psid := .psid }}
+  {{ $pages := (union $s.Pages $s.Sections).ByWeight }}
+  {{ $subSection := 1 }}
+
+  {{ range where $pages ".Params.no_print" "!=" true }}
+    {{ $sid := printf "%s%d" $psid $subSection }}
+    {{ $subSection = add $subSection 1 }}
+	{{ partial "print/toc-li.html" (dict "sid" $sid "Page" .) }}
+    {{ if .IsSection }}
+    <ul>
+        {{ template "recurse-toc" (dict "section" . "psid" (printf "%s." $sid)) }}
+    </ul>
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ define "recurse-content" }}
+  {{ $s := .section }}
+  {{ $psid := .psid }}
+  {{ $pages := (union $s.Pages $s.Sections).ByWeight }}
+  {{ $subSection := 1 }}
+  
+  {{ $breakOnWordCount := default 50 ($s.Site.Param "print.section_break_wordcount") }}
+  {{ $doPageBreak := gt (countwords $s.Content) $breakOnWordCount }}
+
+  {{ range where $pages ".Params.no_print" "!=" true }}
+    {{ $sid := printf "%s%d" $psid $subSection }}
+    {{ $subSection = add $subSection 1 }}
+	{{ $params := dict "Page" . "PageNum" $sid "DoPageBreak" $doPageBreak }}
+    {{ partial "print/content.html" $params }}
+
+    {{ if .IsSection }}
+      {{ template "recurse-content" (dict "section" . "psid" (printf "%s." $sid) ) }}
+    {{ end }}
+	{{ $doPageBreak = true }}
+  {{ end }}
+{{ end }}
+
+<div class="td-content">
+<div class="pageinfo pageinfo-primary d-print-none">
+<p>
+{{ T "print_printable_section" }}
+<a href="#" onclick="print();return false;">{{ T "print_click_to_print" }}</a>.
+</p><p>
+<a href="{{ .RelPermalink }}">{{ T "print_show_regular" }}</a>
+</p>
+</div>
+{{ partial "print/page-heading.html" . }}
+
+{{ if not (.Param "print.disable_toc") }}
+    <ul>
+    {{ template "recurse-toc" (dict "section" .CurrentSection "psid" "") }}
+    </ul>
+{{ end }}
+
+<div class="content">
+      {{ .Content }}
+</div>
+</div>
+
+{{ template "recurse-content" (dict "section" .CurrentSection "psid" "") }}

--- a/layouts/partials/print/toc-li-blog.html
+++ b/layouts/partials/print/toc-li-blog.html
@@ -1,0 +1,1 @@
+  <li><a href="#pg-{{.Page.File.UniqueID}}">{{ .Page.Title }}</a></li>

--- a/layouts/partials/print/toc-li.html
+++ b/layouts/partials/print/toc-li.html
@@ -1,0 +1,6 @@
+{{ $tpl := printf "partials/print/toc-li-%s.html" .Page.Type }}
+{{ if templates.Exists $tpl }}
+  {{ partial $tpl . }}
+{{ else -}}
+<li>{{ .sid}}: <a href="#pg-{{.Page.File.UniqueID}}">{{ .Page.Title }}</a></li>
+{{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -4,7 +4,6 @@
 
 {{ if .Site.Params.mermaid.enable }}
 <script src="https://cdn.jsdelivr.net/npm/mermaid@8.8.1/dist/mermaid.min.js" integrity="sha384-to2w0I1OqmbJ9J6yTnIX+KYU8grNpZoD1dKPLjgEJvMe5L5+/7qvuNa2sQo8WAWj" crossorigin="anonymous"></script>
-
 {{ end }}
 
 {{ $jsBase := resources.Get "js/base.js" }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,6 @@
 
 # "production" environment specific build settings
 [build.environment]
-  HUGO_VERSION = "0.55.6"
+  HUGO_VERSION = "0.76.5"
   HUGO_THEME = "repo"
   HUGO_ENV = "production"

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -35,8 +35,9 @@ pygmentsStyle = "tango"
 blog = "/:section/:year/:month/:day/:slug/"
 
 [outputs]
-	home = [ "HTML", "JSON" ]
-	page = [ "HTML" ]
+home = [ "HTML", "JSON" ]
+page = [ "HTML" ]
+section = [ "HTML", "RSS", "print"]
 
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]
@@ -203,3 +204,6 @@ enable = false
 [params.mermaid]
 enable = true
 theme = "default"
+
+[params.print]
+disable_toc = false

--- a/userguide/content/en/docs/Adding content/feedback.md
+++ b/userguide/content/en/docs/Adding content/feedback.md
@@ -1,7 +1,7 @@
 ---
 title: "Analytics and User Feedback"
 date: 2019-06-05
-weight: 7
+weight: 8
 description: >
   Add Google Analytics tracking to your site, use the "was this page helpful?" widget data, disable the widget on a single
   page or all pages, and change the response text.

--- a/userguide/content/en/docs/Adding content/print.md
+++ b/userguide/content/en/docs/Adding content/print.md
@@ -8,9 +8,9 @@ description: >
 
 Individual documentation pages print well from most browsers as the layouts have been styled to omit navigational chrome from the printed output.
 
-On some sites, it can be useful enable a "print entire section" feature (as seen in this user guide).  This will cause an entire section, with all of its child pages and sections, to be rendered in the browser in a format suited to printing, complete with a table of contents for that section.
+On some sites, it can be useful to enable a "print entire section" feature (as seen in this user guide).  Selecting this option renders the entire current top-level section (such as Documentation for this page) with all of its child pages and sections in a format suited to printing, complete with a table of contents for the section.
 
-To enable, add the "print" output format in your site's `config.toml` file for the "section" type:
+To enable this feature, add the "print" output format in your site's `config.toml` file for the "section" type:
 
 ```toml
 [outputs]
@@ -23,7 +23,7 @@ The site should then show a "Print entire section" link in the right hand naviga
 
 ### Disabling the ToC
 
-To disable the table of contents, set the `disable_toc` param to `true`, either in the page front matter, or in `config.toml`:
+To disable showing the the table of contents in the printable view, set the `disable_toc` param to `true`, either in the page front matter, or in `config.toml`:
 
 ```toml
 [params.print]

--- a/userguide/content/en/docs/Adding content/print.md
+++ b/userguide/content/en/docs/Adding content/print.md
@@ -1,0 +1,44 @@
+---
+title: "Print Support"
+linkTitle: "Print Support"
+weight:  7
+description: >
+     Making it easier to print entire sections of documentation.
+---
+
+Individual documentation pages print well from most browsers as the layouts have been styled to omit navigational chrome from the printed output.
+
+On some sites, it can be useful enable a "print entire section" feature (as seen in this user guide).  This will cause an entire section, with all of its child pages and sections, to be rendered in the browser in a format suited to printing, complete with a table of contents for that section.
+
+To enable, add the "print" output format in your site's `config.toml` file for the "section" type:
+
+```toml
+[outputs]
+section = [ "HTML", "RSS", "print" ]
+```
+
+The site should then show a "Print entire section" link in the right hand navigation.
+
+## Further Customization
+
+### Disabling the ToC
+
+To disable the table of contents, set the `disable_toc` param to `true`, either in the page front matter, or in `config.toml`:
+
+```toml
+[params.print]
+disable_toc = true
+```
+
+
+## Layout hooks
+
+A number of layout partials and hooks are defined that can be used to customize the printed format.  These can be found in `layouts/partials/print`.
+
+Hooks can be defined on a per-type basis.  For example, you may want to customize the layouts of heading for "blog" pages vs "docs". This can be achieved by creating `layouts/partials/print/page-heading-<type>.html` - eg. `page-heading-blog.html`.  It defaults to using the page title and description as a heading.
+
+Similarly, the formatting for each page can be customized by creating `layouts/partials/print/content-<type>.html`.
+
+
+
+

--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -1,7 +1,7 @@
 ---
 title: "Repository Links"
 linkTitle: "Repository Links"
-weight: 8
+weight: 9
 description: >
   Help your users interact with your source repository.
 ---


### PR DESCRIPTION
*(this isn't "finished"; could use some feedback!)*

It's sometimes useful to be able to create a printout of all the pages
within a documentation or blog section, without having to select each
one at a time.

This commit adds a "print this section" button to the right navigation
by creating a new "print" output format and applying it to sections.

Each sub-section starts a new page.

Partials can be created to customize the layout on a per-type basis for:

* print/page-heading-<type>.html
* print/toc-li-<type>.html
* print/content-<type>.html

Pages can be omitted from a printed section entirely by setting
no_print=true in the page front matter.

Types can be excluded from being printable by setting outputs explicitly
in their front matter and listing only HTML, RSS, etc (in conjunction
with cascade)

To enable the feature, add the following to the site's config.toml

[outputs]
section = [ "HTML", "RSS", "print"]