### PR TITLE
Fix an issue that inline styles in the offline search result is ignored.

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -188,8 +188,13 @@
                 });
             });
 
+            // Enable inline styles in popover.
+            const whiteList = $.fn.tooltip.Constructor.Default.whiteList;
+            whiteList['*'].push('style');
+
             $targetSearchInput
                 .data('content', $html[0].outerHTML)
+                .popover({ whiteList: whiteList })
                 .popover('show');
         };
     });


### PR DESCRIPTION
This is a fix for the issue that the inline style of the search result in offline search is ignored due to the Bootstrap update, and the position of the close button is misaligned

| Current | Fixed |
| - | - |
| <img width="499" alt="Screen Shot 2021-04-06 at 22 02 55" src="https://user-images.githubusercontent.com/659178/113716788-e8c8f400-9725-11eb-83e0-5cd4b8a03afd.png"> |  <img width="510" alt="Screen Shot 2021-04-06 at 22 03 36" src="https://user-images.githubusercontent.com/659178/113716803-ec5c7b00-9725-11eb-96bd-4d609d1af20e.png"> |



