### PR TITLE
Add Persian language translations and override some styles in rtl direction

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -35,7 +35,7 @@ footer {
     min-height: 150px;
 
     @include media-breakpoint-down(md) {
-         min-height: 200px;
+        min-height: 200px;
     }
 }
 
@@ -48,7 +48,10 @@ footer {
         visibility: hidden;
     }
 
-    h2[id]:before, h3[id]:before, h4[id]:before, h5[id]:before {
+    h2[id]:before,
+    h3[id]:before,
+    h4[id]:before,
+    h5[id]:before {
         display: block;
         content: " ";
         margin-top: -5rem;
@@ -57,4 +60,5 @@ footer {
     }
 }
 
+@import "rtl/main";
 @import "styles_project";

--- a/assets/scss/rtl/_main.scss
+++ b/assets/scss/rtl/_main.scss
@@ -1,0 +1,27 @@
+body:lang(fa) {
+    @import url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v27.0.1/dist/font-face.css');
+    @import 'spacing';
+
+    font-family: 'Vazir', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+    direction: rtl;
+    text-align: right;
+
+    .dropdown-menu {
+        text-align: right;
+    }
+
+    .text-right {
+        text-align: left !important;
+    }
+
+    pre {
+        text-align: left;
+        direction: ltr;
+    }
+
+    .td-rss-button {
+        left: 1rem !important;
+        right: auto !important;
+    }
+}

--- a/assets/scss/rtl/_spacing.scss
+++ b/assets/scss/rtl/_spacing.scss
@@ -1,0 +1,91 @@
+@each $breakpoint in map-keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+        $infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+        @each $prop,
+        $abbrev in (margin: m, padding: p) {
+
+            @each $size,
+            $length in $spacers {
+                .#{$abbrev}#{$infix}-#{$size} {
+                    #{$prop}: $length !important;
+                }
+
+                .#{$abbrev}t#{$infix}-#{$size},
+                .#{$abbrev}y#{$infix}-#{$size} {
+                    #{$prop}-top: $length !important;
+                }
+
+                .#{$abbrev}r#{$infix}-#{$size},
+                .#{$abbrev}x#{$infix}-#{$size} {
+                    #{$prop}-inline-end: $length !important;
+                }
+
+                .#{$abbrev}b#{$infix}-#{$size},
+                .#{$abbrev}y#{$infix}-#{$size} {
+                    #{$prop}-bottom: $length !important;
+                }
+
+                .#{$abbrev}l#{$infix}-#{$size},
+                .#{$abbrev}x#{$infix}-#{$size} {
+                    #{$prop}-inline-start: $length !important;
+                }
+            }
+        }
+
+        // Negative margins (e.g., where `.mb-n1` is negative version of `.mb-1`)
+        @each $size,
+        $length in $spacers {
+            @if $size !=0 {
+                .m#{$infix}-n#{$size} {
+                    margin: -$length !important;
+                }
+
+                .mt#{$infix}-n#{$size},
+                .my#{$infix}-n#{$size} {
+                    margin-top: -$length !important;
+                }
+
+                .mr#{$infix}-n#{$size},
+                .mx#{$infix}-n#{$size} {
+                    margin-right: -$length !important;
+                }
+
+                .mb#{$infix}-n#{$size},
+                .my#{$infix}-n#{$size} {
+                    margin-bottom: -$length !important;
+                }
+
+                .ml#{$infix}-n#{$size},
+                .mx#{$infix}-n#{$size} {
+                    margin-left: -$length !important;
+                }
+            }
+        }
+
+        // Some special margin utils
+        .m#{$infix}-auto {
+            margin: auto !important;
+        }
+
+        .mt#{$infix}-auto,
+        .my#{$infix}-auto {
+            margin-top: auto !important;
+        }
+
+        .mr#{$infix}-auto,
+        .mx#{$infix}-auto {
+            margin-right: auto !important;
+        }
+
+        .mb#{$infix}-auto,
+        .my#{$infix}-auto {
+            margin-bottom: auto !important;
+        }
+
+        .ml#{$infix}-auto,
+        .mx#{$infix}-auto {
+            margin-left: auto !important;
+        }
+    }
+}

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -1,0 +1,45 @@
+
+
+# UI strings. Buttons and similar.
+
+[ui_pager_prev]
+other = "قبلی"
+
+[ui_pager_next]
+other = "بعدی"
+
+[ui_read_more]
+other = "بیشتر بخوانید"
+
+[ui_search]
+other = "در این سایت جستجو کنید..."
+
+# Used in sentences such as "Posted in News"
+[ui_in]
+other = "در"
+
+# Footer text
+[footer_all_rights_reserved]
+other = "تمام حقوق محفوظ است."
+
+[footer_privacy_policy]
+other = "سیاست حفظ حریم خصوصی"
+
+
+# Post (blog, articles etc.)
+[post_byline_by]
+other = "توسط"
+[post_created]
+other = "ساخته شده"
+[post_last_mod]
+other = "آخرین تغییرات"
+[post_edit_this]
+other = "این صفحه را ویرایش کنید"
+[post_create_child_page]
+other = "ایجاد زیر صفحه در این صفحه"
+[post_create_issue]
+other = "ساخت ایشو"
+[post_create_project_issue]
+other = "ساخت ایشو برای پوسته"
+[post_posts_in]
+other = "نوشته ها در"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -43,3 +43,13 @@ other = "ساخت ایشو"
 other = "ساخت ایشو برای پوسته"
 [post_posts_in]
 other = "نوشته ها در"
+
+# Print support
+[print_printable_section]
+other = "این حالت نمایش چند صفحه ای قابل پرینت این قسمت می‌باشد."
+[print_click_to_print]
+other = "برای پرینت کلیک کنید."
+[print_show_regular]
+other = "بازگشت به حالت نمایش عادی این قسمت"
+[print_entire_section]
+other = "پرینت کامل قسمت"


### PR DESCRIPTION
Hi

I added the Persian language and also override some styles in RTL direction and add [Vazir](https://github.com/rastikerdar/vazir-font) font when the language is Persian which is a good-looking open-source Persian font.

Here is the Docsy Example in the Persian language:

<img width="1440" alt="Screen Shot 2020-11-26 at 16 34 26" src="https://user-images.githubusercontent.com/5784889/100369909-c659f800-301a-11eb-83a7-42531f2f359a.png">
<img width="1440" alt="Screen Shot 2020-11-26 at 16 34 39" src="https://user-images.githubusercontent.com/5784889/100369999-de317c00-301a-11eb-8e59-a800da334904.png">
<img width="1440" alt="Screen Shot 2020-11-26 at 16 35 09" src="https://user-images.githubusercontent.com/5784889/100370009-dffb3f80-301a-11eb-9de8-77b6ba3a38c8.png">



I also added Persian content in the docsy-example project.