### PR TITLE
Navigation: omit hidden pages from section index page list by using new front matter variable

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -2,6 +2,7 @@
     {{ $parent := .Page }}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
     {{ $pages = (where $pages "Type" "!=" "search") }}
+    {{ $pages = (where $pages ".Params.toc_hide" "!=" true) }}
     {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
     {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
     {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}

--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -2,7 +2,7 @@
     {{ $parent := .Page }}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
     {{ $pages = (where $pages "Type" "!=" "search") }}
-    {{ $pages = (where $pages ".Params.toc_hide" "!=" true) }}
+    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
     {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
     {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
     {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -78,7 +78,7 @@ description: >
 ---
 ```
 
-To hide a page or section from the menu, set `toc_hide: true` in front matter.
+To hide a page or section from the menu, set `toc_hide: true` in front matter. When set to true in a page, that page is not displayed in the section index page's list of pages. 
 
 ### Section menu options
 

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -80,7 +80,7 @@ description: >
 
 To hide a page or section from the menu, set `toc_hide: true` in the front matter. 
 
-To hide a page on the section summary, set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summery` to `true` in the front matter.
+To hide a page from the section summary on a [docs section landing page]({{< ref "content#docs-section-landing-pages" >}}), set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summary` to `true` in the front matter.
 
 ```yaml
 ---

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -78,7 +78,7 @@ description: >
 ---
 ```
 
-To hide a page or section from the menu, set `toc_hide: true` in the front matter. 
+To hide a page or section from the left navigation menu, set `toc_hide: true` in the front matter. 
 
 To hide a page from the section summary on a [docs section landing page]({{< ref "content#docs-section-landing-pages" >}}), set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summary` to `true` in the front matter.
 

--- a/userguide/content/en/docs/Adding content/navigation.md
+++ b/userguide/content/en/docs/Adding content/navigation.md
@@ -78,7 +78,20 @@ description: >
 ---
 ```
 
-To hide a page or section from the menu, set `toc_hide: true` in front matter. When set to true in a page, that page is not displayed in the section index page's list of pages. 
+To hide a page or section from the menu, set `toc_hide: true` in the front matter. 
+
+To hide a page on the section summary, set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summery` to `true` in the front matter.
+
+```yaml
+---
+title: "My Hidden Page"
+weight: 99
+toc_hide: true
+hide_summary: true
+description: >
+  Page hidden from both the TOC menu and the section summary list.
+---
+```
 
 ### Section menu options
 


### PR DESCRIPTION
Fix: https://github.com/google/docsy/issues/647

Update section-index.html to exclude pages with new  front matter variable `hide_summary: true`. 
This enables pages hidden from TOC to also be hidden from section summary. (see narranfrei's comment below)

Before:
![image](https://user-images.githubusercontent.com/26799583/127909270-4d303023-a044-45f8-be39-abd0f2e25c00.png)





With this code change:
![image](https://user-images.githubusercontent.com/26799583/127909374-3a1ca6a0-d264-465a-ad45-83fe4523c084.png)


