### PR TITLE
WIP: try darkmode hack #331

### DIFF
--- a/assets/js/dark.js
+++ b/assets/js/dark.js
@@ -1,0 +1,39 @@
+/*
+
+Try out dark mode as mentioned in:
+https://github.com/google/docsy/issues/331
+https://github.com/GoogleContainerTools/skaffold/commit/ccdffd1e27785b203f953dd9b8b8735972ca5d99
+
+*/
+
+// adapted from https://radu-matei.com/blog/dark-mode/
+window.onload = function(){
+  var toggle = document.getElementById("dark-mode-toggle");
+  var darkTheme = document.getElementById("dark-mode-theme");
+
+  // the default theme is light
+  var savedTheme = localStorage.getItem("dark-mode-storage") || "light";
+  setTheme(savedTheme);
+
+  toggle.addEventListener("click", () => {
+    if (toggle.className === "fas fa-moon") {
+      setTheme("dark");
+    } else if (toggle.className === "fas fa-sun") {
+      setTheme("light");
+    }
+  });
+
+  function setTheme(mode) {
+    localStorage.setItem("dark-mode-storage", mode);
+
+    if (mode === "dark") {
+      darkTheme.disabled = false;
+      toggle.className = "fas fa-sun";
+      toggle.title = "Enable Light Mode";
+    } else if (mode === "light") {
+      darkTheme.disabled = true;
+      toggle.className = "fas fa-moon";
+      toggle.title = "Enable Dark Mode";
+    }
+  }
+} 

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,3 +1,5 @@
 {{ with .Site.Params.algolia_docsearch }}
 <!-- stylesheet for algolia docsearch -->
 {{ end }}
+<link disabled id="dark-mode-theme"rel="stylesheet" type="text/css" href="{{ "/css/dark.css" | relURL }}">
+<!-- <script src="/javascripts/dark.js"></script> -->

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -32,4 +32,5 @@
 		</ul>
 	</div>
 	<div class="navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
+	<div class="navbar-nav"><a id="dark-mode-toggle" class="fas fa-moon" title="Enable Dark Mode" style="color: white;"></a></div>
 </nav>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -29,10 +29,11 @@
 {{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
 {{ $jsMermaid := resources.Get "js/mermaid.js" | resources.ExecuteAsTemplate "js/mermaid.js" . }}
 {{ $jsPlantuml := resources.Get "js/plantuml.js" | resources.ExecuteAsTemplate "js/plantuml.js" . }}
+{{ $jsDark := resources.Get "js/dark.js" }}
 {{ if .Site.Params.offlineSearch }}
 {{ $jsSearch = resources.Get "js/offline-search.js" }}
 {{ end }}
-{{ $js := (slice $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml) | resources.Concat "js/main.js" }}
+{{ $js := (slice $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsDark) | resources.Concat "js/main.js" }}
 {{ if .Site.IsServer }}
 <script src="{{ $js.RelPermalink }}"></script>
 {{ else }}

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -1,0 +1,22 @@
+/*
+
+Try out dark mode as mentioned in:
+https://github.com/google/docsy/issues/331
+https://github.com/GoogleContainerTools/skaffold/commit/ccdffd1e27785b203f953dd9b8b8735972ca5d99
+
+*/
+html {
+  background-color: #171717 !important;
+  }
+ 
+  body {
+  filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(85%);
+  -webkit-filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(85%);
+  }
+ 
+  img,
+  video,
+  iframe {
+  filter: hue-rotate(180deg) contrast(100%) invert(100%);
+  -webkit-filter: hue-rotate(180deg) contrast(100%) invert(100%);
+  } 


### PR DESCRIPTION
I have tried to implement the in #331 mentioned - I would call it - "darkmode hack" ;-) and made a PR with the WIP flag to get it deployed by netlify, that the involved people of #331 can see how it looks like. (I hope that's OK?)

In my opinion, the result generated by the snippets from https://github.com/GoogleContainerTools/skaffold/commit/ccdffd1e27785b203f953dd9b8b8735972ca5d99 is ... - yes it's dark and it's a mode and it's really quick to implement ;-)

I think, if we really want a darkmode, it would be better to write an separate _variables.scss to define the colors by hand.

Any other comments?