### PR TITLE
Remove incorrect comment in card shortcode

### DIFF
--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -1,4 +1,3 @@
-<!-- Make sure that we are enclosed within a tabpane shortcode block -->
 <div class="card mb-4">
   {{ with $.Get "header" }}
     <div class="card-header">


### PR DESCRIPTION
The card shortcode doesn't have to be used inside tabpanes.

I suspect this was copied from https://github.com/google/docsy/blob/master/layouts/shortcodes/tab.html, which is designed to be used inside tabpanes.