### PR TITLE
Add all RTL languages to the RTL styles

### DIFF
--- a/assets/scss/rtl/_main.scss
+++ b/assets/scss/rtl/_main.scss
@@ -1,8 +1,12 @@
-body:lang(fa) {
-    @import url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v27.0.1/dist/font-face.css');
-    @import 'spacing';
+body:lang(fa),
+body:lang(ar),
+body:lang(az),
+body:lang(dv),
+body:lang(he),
+body:lang(ku),
+body:lang(ur) {
 
-    font-family: 'Vazir', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    @import 'spacing';
 
     direction: rtl;
     text-align: right;
@@ -24,4 +28,19 @@ body:lang(fa) {
         left: 1rem !important;
         right: auto !important;
     }
+}
+
+body:lang(fa) {
+    @import url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v27.0.1/dist/font-face.css');
+    font-family: 'Vazir', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+body:lang(he) {
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap');
+    font-family: 'Rubik', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+body:lang(ar) {
+    @import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;500;700&display=swap');
+    font-family: 'Tajawal', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }


### PR DESCRIPTION
Hi
Based on this [issue](https://github.com/google/docsy/issues/253) I added other RTL languages to the RTL styles and now Docsy shows all of them in the right direction.
I also added custom fonts (from Google font) for Arabic and Hebrew languages.