### PR TITLE
Do not use site.BaseURL directly

### DIFF
--- a/layouts/shortcodes/swaggerui.html
+++ b/layouts/shortcodes/swaggerui.html
@@ -1,17 +1,9 @@
 {{ $original := .Get "src" }}
 <div id="ohpen_swagger_ui"></div>
 <script>
-  var resolveUrl = function () {
-    var passedUrl = '{{ $original }}';
-    var baseUrl = '{{  site.BaseURL  }}'.replace(/\/$/, '');
-    if (passedUrl.startsWith('/')) {
-      return baseUrl + passedUrl;
-    }
-    return passedUrl;
-  };
   window.onload = function () {
     const ui = SwaggerUIBundle({
-      url: resolveUrl(),
+      url: {{ $original | relURL }},
       dom_id: '#ohpen_swagger_ui',
       presets: [
         SwaggerUIBundle.presets.apis,

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -2,9 +2,8 @@
 <html lang="{{ .Site.Language.Lang }}" class="no-js">
   <head>
     {{ partial "head.html" . }}
-    {{ $baseurl := urls.Parse site.BaseURL }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link rel="stylesheet" type="text/css" href="{{ $baseurl }}/css/swagger-ui.css">
+    <link rel="stylesheet" type="text/css" href="{{ "/css/swagger-ui.css" | relURL }}">
   </head>
   <body class="td-{{ .Kind }}">
     <header>
@@ -21,8 +20,8 @@
           </div>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
-            <script src="{{ $baseurl }}/js/swagger-ui-bundle.js"></script>
-            <script src="{{ $baseurl }}/js/swagger-ui-standalone-preset.js"></script>
+            <script src="{{ "/js/swagger-ui-bundle.js" | relURL }}"></script>
+            <script src="{{ "/js/swagger-ui-standalone-preset.js" | relURL }}"></script>
             {{ block "main" . }}{{ end }}
           </main>
         </div>


### PR DESCRIPTION
The site.BaseURL can sometimes be "/". In that case, the URL of the
resource related to swagger-ui will be corrupted.

This patch fixes it.
