### PR TITLE
Adding shortcodes for card groups and cards

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,5 +38,5 @@
 <link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
 {{ end }}
 <!-- stylesheet for tabbed pane -->
-<link rel="stylesheet" href="{{ "/css/tabbed-pane.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "/css/shortcodes.css" | relURL }}"/>
 {{ partial "hooks/head-end.html" . }}

--- a/layouts/shortcodes/card-code.html
+++ b/layouts/shortcodes/card-code.html
@@ -1,0 +1,20 @@
+<div class="card">
+  {{ $lang := "" }}
+  {{ with $.Get "lang" }}
+    {{ $lang = $.Get "lang" }}
+  {{ end }}
+  {{ $highlight := "" }}
+  {{ with $.Get "highlight" }}
+    {{ $highlight = $.Get "highlight" }}
+  {{ end }}
+  {{- with $.Get "header" -}}
+    <div class="card-header bg-white">
+      {{- $.Get "header" | markdownify -}}
+    </div>
+  {{end}}
+  <div class="card-body code p-l0 m-0">
+      {{ with $.Inner }}
+        {{- highlight $.Inner $lang $highlight -}}
+      {{ end }}
+  </div>
+</div>

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,0 +1,50 @@
+<!-- Make sure that we are enclosed within a tabpane shortcode block -->
+<div class="card mb-4">
+  {{ with $.Get "header" }}
+    <div class="card-header">
+      {{ if eq $.Page.File.Ext "md" }}
+        {{ $.Get "header" | markdownify }}
+      {{ else }}
+        {{ $.Get "header" | htmlUnescape | safeHTML }}
+      {{ end }}
+    </div>
+  {{ end }}
+  <div class="card-body">
+    {{ with $.Get "title" }}
+      <h5 class="card-title">
+        {{ if eq $.Page.File.Ext "md" }}
+          {{ $.Get "title" | markdownify }}
+        {{ else }}
+          {{ $.Get "title" | htmlUnescape | safeHTML }}
+        {{ end }}
+      </h5>
+    {{ end }}
+    {{ with $.Get "subtitle" }}
+      <h6 class="card-title mb-2 text-muted">
+        {{ if eq $.Page.File.Ext "md" }}
+          {{ $.Get "subtitle" | markdownify }}
+        {{ else }}
+          {{ $.Get "subtitle" | htmlUnescape | safeHTML }}
+        {{ end }}
+      </h6>
+    {{ end }}
+    {{ with $.Inner }}
+      <p class="card-text">
+        {{ if eq $.Page.File.Ext "md" }}
+          {{ $.Inner | markdownify }}
+        {{ else }}
+          {{ $.Inner | htmlUnescape | safeHTML }}
+        {{ end }}
+      </p>
+    {{ end }}
+  </div>
+  {{ with $.Get "footer" }}
+    <div class="card-footer">
+      {{ if eq $.Page.File.Ext "md" }}
+        {{ $.Get "footer" | markdownify }}
+      {{ else }}
+        {{ $.Get "footer" | htmlUnescape | safeHTML }}
+      {{ end }}
+    </div>
+  {{ end }}
+</div>

--- a/layouts/shortcodes/cardpane.html
+++ b/layouts/shortcodes/cardpane.html
@@ -1,0 +1,3 @@
+<div class="card-deck mb-4">
+{{- .Inner -}}
+</div>

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,6 +1,8 @@
 <!-- Make sure that we are enclosed within a tabpane shortcode block -->
-{{- if ne .Parent.Name "tabpane" -}}
+{{ with $.Parent }}
+{{- if ne $.Parent.Name "tabpane" -}}
 {{- errorf "tab must be used within a tabpane block" -}}
+{{- end -}}
 {{- end -}}
 
 <!-- Prefill header if not given as parameter -->

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -37,8 +37,7 @@
     {{- $entryid := printf "tabs-%v-%v" $.Ordinal $index | anchorize -}}
     <div class="tab-pane fade{{ if eq $index "0" }} show active{{ end }}"
         id="{{ $entryid }}" role="tabpanel" aria-labelled-by="{{ $tabid }}">
