### PR TITLE
Disable lastmod when no GitHub info is present

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -3,7 +3,7 @@
     {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
         {{ partial "reading-time.html" . }}
-    {{ end }}       
+    {{ end }}
 	{{ .Content }}
 	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}
 		{{ partial "feedback.html" .Site.Params.ui.feedback }}
@@ -13,5 +13,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -15,6 +15,6 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>
 {{ end }}

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,5 +1,7 @@
+<div class="text-muted mt-5 pt-3 border-top">
 {{ if and (.GitInfo) (.Site.Params.github_repo) }}
     {{ T "post_last_mod"}}
     {{ .Lastmod.Format .Site.Params.time_format_default }}
     {{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{ end }}
 {{ end }}
+</div>

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,1 +1,5 @@
-{{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}
+{{ if and (.GitInfo) (.Site.Params.github_repo) }}
+    {{ T "post_last_mod"}}
+    {{ .Lastmod.Format .Site.Params.time_format_default }}
+    {{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{ end }}
+{{ end }}

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -12,6 +12,6 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>
 {{ end }}


### PR DESCRIPTION
Hi,

I stumbled onto the problem, that the information of the last modification is still shown, but not working, if you do not add the github repository link. For some websites it does make sense not to show that info, therefore I thought instead of overriding the partial I create a pull request here.

As the partial is just used together with the 'div' declaration, I move this div into the partial itself too