### PR TITLE
Make docsy a go module (with its own submodules)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 .hugo_build.lock
 /public
 resources/
+_vendor/
 
 # vim temporary files
 *~

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,0 +1,4 @@
+# github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6
+# github.com/twbs/bootstrap v4.5.2+incompatible
+# github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924
+# github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8

--- a/config.toml
+++ b/config.toml
@@ -25,3 +25,56 @@ isHTML = true
 mediaType = "text/html"
 path = "_print"
 permalinkable = false
+
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+
+  [[module.mounts]]
+    source = "layouts"
+    target = "layouts"
+
+  [[module.mounts]]
+    source = "data"
+    target = "data"
+
+  [[module.mounts]]
+    source = "assets"
+    target = "assets"
+
+  [[module.mounts]]
+    source = "i18n"
+    target = "i18n"
+
+  [[module.mounts]]
+    source = "archetypes"
+    target = "archetypes"
+
+  [[module.mounts]]
+    source = "_vendor/github.com/FortAwesome/Font-Awesome/scss"
+    target = "assets/vendor/Font-Awesome/scss"
+
+  [[module.mounts]]
+    source = "_vendor/github.com/twbs/bootstrap/scss"
+    target = "assets/vendor/bootstrap/scss"
+
+  [[module.imports]]
+    path = "github.com/gohugoio/hugo-mod-bootstrap-scss-v4"
+    [[module.imports.mounts]]
+      source = "/"
+      target = "assets/vendor"
+    [[module.imports.mounts]]
+      source = "assets/scss/bootstrap/_vendor"
+      target = "assets/vendor/bootstrap/scss/vendor"
+
+    [[module.imports]]
+      path = "github.com/deining/hugo-mod-font-awesome-scss"
+    [[module.imports.mounts]]
+      source = "/"
+      target = "assets/vendor"
+

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/google/docsy
+module github.com/deining/docsy
 
