### PR TITLE
Add Graphviz to Docsy theme example list

### DIFF
--- a/userguide/content/en/docs/Examples/_index.md
+++ b/userguide/content/en/docs/Examples/_index.md
@@ -24,6 +24,7 @@ Example sites that have low to no customization:
 | [gRPC](https://www.grpc.io/) | https://github.com/grpc/grpc.io |
 | [tekton.dev](https://tekton.dev/) | https://github.com/tektoncd |
 | [fluxcd.io](https://fluxcd.io) | https://github.com/fluxcd/website |
+| [Graphviz](https://graphviz.org) | https://gitlab.com/graphviz/graphviz.gitlab.io |
 
 ## Customized Docsy examples
 


### PR DESCRIPTION
I migrated the Graphviz docs to Docsy today with https://gitlab.com/graphviz/graphviz.gitlab.io/-/merge_requests/353.

Thanks for Docsy, it's great being able to outsource a lot of the hard parts of technical documentation to a central team.