### PR TITLE
Show print section page, even if github_repo not set

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,39 +1,37 @@
 {{ if .Path }}
-{{ $pathFormatted := replace .Path "\\" "/" }}
-{{ $gh_repo := ($.Param "github_repo") }}
-{{ $gh_subdir := ($.Param "github_subdir") }}
-{{ $gh_project_repo := ($.Param "github_project_repo") }}
-{{ $gh_branch := (default "master" ($.Param "github_branch")) }}
-{{ if $gh_repo }}
-<div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
-{{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
-{{ else if .Site.Language.Lang }}
-{{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
-{{ else if $gh_subdir }}
-{{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
-{{ end }}
-{{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-{{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
-{{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
-{{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
-{{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
-{{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
+  {{ $pathFormatted := replace .Path "\\" "/" }}
+  {{ $gh_repo := ($.Param "github_repo") }}
+  {{ $gh_subdir := ($.Param "github_subdir") }}
+  {{ $gh_project_repo := ($.Param "github_project_repo") }}
+  {{ $gh_branch := (default "master" ($.Param "github_branch")) }}
+  <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
+  {{ if $gh_repo }}
+    {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted }}
+    {{ if and ($gh_subdir) (.Site.Language.Lang) }}
+      {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted }}
+    {{ else if .Site.Language.Lang }}
+      {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted }}
+    {{ else if $gh_subdir }}
+      {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted }}
+    {{ end }}
+    {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+    {{ $createURL := printf "%s/edit/%s" $gh_repo $gh_repo_path }}
+    {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
+    {{ $newPageStub := resources.Get "stubs/new-page-template.md" }}
+    {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL }}
+    {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS }}
 
-<a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
-<a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
-<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-{{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
-<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-{{ end }}
+    <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
+    <a href="{{ $newPageURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_create_child_page" }}</a>
+    <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
+    {{ if $gh_project_repo }}
+      {{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
+      <a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+    {{ end }}
 
-{{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}
-<a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
-{{ end }}
-
-
-</div>
-{{ end }}
+  {{ end }}
+  {{ with .CurrentSection.AlternativeOutputFormats.Get "print" }}
+    <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+  {{ end }}
+  </div>
 {{ end }}


### PR DESCRIPTION
This diff is easier to view if you hide the whitespace changes by adding `&w=1` to the github URL :-) 

Resolves #396 