### PR TITLE
td-default: ensure the first top-level section gets extra padding, but no other

### DIFF
--- a/assets/scss/_main-container.scss
+++ b/assets/scss/_main-container.scss
@@ -8,7 +8,7 @@
 // The outer page container for the default base template.
 .td-default {
     main {
-        section:first-of-type {
+        > section:first-of-type {
             @include media-breakpoint-up(md) {
                 padding-top: 8rem;
             }


### PR DESCRIPTION
Ensure that only the first top-level `section` (usually the **hero section**) under `.td-default` gets extra padding, and not the first section of any nested sections.

cc @zacharysarah @nate-double-u