### PR TITLE
Fix print partial for older Hugo versions

### DIFF
--- a/layouts/partials/print/content.html
+++ b/layouts/partials/print/content.html
@@ -1,6 +1,6 @@
-{{ $tpl := printf "partials/print/content-%s.html" .Page.Type }}
+{{ $tpl := printf "print/content-%s.html" .Page.Type }}
 
-{{ if templates.Exists $tpl }}
+{{ if templates.Exists (printf "partials/%s" $tpl) }}
   {{ partial $tpl . }}
 {{ else -}}
 {{ $break := cond .DoPageBreak "page-break-before: always" "" -}}

--- a/layouts/partials/print/page-heading.html
+++ b/layouts/partials/print/page-heading.html
@@ -1,7 +1,7 @@
 {{/* Use the title and description of the first page to begin the document */}}
 
-{{ $tpl := printf "partials/print/page-heading-%s.html" .Page.Type }}
-{{ if templates.Exists $tpl }}
+{{ $tpl := printf "print/page-heading-%s.html" .Page.Type }}
+{{ if templates.Exists (printf "partials/%s" $tpl) }}
   {{ partial $tpl . }}
 {{ else -}}
 <h1 class="title">{{ .Title }}</h1>

--- a/layouts/partials/print/toc-li.html
+++ b/layouts/partials/print/toc-li.html
@@ -1,5 +1,5 @@
-{{ $tpl := printf "partials/print/toc-li-%s.html" .Page.Type }}
-{{ if templates.Exists $tpl }}
+{{ $tpl := printf "print/toc-li-%s.html" .Page.Type }}
+{{ if templates.Exists (printf "partials/%s" $tpl) }}
   {{ partial $tpl . }}
 {{ else -}}
 <li>{{ .sid}}: <a href="#pg-{{.Page.File.UniqueID}}">{{ .Page.Title }}</a></li>


### PR DESCRIPTION
This was working fine for Hugo v0.75.0 and later, but not earlier - Not
sure why it was working for any version!

Tested now on 0.73.0, 0.74.0 and master

Resolves google/docsy-example#91