### PR TITLE
Fix Mermaid enabling docs

### DIFF
--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -303,6 +303,14 @@ To enable/disable Mermaid, update `config.toml`:
 enable = true
 ```
 
+You also need to disable the `guessSyntax` from markup highlighting in `config.toml`  for Mermaid to work:
+
+```toml
+[markup]
+  [markup.highlight]
+      guessSyntax = "false"
+```
+
 You can also update settings for Mermaid, such as themes, padding, etc:
 
 ```toml


### PR DESCRIPTION
There's a bug that causes Mermaid not to work if `guessSyntax = "true" is set. https://github.com/google/docsy/issues/573#issuecomment-872068168 

A nicer fix would be to dive into Hugo's markup rendered and Chroma, but this is at least something until the underlying bug is squashed.