### PR TITLE
Add reading time to i8n and reading-time.html partial

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -47,6 +47,8 @@ other = "Create documentation issue"
 other = "Create project issue"
 [post_posts_in]
 other = "Posts in"
+[post_reading_time]
+other = "minute read"
 
 # Print support
 [print_printable_section]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -43,6 +43,8 @@ other = "Créer un problème dans la documentation"
 other = "Créer un problème dans le projet"
 [post_posts_in]
 other = "Messages dans"
+[post_reading_time]
+other = "minutes à lire"
 
 # Print support
 [print_printable_section]

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,1 +1,1 @@
-<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i> {{ .ReadingTime }} minute read</p>
+<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i> {{ .ReadingTime }} {{ T "post_reading_time" }}</p>


### PR DESCRIPTION
Just a small improvement to the mulilangue functionality.   Allows the 'reading time' message on blog list page to be translated.  