### PR TITLE
Fix de translation for previous and next

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -3,10 +3,10 @@
 # UI strings. Buttons and similar.
 
 [ui_pager_prev]
-other = "Weiter"
+other = "Zurück"
 
 [ui_pager_next]
-other = "Zurück"
+other = "Weiter"
 
 [ui_read_more]
 other = "Weiterlesen"


### PR DESCRIPTION
While switching my website from German to english I realized that the buttons 'next' and 'previous' swapped all of a sudden. Looking into the toml file I figured out that they are mixed up so I thought I fix it :) 