### PR TITLE
Fix Prism.js with non-empty BaseURL.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -35,6 +35,6 @@
 {{end}}
 {{ if .Site.Params.prism_syntax_highlighting }}
 <!-- stylesheet for Prism -->
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/prism.css" />
+<link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
 {{ end }}
 {{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,8 +33,8 @@
   integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
   crossorigin="anonymous"></script>
 {{end}}
-{{ with .Site.Params.prism_syntax_highlighting }}
+{{ if .Site.Params.prism_syntax_highlighting }}
 <!-- stylesheet for Prism -->
-<link rel="stylesheet" href="/css/prism.css" />
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/prism.css" />
 {{ end }}
 {{ partial "hooks/head-end.html" . }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -22,6 +22,6 @@
 {{ end }}
 {{ if .Site.Params.prism_syntax_highlighting }}
 <!-- scripts for prism -->
-<script src='{{ .Site.BaseURL }}/js/prism.js'></script>
+<script src='{{ "/js/prism.js" | relURL }}'></script>
 {{ end }}
 {{ partial "hooks/body-end.html" . }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -20,8 +20,8 @@
 {{ $js := $js | minify | fingerprint }}
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end }}
-{{ with .Site.Params.prism_syntax_highlighting }}
+{{ if .Site.Params.prism_syntax_highlighting }}
 <!-- scripts for prism -->
-<script src='/js/prism.js'></script>
+<script src='{{ .Site.BaseURL }}/js/prism.js'></script>
 {{ end }}
 {{ partial "hooks/body-end.html" . }}


### PR DESCRIPTION
When using a BaseURL, we need to supply that URL as a prefix to the path
used to load Prism.js.