### PR TITLE
Update Korean translations in i18n ko.toml

### DIFF
--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -36,7 +36,7 @@ other = "최종 수정"
 [post_edit_this]
 other = "페이지 편집"
 [post_create_child_page]
-other = "Create child page"
+other = "하부 페이지 생성"
 [post_create_issue]
 other = "문서에 이슈 생성"
 [post_create_project_issue]
@@ -46,10 +46,10 @@ other = "Posts in"
 
 # Print support
 [print_printable_section]
-other = "This the multi-page printable view of this section."
+other = "이 섹션의 다중 페이지 출력 화면임."
 [print_click_to_print]
-other = "Click here to print"
+other = "여기를 클릭하여 프린트"
 [print_show_regular]
-other = "Return to the regular view of this page"
+other = "이 페이지의 일반 화면으로 돌아가기"
 [print_entire_section]
-other = "Print entire section"
+other = "전체 섹션 프린트"


### PR DESCRIPTION
This PR updates i18n/ko.toml to complete Korean translation.

Please note that some items in i18n/ko.toml remain not translated 
since they are not suitable to be translated into Korean (Grammar). E.g., "in", "By", "Posts in", ...

By the way, I am contributing to https://kubernetes.io/ (https://github.com/kubernetes/website).
And Docsy is very useful for us ! Thank you.