### PR TITLE
Preview of user guide: eliminate warning

### DIFF
--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -35,7 +35,7 @@ pygmentsStyle = "tango"
 blog = "/:section/:year/:month/:day/:slug/"
 
 [outputs]
-home = [ "HTML", "JSON" ]
+home = [ "HTML" ]
 page = [ "HTML" ]
 section = [ "HTML", "RSS", "print"]
 


### PR DESCRIPTION
This PR removes a warning that is printed out when previewing the user guide.

```
/path/to/docsy/userguide
$ hugo server --disableFastRender --themesDir=../..
Start building sites …
WARN 2021/04/27 12:15:37 found no layout file for "JSON" for kind "home": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
...
```
