### PR TITLE
Shortcode 'feature': fix output of invalid nested <p> tags

### DIFF
--- a/layouts/shortcodes/blocks/feature.html
+++ b/layouts/shortcodes/blocks/feature.html
@@ -4,7 +4,19 @@
   <div class="mb-4 h1">
     <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
   </div>
-  <h4 class="h3">{{ .Get "title" | markdownify }}</h4>
-  <p class="mb-0">{{ .Inner }}</p>
+  <h4 class="h3">
+    {{ if eq .Page.File.Ext "md" }}
+      {{ .Get "title" | markdownify }}
+    {{ else }}
+      {{ .Get "title" | htmlUnescape | safeHTML }}
+    {{ end }}
+  </h4>
+  <p class="mb-0">
+    {{ if eq .Page.File.Ext "md" }}
+      {{ .Inner | markdownify }}
+    {{ else }}
+      {{ .Inner | htmlUnescape | safeHTML }}
+    {{ end }}
+  </p>
   {{ with .Get "url" }}<p><a href="{{ . }}">{{ with $url_text }}{{ $url_text }}{{ else }}{{ T "ui_read_more" }}{{ end }} …</a></p>{{ end }}
 </div>


### PR DESCRIPTION
This PR fixes invalid HTML output caused by by shortcode `feature`:

HTML source from docsy.dev:

```
<div class="col-lg-4 mb-5 mb-lg-0 text-center ">
  <div class="mb-4 h1">
    <i class="fas fa-lightbulb"></i>
  </div>
  <h4 class="h3">See Docsy in action!</h4>
  <p class="mb-0"><p>As well as our example site, there’s a growing number of projects using Docsy for their doc sites.</p>
</p>
  <p><a href="/docs/examples/">Read more …</a></p>
</div>
```

Note that markup of paragraph `As well as our example site, there’s ...` contains nested `<p>` tags, which is invalid.