### PR TITLE
Removed pager when printing

### DIFF
--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -1,4 +1,4 @@
-<ul class="list-unstyled d-flex justify-content-between align-items-center mb-0 pt-5">
+<ul class="list-unstyled d-flex justify-content-between align-items-center mb-0 pt-5 d-print-none">
   <li>
     <a {{if .PrevInSection}}href="{{.PrevInSection.RelPermalink}}"{{end}} class="btn btn-primary {{if not .PrevInSection}} disabled{{end}}"><span class="mr-1">←</span> {{ T "ui_pager_prev" }}</a>
   </li>


### PR DESCRIPTION
The pager should not be presented in the printer page.
Added d-print-none style to avoid this problem.