### PR TITLE
Make it easier to create a "docs only" site

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,5 +1,6 @@
 <div class="section-index">
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $parent := .Page }}
     {{ if $parent.Params.no_list }}
     {{/* If no_list is true we don't show a list of subpages */}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -23,7 +23,8 @@
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end }}
-    {{ template "section-tree-nav-section" (dict "page" . "section" .FirstSection "delayActive" $shouldDelayActive)  }}
+    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection }}
+    {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "delayActive" $shouldDelayActive)  }}
   </nav>
 </div>
 {{ define "section-tree-nav-section" }}
@@ -42,12 +43,14 @@
       {{ $pages := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
       {{ $pages := $pages | first 50 }}
       {{ range $pages }}
-      {{ if .IsPage }}
-      {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
-      {{ $active := eq . $p }}
-      <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
-      {{ else }}
-      {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
+      {{ if (not (and (eq $s $p.Site.Home) (eq .Params.toc_root true))) }}
+        {{ if .IsPage }}
+          {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
+          {{ $active := eq . $p }}
+          <a class="td-sidebar-link td-sidebar-link__page {{ if and (not $shouldDelayActive) $active }} active{{ end }}" id="{{ $mid }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        {{ else }}
+          {{ template "section-tree-nav-section" (dict "page" $p "section" .) }}
+        {{ end }}
       {{ end }}
       {{ end }}
     </li>

--- a/userguide/content/en/docs/Adding content/content.md
+++ b/userguide/content/en/docs/Adding content/content.md
@@ -48,13 +48,57 @@ Alternatively, create your own page template for your new section in your projec
 
 You can find out much more about how Hugo page layouts work in [Hugo Templates](https://gohugo.io/templates/). The rest of this page tells you about how to add content and use each of Docsy's templates.
 
+### Alternative site structure
+
+As noted above, by default your site has a home page (using the `_default` layout), a docs section under `/docs/`, a blog section under `/blog/` and a community section under `/community/`.   [The type](https://gohugo.io/content-management/types/) of each section (which determines the layout it uses) matches its directory name.
+
+In some cases, you may want to have a different directory structure, but still make use of Docsy's layouts.  A common example is for a "docs site", where most of the pages (including the home page) use the docs layout, or perhaps you'd rather have a `/news/` directory treated with the blog layout.
+
+Since Hugo 0.76, this has become practical without copying layouts to your site, or having to specify `type: blog` on every single page by making use of [target specific cascading front matter](https://gohugo.io/content-management/front-matter/#target-specific-pages).
+
+For example, for the `/news/` section, you can specify the following front matter in the index page which will change the type of the section and everything below it to "blog":
+
+```yaml
+---
+title: "Latest News"
+linkTitle: "News"
+menu:
+  main:
+    weight: 30
+
+cascade:
+- type: "blog"
+---
+```
+
+If you want to create a "docs" site, specifying something like the following in the top level `_index.md` will set all top level sections to be treated as "docs", except for "news":
+
+```yaml
+---
+title: "My Wonderful Site"
+
+cascade:
+- type: "blog"
+  toc_root: true
+  _target:
+    path: "/news/**"
+- type: "docs"
+  _target:
+    path: "/**"
+---
+```
+
+Note the addition of `toc_root` here.  Setting that to true for a section causes it to be treated as a separate part of the site, with its own left hand navigation menu.
+
+An example docs-based site that uses this technique can be found at the [mostly docs](https://github.com/gwatts/mostlydocs/) repo.
+
 ## Page frontmatter
 
 Each page file in a Hugo site has metadata frontmatter that tells Hugo about the page. You specify page frontmatter in TOML, YAML, or JSON (our example site and this site use YAML). Use the frontmatter to specify the page title, description, creation date, link title, template, menu weighting, and even any resources such as images used by the page. You can see a complete list of possible page frontmatter in [Front Matter](https://gohugo.io/content-management/front-matter/).
 
 For example, here's the frontmatter for this page:
 
-```
+```yaml
 ---
 title: "Adding Content"
 linkTitle: "Adding Content"


### PR DESCRIPTION
The "docs only" example created for issue #173 has been a super useful reference for my own internal docs site - However, I got to thinking whether Hugo's new target cascading front matter (introduced in 0.76.0) would allow us to do the same thing, with much less copying of Docsy's layout templates.

The problem with having to copy the templates, is that it becomes work to keep those templates up to date with the improvements made in the theme itself - Much better to have as little customization of those as possible.

To that end, I created a version of your example with zero custom layouts: https://github.com/gwatts/mostlydocs (example rendered: https://mostlydocs.netlify.app/ )

Getting the section menu to work correctly for that required a couple of small tweaks, which is what this PR is for.

The first commit hides the search result page from the section list on the home page.  The second ensures that the home page is correctly included in the section menu, if the home page is of type "docs".

It also adds a "toc_root" parameter - I use that on the example site to add a "blog" section that does not appear in that documentation menu, so that the blog appears to be separate.  Setting it to false (or omitting it), causes any blog section to be included in the tree like any other section.

Of course, if your site is really "just docs" you can just delete that blog section entirely.

None of this should have any effect on sites using Docsy today (if i've done this right ;-) ).