### PR TITLE
Remove markdownify for non-Markdown files

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -2,5 +2,9 @@
 {{ $color := .Get "color" | default "primary" }}
 <div class="alert alert-{{ $color }}" role="alert">
 {{ with .Get "title" }}<h4 class="alert-heading">{{ . | safeHTML }}</h4>{{ end }}
-{{ .Inner | markdownify }}
+{{ if eq .Page.File.Ext "md" }}
+    {{ .Inner | markdownify }}
+{{ else }}
+    {{ .Inner | htmlUnescape | safeHTML }}
+{{ end }}
 </div>

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -32,7 +32,11 @@
           {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
           {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
           <div class="pt-3 lead">
-            {{ .Inner | markdownify}}
+            {{ if eq .Page.File.Ext "md" }}
+                {{ .Inner | markdownify }}
+            {{ else }}
+                {{ .Inner | htmlUnescape | safeHTML }}
+            {{ end }}
           </div>
         </div>
       </div>

--- a/layouts/shortcodes/blocks/lead.html
+++ b/layouts/shortcodes/blocks/lead.html
@@ -6,7 +6,11 @@
 <section class="row td-box td-box--{{ $col_id }} position-relative td-box--gradient td-box--height-{{ $height }}">
 	<div class="container text-center td-arrow-down">
 		<span class="h4 mb-0">
-			{{ .Inner | markdownify }}
+			{{ if eq .Page.File.Ext "md" }}
+				{{ .Inner | markdownify }}
+			{{ else }}
+				{{ .Inner | htmlUnescape | safeHTML }}
+			{{ end }}
 		</span>
 	</div>
 </section>

--- a/layouts/shortcodes/blocks/section.html
+++ b/layouts/shortcodes/blocks/section.html
@@ -6,7 +6,11 @@
 <section class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }}">
 	<div class="col">
 		<div class="row {{ $type }}">
-			{{ .Inner | markdownify}}
+			{{ if eq .Page.File.Ext "md" }}
+				{{ .Inner | markdownify }}
+			{{ else }}
+				{{ .Inner | htmlUnescape | safeHTML }}
+			{{ end }}
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
When using Asciidoc (or RST, I suppose), the Inner content passed to these shortcodes should already be HTML-formatted. Making this change allows us to pass formatted content (which may include a shortcode) to a shortcode, which previously only worked with Markdown.

There might be an opportunity for a new abstraction here (maybe a partial?), but this approach seems to work OK for me. Maybe it'll be useful to others too?