### PR TITLE
Add page description and taxonomies to lunr search

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -45,7 +45,15 @@
             (data) => {
                 idx = lunr(function () {
                     this.ref('ref');
-                    this.field('title', { boost: 2 });
+
+                    // If you added more searchable fields to the search index, list them here.
+                    // Here you can specify searchable fields to the search index - e.g. individual toxonomies for you project
+                    // With "boost" you can add weighting for specific (default weighting without boost: 1)
+                    this.field('title', { boost: 5 });
+                    this.field('categories', { boost: 3 });
+                    this.field('tags', { boost: 3 });
+                    // this.field('projects', { boost: 3 }); // example for an individual toxonomy called projects
+                    this.field('description', { boost: 2 });
                     this.field('body');
 
                     data.forEach((doc) => {

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -2,6 +2,6 @@
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
 {{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
 {{/* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
-{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" (.Description | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 200) | htmlUnescape)) -}}
+{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" (.Description | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,6 +1,7 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
 {{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
-{{- $.Scratch.Add "offline-search-index" (dict "title" .Title "ref" .RelPermalink "body" (.Plain | htmlUnescape) "excerpt" (.Plain | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
+{{/* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
+{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" (.Description | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 200) | htmlUnescape)) -}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}


### PR DESCRIPTION
Add page description and taxonomies to lunr.js search index
changes in offline-search-index.json and offline-search.js

Fixes #389 