### PR TITLE
Fix cut off very long foldable sidebar menus #616

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -159,7 +159,7 @@ nav.foldable-nav {
     }
 
     input:checked ~ ul.foldable {
-        max-height: 100vmax;
+        max-height: 100000vmax;
         transition: max-height 1s ease-in-out;
     }
 


### PR DESCRIPTION
max-height of a menu item with sup items is now set to 100000vmax in the foldable sidebar menu