### PR TITLE
Use hugo.IsProduction to determine build environment for CSS and JS

### DIFF
--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -1,6 +1,6 @@
 
 {{ $scssMain := "scss/main.scss"}}
-{{ if .Site.IsServer }}
+{{ if not hugo.IsProduction }}
 {{/* Note the missing postCSS. This makes it snappier to develop in Chrome, but makes it look sub-optimal in other browsers. */}}
 {{ $css := resources.Get $scssMain | toCSS (dict "enableSourceMap" true) }}
 <link href="{{ $css.RelPermalink }}" rel="stylesheet">

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -51,7 +51,7 @@ window.markmap = {
 {{ $jsSearch = resources.Get "js/offline-search.js" }}
 {{ end }}
 {{ $js := (slice $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsMarkmap) | resources.Concat "js/main.js" }}
-{{ if .Site.IsServer }}
+{{ if not hugo.IsProduction }}
 <script src="{{ $js.RelPermalink }}"></script>
 {{ else }}
 {{ $js := $js | minify | fingerprint }}


### PR DESCRIPTION
TL;DR: use `hugo.IsProduction` to determine build environment (production or development) rather than `.Site.IsServer`, when deciding which kind of CSS and JS to generate (production-grade or not).

---

Hugo supports two kinds of build contexts (or "environments" as they are called in the Hugo docs): _development_ and _production_.

By default, hugo _serves_ a development version of a site, and _builds_ (to disk) a production version. You can change the default for either of these commands by using the [-e flag][]. It can be very useful to build a development version of the site -- e.g., for offline analysis. We can't do this currently due to the use of `.Site.IsServer` expression in the `head-css.html` and `scripts.html` partials. This PR fixes the issue.

[-e flag]: https://gohugo.io/commands/hugo/#options

/cc @nate-double-u