### PR TITLE
Removed pagination widget form printed blog post list

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -28,7 +28,7 @@
 		{{ end }}
 	</div>
 </div>
-<div class="row pl-2 pt-2">
+<div class="row pl-2 pt-2 d-print-none">
 	<div class="col">
 		{{ if .Pages }}
 			{{ template "_internal/pagination.html" . }}


### PR DESCRIPTION
# Problem

The printed blog post list page shows the pagination widget (_internal/pagination.html) when the page is printed and the list is long enough.
The pagination widget is not shown if the link "Print entire section" is used instead.

# Way to reproduce

* Add blog posts until the pagination widget appear;
* Print the page (not the section);

# Proposed solution

Added d-print-none to the row with the pagination widget.