### PR TITLE
Add zh translation for post_create_child_page and add post_create_child_page for all languages

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -35,6 +35,8 @@ other = "Erstellt"
 other = "Zuletzt geändert"
 [post_edit_this]
 other = "Diese Seite bearbeiten"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Problem zu dieser Seite melden"
 [post_create_project_issue]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -35,6 +35,8 @@ other = "Creado"
 other = "Última modificación"
 [post_edit_this]
 other = "Editar esta página"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Notificar una incidencia con la documentanción"
 [post_create_project_issue]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -35,6 +35,8 @@ other = "Crée"
 other = "Dernière modification"
 [post_edit_this]
 other = "Modifier cette page"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Créer un problème dans la documentation"
 [post_create_project_issue]

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -37,6 +37,8 @@ other = "Elkészítve"
 other = "Utolsó módosítás"
 [post_edit_this]
 other = "Oldal szerkesztése"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Dokumentáció issue létrehozása"
 [post_create_project_issue]

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -35,6 +35,8 @@ other = "Creato"
 other = "Ultima modifica"
 [post_edit_this]
 other = "Modifica"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Crea issue di documentazione"
 [post_create_project_issue]

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -35,6 +35,8 @@ other = "作成"
 other = "最終更新"
 [post_edit_this]
 other = "ページの編集"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "ドキュメントのissueを作成"
 [post_create_project_issue]

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -35,6 +35,8 @@ other = "작성"
 other = "최종 수정"
 [post_edit_this]
 other = "페이지 편집"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "문서에 이슈 생성"
 [post_create_project_issue]

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -35,6 +35,8 @@ other = "Opprettet"
 other = "Sist endret"
 [post_edit_this]
 other = "Endre denne siden"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Opprett dokumentasjon sak"
 [post_create_project_issue]

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -35,6 +35,8 @@ other = "Criado"
 other = "Última modificação"
 [post_edit_this]
 other = "Editar essa página"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Relatar um problema de documentação"
 [post_create_project_issue]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -35,6 +35,8 @@ other = "Создано"
 other = "Изменено"
 [post_edit_this]
 other = "Отредактировать страницу"
+[post_create_child_page]
+other = "Create child page"
 [post_create_issue]
 other = "Предложить изменения документации"
 [post_create_project_issue]

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -35,6 +35,8 @@ other = "创建"
 other = "最后修改"
 [post_edit_this]
 other = "编辑此页"
+[post_create_child_page]
+other = "添加子页面"
 [post_create_issue]
 other = "提交文档问题"
 [post_create_project_issue]


### PR DESCRIPTION
1. Add zh translation for post_create_child_page.
2.  Add post_create_child_page for each language. Otherwise, it will be "[i18n] post_create_child_page". I think English is better than "[i18n] ...".