-    {{- highlight (index . "content") $lang $hloptions -}}
-
-     </div>
+      {{- highlight (index . "content") $lang $hloptions -}}
+    </div>
   {{ end }}
 </div>

--- a/static/css/shortcodes.css
+++ b/static/css/shortcodes.css
@@ -1,0 +1,2 @@
+@import "shortcodes/tabbed-pane.css";
+@import "shortcodes/cards-pane.css";

--- a/static/css/shortcodes/cards-pane.css
+++ b/static/css/shortcodes/cards-pane.css
@@ -1,0 +1,21 @@
+.card-deck {
+  max-width: 83%;
+}
+
+.card {
+  max-width: 80%;
+}
+
+.card-body.code {
+  background-color: #f8f9fa;
+  padding: 0 0 0 1ex;
+}
+
+.card-body pre {
+  margin: 0;
+  padding: 0 1rem 1rem 1rem;
+}
+
+.card .highlight {
+  border: none;
+}

--- a/static/css/shortcodes/tabbed-pane.css
+++ b/static/css/shortcodes/tabbed-pane.css
@@ -1,0 +1,18 @@
+.td-content .highlight {
+  margin: 0rem 0 2rem 0;
+}
+
+.tab-content .highlight {
+  border: none;
+}
+
+.tab-content {
+  margin: 0rem;
+  max-width: 80%;
+}
+
+.tab-content pre {
+  border-left: 1px solid rgba(0, 0, 0, 0.125);
+  border-right: 1px solid rgba(0, 0, 0, 0.125);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}

--- a/static/css/tabbed-pane.css
+++ b/static/css/tabbed-pane.css
@@ -1,8 +1,0 @@
-.td-content .highlight {
-  margin: 0rem 0 2rem 0;
-}
-
-.tab-content {
-  margin: 0rem;
-  max-width: 80%;
-}

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -35,7 +35,7 @@ pygmentsStyle = "tango"
 blog = "/:section/:year/:month/:day/:slug/"
 
 [outputs]
-home = [ "HTML", "JSON" ]
+home = [ "HTML" ]
 page = [ "HTML" ]
 section = [ "HTML", "RSS", "print"]
 

--- a/userguide/content/en/docs/Adding content/Shortcodes/index.md
+++ b/userguide/content/en/docs/Adding content/Shortcodes/index.md
@@ -207,7 +207,7 @@ Norway Spruce Picea abies shoot with foliage buds.
 Norway Spruce Picea abies shoot with foliage buds.
 {{< /imgproc >}}
 
