### PR TITLE
Change navbar search border colour to make it stand out

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -59,7 +59,7 @@
     }
 
     .td-search-input {
-        border: none;
+        border-color: $navbar-dark-color;
 
         @include placeholder {
             color: $navbar-dark-color;


### PR DESCRIPTION
Currently the navbar search input has border `none` so you just see a hint of the drop shadow.  As the input text is shorter than the input it looks like there is a lot of empty space to the right of it.  

Before the change it looks like 

![image](https://user-images.githubusercontent.com/22818309/125934640-7ebc0f11-abb0-49a3-8a6d-3b0fb6772c9b.png)

After the change it looks like

![image](https://user-images.githubusercontent.com/22818309/125934820-05b979b1-84f7-4ea7-a513-c2b1daa4773d.png)