-go 1.16
+go 1.17
 
 require (
-	github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924 // indirect
-	github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6 // indirect
+	github.com/deining/hugo-mod-font-awesome-scss v1.15.4 // indirect
+	github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v1.6.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/google/docsy
+
+go 1.16
+
+require (
+	github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924 // indirect
+	github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8 h1:3h1ZlZmKNqZtiTD6FF7GijnIB/PU9/jR+dclHF80pFE=
+github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924 h1:X8/yaitCpv2jrZR/NyH8Lsu4n9byqJrni72tcfgxMEM=
+github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924/go.mod h1:Xg+5zZzZpuh3Bua72PlygSwF2jpk9m8lN/ZyEdKNM/0=
+github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6 h1:Neo6xDvmZMV41d4kmbjv9ZCYuqzbITl8R/4t6Aeng5A=
+github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6/go.mod h1:dAcE2kCmCarbiwNTV4xxlDFShQHiok9kDjw1VoN2J8g=
+github.com/twbs/bootstrap v4.5.2+incompatible h1:QR6UOtm1+LCDK53CzEp8U0NPIYeRUktVgNhq0gaAGP0=
+github.com/twbs/bootstrap v4.5.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,11 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8 h1:3h1ZlZ
 github.com/FortAwesome/Font-Awesome v0.0.0-20210316185733-d79d85c3fad8/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924 h1:X8/yaitCpv2jrZR/NyH8Lsu4n9byqJrni72tcfgxMEM=
 github.com/deining/hugo-mod-font-awesome-scss v0.0.0-20210415150057-c3ffa1501924/go.mod h1:Xg+5zZzZpuh3Bua72PlygSwF2jpk9m8lN/ZyEdKNM/0=
+github.com/deining/hugo-mod-font-awesome-scss v1.15.4 h1:uZTPkPWhuBczh2CU1AkwORDxmL4HFfHVyNMs6QEd8Kw=
+github.com/deining/hugo-mod-font-awesome-scss v1.15.4/go.mod h1:w1xhGWSj/tozFzLH3na6d+Ptv7ahW9XArWet4ZTVk6A=
 github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6 h1:Neo6xDvmZMV41d4kmbjv9ZCYuqzbITl8R/4t6Aeng5A=
 github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v0.0.0-20200902213320-c9cb5e39d8c6/go.mod h1:dAcE2kCmCarbiwNTV4xxlDFShQHiok9kDjw1VoN2J8g=
+github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v1.6.1 h1:r+fas/SvSP5JwS/p5iyESN4vqVPVJiJgMo/8EL/SMpk=
+github.com/gohugoio/hugo-mod-bootstrap-scss-v4 v1.6.1/go.mod h1:VHQ9xbucU9fEzMSHMnpYlPmqWgcG2+AgFLt0wE//eg4=
 github.com/twbs/bootstrap v4.5.2+incompatible h1:QR6UOtm1+LCDK53CzEp8U0NPIYeRUktVgNhq0gaAGP0=
 github.com/twbs/bootstrap v4.5.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
Making docsy a go module was discussed in [issue 456](https://github.com/google/docsy/issues/456#issuecomment-786122011) already. I'm citing from there:

```
I think we looked at making Docsy into a module
(with its own modules - it currently has Git submodules)
and it would have required a fair bit of refactoring, (...).
It's definitely something to revisit though.
```

I worked myself into hugo modules recently and ended up with this PR which turns docsy into a module —without the need of any refactoring of the existing codebase. The only change needed is to add a `module` section (with several `imports` and `mounts`) to `config.toml`.

With a new hugo site set up and a fresh copy of the docsy theme cloned to the `themes` folder, let's compare the proposed `modules` approach with the current `submodules` approach:

**Resolving dependencies with Submodules (current HEAD)**
```
$ # inside /path/to/mysite/themes
$ time git submodule update --init --recursive
Submodule 'assets/vendor/Font-Awesome' (https://github.com/FortAwesome/Font-Awesome.git) registered for path 'assets/vendor/Font-Awesome'
Submodule 'assets/vendor/bootstrap' (https://github.com/twbs/bootstrap.git) registered for path 'assets/vendor/bootstrap'
Cloning into '/path/to/docsy/assets/vendor/Font-Awesome'...
Cloning into '/path/to/docsy/assets/vendor/bootstrap'...
Submodule path 'assets/vendor/Font-Awesome': checked out 'fcec2d1b01ff069ac10500ac42e4478d20d21f4c'
Submodule path 'assets/vendor/bootstrap': checked out '6ffb0b48e455430f8a5359ed689ad64c1143fac2'

real    0m29.895s
```  
**Pulling in dependencies with Docsy as Hugo module (this PR applied)**
```
$ # inside /path/to/mysite/themes
time hugo mod vendor --ignoreVendorPaths **
hugo: downloading modules …
hugo: collected modules in 6274 ms

real    0m7.421s
```  

As you can see, the process is **more than 4 times faster** now.

Let's compare downloaded file sizes:

**With Submodules (current HEAD)**
```
$ # inside /path/to/mysite/_vendor
$ du . -h
12K     ./github.com/deining/hugo-mod-font-awesome-scss
12K     ./github.com/deining
254K    ./github.com/FortAwesome/Font-Awesome/scss
254K    ./github.com/FortAwesome/Font-Awesome
254K    ./github.com/FortAwesome
12K     ./github.com/gohugoio/hugo-mod-bootstrap-scss-v4/assets/scss/bootstrap/_vendor
12K     ./github.com/gohugoio/hugo-mod-bootstrap-scss-v4/assets/scss/bootstrap
12K     ./github.com/gohugoio/hugo-mod-bootstrap-scss-v4/assets/scss
12K     ./github.com/gohugoio/hugo-mod-bootstrap-scss-v4/assets
28K     ./github.com/gohugoio/hugo-mod-bootstrap-scss-v4
28K     ./github.com/gohugoio
79K     ./github.com/twbs/bootstrap/scss/mixins
37K     ./github.com/twbs/bootstrap/scss/utilities
367K    ./github.com/twbs/bootstrap/scss
379K    ./github.com/twbs/bootstrap
379K    ./github.com/twbs
673K    ./github.com
674K    .
```

**With Docsy as Hugo module (this PR applied)**
```
$ # inside /path/to/mysite/themes/docsy/assets/vendor
$ du . -hs
56M     .
```  

As you can see, the download size is **drastically reduced** now.

**Requirements for using Hugo modules (this PR applied)**
- hugo extended (as ususal)
- go (I used latest version 1.16.3)

Having to deal with submodules when setup a new docsy theme doesn't account for a nice first time user experience IMHO. I even tend to say it scares users away from using dosy. I think this PR proposes a pretty neat alternative which is far superior to the existing solution IMHO, and I would like to put it up for discussion now.

I'm willing to follow up on currrent work and rework and/or extend the current documentation. However, prior to that, there are a few issues which should be clarified, like:

* Can my PR be accepted and merged?
* If so, will the modules approach replace the current submodules approach or do we want to have both side by side?
* (maybe a bit provocative): do we need submodules/hugo modules for docsy's dependencies at all? Why don't we simply check in the scss files needed? With hugo modules in place (this PR applied) it should be fairly easy for the maintainers to update the exsiting scss files once a new version of bootstrap/font awesome is released.
* ...

The discussion is open, looking forward to your input.

One last note: this [blog post](https://discourse.gohugo.io/t/how-to-add-a-theme-using-modules-for-beginners/20665) explains how to add a theme to an existing site using modules.