-The example above has also a byline with photo attribution added. When using illustrations with a free license from [WikiMedia](https://commons.wikimedia.org/) and simlilar, you will in most situations need a way to attribute the author or licensor. You can add metadata to your page resources in the page front matter. The `byline` param is used by convention in this theme:
+The example above has also a byline with photo attribution added. When using illustrations with a free license from [WikiMedia](https://commons.wikimedia.org/) and similar, you will in most situations need a way to attribute the author or licensor. You can add metadata to your page resources in the page front matter. The `byline` param is used by convention in this theme:
 
 
 ```yaml
@@ -340,3 +340,137 @@ Tabbed panes are implemented using two shortcodes:
 
 * The `tabpane` shortcode, which is the container element for the tabs. This shortcode can optionally held the named parameters `lang` and/or `highlight`. The values of these optional parameters are passed on as second `LANG` and third `OPTIONS` arguments to Hugo's built-in [`highlight`](https://gohugo.io/functions/highlight/) function which is used to render the code blocks of the individual tabs. In case the header text of the tab equals the `language` used in the tab's code block (as in the first tabbed pane example above), you may specify `langEqualsHeader=true` in the surrounding `tabpane` shortcode. Then, the header text of the individual tab is automatically set as `language` parameter of the respective tab.
 * The various `tab` shortcodes which actually represent the tabs you would like to show. We recommend specifying the named parameter `header` for each text in order to set the header text of each tab. If needed, you can additionally specify the named parameters `lang` and `highlight` for each tab. This allows you to overwrite the settings given in the parent `tabpane` shortcode. If the language is neither specified in the `tabpane` nor in the `tab`shortcode, it defaults to Hugo's site variable `.Site.Language.Lang`.
+
+## Card panes
+
+When authoring content, it's sometimes very useful to put similar text blocks or code fragments on card like elements, which can be optionally presented side by side. Let's showcase this feature with the following sample card group which shows the first four Presidents of the United States:
+
+{{< cardpane >}}
+{{< card header="**George Washington**" title="\*1732 &nbsp;&nbsp;&nbsp; †1799" subtitle="**President:** 1789 – 1797" footer="![SignatureGeorgeWashington](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/George_Washington_signature.svg/320px-George_Washington_signature.svg.png \"Signature George Washington\")">}}
+![PortraitGeorgeWashington](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg/633px-Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg "Portrait George Washington")
+{{< /card >}}
+{{< card header="**John Adams**" title="\* 1735 &nbsp;&nbsp;&nbsp; † 1826" subtitle="**President:** 1797 – 1801" footer="![SignatureJohnAdams](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/John_Adams_Sig_2.svg/320px-John_Adams_Sig_2.svg.png \"Signature John Adams\")" >}}
+![PortraitJohnAdams](https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg/633px-Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg "Portrait John Adams")
+{{< /card >}}
+{{< card header="**Thomas Jefferson**" title="\* 1743 &nbsp;&nbsp;&nbsp; † 1826" subtitle="**President:** 1801 – 1809" footer="![SignatureThomasJefferson](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Thomas_Jefferson_Signature.svg/320px-Thomas_Jefferson_Signature.svg.png \"Signature Thomas Jefferson\")" >}}
+![PortraitThomasJefferson](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg/390px-Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg "Portrait Thomas Jefferson")
+{{< /card >}}
+{{< card header="**James Madison**" title="\* 1751 &nbsp;&nbsp;&nbsp; † 1836" subtitle="**President:** 1809 – 1817" footer="![SignatureJamesMadison](https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/James_Madison_sig.svg/320px-James_Madison_sig.svg.png \"Signature James Madison\")" >}}
+![PortraitJamesMadison](https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/James_Madison%28cropped%29%28c%29.jpg/393px-James_Madison%28cropped%29%28c%29.jpg "Portrait James Madison")
+{{< /card >}}
+{{< /cardpane >}}
+
+Docsy supports creating such card panes via different shortcodes:
+
+* The `cardpane` shortcode which is the container element for the various cards to be presented.
+* The `card` shortcodes, with each shortcode representing an individual card. While cards are often presented inside a card group, a single card may stand on its own, too. A `card` shortcode can held text, images or any other arbitrary kind of markdown or HTML markup as content. If your content is programming code, you are advised to make use of the `card-code` shortcode, a special kind of card with code-highlighting and other optional features like line numbers, highlighting of certain lines, ….
+
+### Shortcode `card` (for text, images, …)
+
+As stated above, a card is coded using one of the shortcode `card` or `card-code`.
+If your content is any kind of text other than programming code, use the universal `card`shortcode. The following code sample demonstrates how to code a card element:
+
+```go-html-template
+{{</* card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono"
+          footer="![SignatureJohnLennon](https://server.tld/…/signature.png \"Signature John Lennon\")">*/>}}
+Imagine there's no heaven, It's easy if you try<br/>
+No hell below us, above us only sky<br/>
+Imagine all the people living for today…
+
+…
+{{</* /card */>}}
+```
+This code translates to the left card shown below, showing the lyrics of John Lennon's famous song `Imagine`. A second explanatory card element to the right indicates and explains the individual components of a card:
+
+{{< cardpane >}}
+{{< card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono" footer="![SignatureJohnLennon](https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Firma_de_John_Lennon.svg/320px-Firma_de_John_Lennon.svg.png \"Signature John Lennon\")">}}
+Imagine there's no heaven, It's easy if you try<br/>
+No hell below us, above us only sky<br/>
+Imagine all the people living for today…
+
+Imagine there's no countries, it isn't hard to do<br/>
+Nothing to kill or die for, and no religion too<br/>
+Imagine all the people living life in peace…
+
+Imagine no possessions, I wonder if you can<br/>
+No need for greed or hunger - a brotherhood of man<br/>
+Imagine all the people sharing all the world… 
+
+You may say I'm a dreamer, but I'm not the only one<br/>
+I hope someday you'll join us and the world will live as one
+{{< /card >}}
+{{< card header="**Header**: specified via named parameter `Header`" title="**Card title**: specified via named parameter `title`" subtitle="**Card subtitle**: specified via named parameter `subtitle`" footer="**Footer**: specified via named parameter `footer`" >}}
+  **Content**: inner content of the shortcode, this may be formatted text, images, videos, … . If the extension of your page file equals `.md`, markdown format is expected, otherwise, your content will be treated as plain HTML.
+{{< /card >}}
+{{< /cardpane >}}
+
+While the main content of the card is taken from the inner markup of the `card` shortcode, the optional elements `footer`, `header`, `title`, and `subtitle` are all specified as named parameters of the shortcode.
+
+### Shortcode `card-code` (for programming code)
+
+In case you want to display programming code on your card, a special shortcode `card-code` is provided for this purpose. The following sample demonstrates how to code a card element with the famous `Hello world!`application coded in C:
+
+```go-html-template
+{{</* card-code header="**C**" lang="C" */>}}
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+  puts("Hello World!");
+  return EXIT_SUCCESS;
+}
+{{</* /card-code */>}}
+```
+
+This code translates to the card shown below:
+
+{{< card-code header="**C**" lang="C" highlight="" >}}
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+  puts("Hello World!");
+  return EXIT_SUCCESS;
+}
+{{< /card-code >}}
+
+<br/>The `card-code` shortcode can optionally held the named parameters `lang` and/or `highlight`. The values of these optional parameters are passed on as second `LANG` and third `OPTIONS` arguments to Hugo's built-in [`highlight`](https://gohugo.io/functions/highlight/) function which is used to render the code block presented on the card.
+
+### Card groups
+
+Displaying two ore more cards side by side can be easily achieved by putting them between the opening and closing elements of a `cardpane` shortcode.
+The general markup of a card group resembles closely the markup of a tabbed pane:
+
+```go-html-template
+{{</* cardpane */>}}
+  {{</* card header="Header card 1" */>}}
+    Content card 1
+  {{</* /card */>}}
+  {{</* card header="Header card 2" */>}}
+    Content card 2
+  {{</* /card */>}}
+  {{</* card header="Header card 3" */>}}
+    Content card 3
+  {{</* /card */>}}
+{{</* /cardpane */>}}
+```
+
+Contrary to tabs, cards are presented side by side, however. This is especially useful it you want to compare different programming techniques (traditional vs. modern) on two cards, like demonstrated in the example above:
+
+{{< cardpane >}}
+{{< card-code header="**Java 5**" >}}
+File[] hiddenFiles = new File("directory_name")
+  .listFiles(new FileFilter() {
+    public boolean accept(File file) {
+      return file.isHidden();
+    }
+  });
+{{< /card-code >}}
+{{< card-code header="**Java 8, Lambda expression**" >}}
+File[] hiddenFiles = new File("directory_name")
+  .listFiles(File::isHidden);
+{{< /card-code >}}
+{{< /cardpane >}}
+


### PR DESCRIPTION
This PR adds three shortcodes `cardpane`, `card` and `card-code` in order to allow authoring of cards and card groups. Cards may held either text or programming code. For a preview have a look at the implementation details and the documentation given here:

https://deploy-preview-532--docsydocs.netlify.app/docs/adding-content/shortcodes/#card-panes

I hope you like the feature.