### PR TITLE
Geriom burger icon

### DIFF
--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -2,6 +2,7 @@
 
 .td-search-input {
     background: transparent;
+    max-width: 90%;
 
     &.form-control:focus {
         border-color: lighten($primary, 60%);

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -2,7 +2,7 @@
 {{ $shouldDelayActive := ge (len .Site.Pages) 2000 }}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable }}
-  <form class="td-sidebar__search d-flex align-items-center">
+  <form class="td-sidebar__search d-flex align-items-center d-lg-none">
     {{ partial "search-input.html" . }}
     <button class="btn btn-link td-sidebar__toggle d-md-none p-0 ml-3 fas fa-bars" type="button" data-toggle="collapse" data-target="#td-section-nav" aria-controls="td-docs-nav" aria-expanded="false" aria-label="Toggle section navigation">
     </button>


### PR DESCRIPTION
This PR modifies de search bar on top of the left nav in two ways:

- Hide it in large screens to avoid having two search bars. 
- Set the width to 90% to address #357 

This is how it looks in different screen sizes:

![docsy-iphone](https://user-images.githubusercontent.com/22261639/97131281-21e24e80-171a-11eb-97a3-894f78378f20.png)

![docsy-tablet](https://user-images.githubusercontent.com/22261639/97131292-29a1f300-171a-11eb-828f-b2b8a4c41a4d.png)

![docsy-large](https://user-images.githubusercontent.com/22261639/97131301-2d357a00-171a-11eb-96ad-3debc88ba519.png)


