### PR TITLE
fix:  L53 add period to end of sentence

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -50,6 +50,6 @@ other = "This the multi-page printable view of this section."
 [print_click_to_print]
 other = "Click here to print"
 [print_show_regular]
-other = "Return to the regular view of this page."
+other = "Return to the regular view of this page"
 [print_entire_section]
 other = "Print entire section"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -50,6 +50,6 @@ other = "This the multi-page printable view of this section."
 [print_click_to_print]
 other = "Click here to print"
 [print_show_regular]
-other = "Return to the regular view of this page"
+other = "Return to the regular view of this page."
 [print_entire_section]
 other = "Print entire section"

--- a/layouts/partials/print/render.html
+++ b/layouts/partials/print/render.html
@@ -21,7 +21,7 @@
   {{ $psid := .psid }}
   {{ $pages := (union $s.Pages $s.Sections).ByWeight }}
   {{ $subSection := 1 }}
-  
+
   {{ $breakOnWordCount := default 50 ($s.Site.Param "print.section_break_wordcount") }}
   {{ $doPageBreak := gt (countwords $s.Content) $breakOnWordCount }}
 
@@ -44,7 +44,7 @@
 {{ T "print_printable_section" }}
 <a href="#" onclick="print();return false;">{{ T "print_click_to_print" }}</a>.
 </p><p>
-<a href="{{ .RelPermalink }}">{{ T "print_show_regular" }}</a>
+<a href="{{ .RelPermalink }}">{{ T "print_show_regular" }}</a>.
 </p>
 </div>
 {{ partial "print/page-heading.html" . }}


### PR DESCRIPTION
Currently renders without the period. Rather than changing `layouts/partials/print/render.html`, adding a period to the parameter in `eng.toml`.