### PR TITLE
typo in config value for github_branch

### DIFF
--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -50,7 +50,7 @@ github_project_repo = "https://github.com/google/docsy"
 Specify a value here if you have would like to reference a different branch for the other github settings like **Edit this page** or **Create project isssue**.
 
 ```toml
-github_brach = "release"
+github_branch = "release"
 ```
 
 


### PR DESCRIPTION
`config.toml` reference should read:

`github_branch = "release"`

not

`github_brach = "release"`