### PR TITLE
Support Google Analytics v4 (gtag.js)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -39,5 +39,9 @@
 {{ partial "hooks/head-end.html" . }}
 <!--To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled -->
 {{ if eq (getenv "HUGO_ENV") "production" }}
+{{ if hasPrefix .Site.GoogleAnalytics "G-"}}
+{{ template "_internal/google_analytics.html" . }}
+{{ else }}
 {{ template "_internal/google_analytics_async.html" . }}
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Using `_internal/google_analytics.html` when G-MEASUREMENT_ID is specified  to support Google Analytics v4.

Hugo's documentation for Google Analytics v4 support is here.
<https://gohugo.io/templates/internal#google-analytics>
