### PR TITLE
Restore old behavior from sidebar menu #571

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -43,7 +43,7 @@
   {{ $ulShow := .ulShow }}
   {{ $active := and (not $shouldDelayActive) (eq $s $p) }}
   {{ $activePath := and (not $shouldDelayActive) ($p.IsDescendant $s) }}
-  {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact)) true false }}
+  {{ $show := cond (or (lt $ulNr $ulShow) $activePath (and (not $shouldDelayActive) (eq $s.Parent $p.Parent)) (and (not $shouldDelayActive) (eq $s.Parent $p)) (not $p.Site.Params.ui.sidebar_menu_compact) (and (not $shouldDelayActive) ($p.IsDescendant $s.Parent))) true false }}
   {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) }}
   {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true }}
   {{ $pages := $pages_tmp | first $sidebarMenuTruncate }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,6 +11,7 @@
     $("#td-sidebar-menu #{{ $mid }}-li span").addClass("td-sidebar-nav-active-item"); 
     $("#td-sidebar-menu #{{ $mid }}").parents("li").addClass("active-path"); 
     $("#td-sidebar-menu li.active-path").addClass("show"); 
+    $("#td-sidebar-menu li.active-path").siblings("li").addClass("show"); 
     $("#td-sidebar-menu #{{ $mid }}-li").siblings("li").addClass("show");  
     $("#td-sidebar-menu #{{ $mid }}-li").children("ul").children("li").addClass("show");  
     $("#td-sidebar-menu").toggleClass("d-none"); 


### PR DESCRIPTION
With my PR #475 the behavior of the sidebar menu changed a little bit as described in the description of #475: "At the moment I would have implemented it in such a way that all ancestors, siblings and direct descendants are always shown."

In #571 the old behavior was desired: "All parent pages, and siblings of parents are shown."

I don't know what's the better behavior, but with this PR it's possible to restore the old behavior. For me both is OK, because in future I will use the foldable sidebar from #518 ;-)