### PR TITLE
Allow setting the color of the root of the sidebar tree separately from the  primary color

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -99,8 +99,8 @@
 
     .td-sidebar-link.tree-root{
         font-weight: $font-weight-bold;
-        color: $primary;
-        border-bottom: 1px $primary solid;
+        color: $td-sidebar-tree-root-color;
+        border-bottom: 1px $td-sidebar-tree-root-color solid;
         margin-bottom: 1rem;
     }
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -46,6 +46,7 @@ $code-color: darken($secondary, 20%) !default;
 // UI element colors
 
 $border-color: $gray-300 !default;
+$td-sidebar-tree-root-color: $primary !default;
 $td-sidebar-bg-color: rgba($primary, 0.03) !default;
 $td-sidebar-border-color: $border-color !default;
 


### PR DESCRIPTION
Our site currently sets the primary color to white and also the background
of the sidebar to white. Updating our docsy theme makes it so that the root
of the sidebar tree disappears. This allows us to keep our theming and keep
the root of the sidebar a dark contrasting color from the background.

I haven't actually tested this, but was chatting with @RichieEscarez and figured that this might be the solution to my problem. 