### PR TITLE
Adding jvmperf.net to the examples page

### DIFF
--- a/userguide/content/en/docs/Examples/_index.md
+++ b/userguide/content/en/docs/Examples/_index.md
@@ -20,6 +20,7 @@ Example sites that have low to no customization:
 | https://googlecontainertools.github.io/kpt/ | https://github.com/GoogleContainerTools/kpt/tree/master/docs | 
 | [Navidrome Music Server](https://www.navidrome.org) | https://github.com/navidrome/website | 
 | https://docs.agilebase.co.uk/ | https://github.com/okohll/abdocs | 
+| https://jvmperf.net/ | https://github.com/cchesser/java-perf-workshop | 
 
 ## Customized Docsy examples
 


### PR DESCRIPTION
I'm leveraging docsy for my new site at jvmperf.net. Thank you for creating and sharing this great Hugo theme!