### PR TITLE
Use hugo.IsProduction instead of checking HUGO_ENV

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
 
-{{ if and (eq (getenv "HUGO_ENV") "production") (ne $outputFormat "print") -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
 <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 {{ else -}}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
@@ -45,7 +45,7 @@
 {{ end }}
 {{ partial "hooks/head-end.html" . }}
 <!--To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled -->
-{{ if eq (getenv "HUGO_ENV") "production" }}
+{{ if hugo.IsProduction }}
 {{ if hasPrefix .Site.GoogleAnalytics "G-"}}
 {{ template "_internal/google_analytics.html" . }}
 {{ else }}


### PR DESCRIPTION
- Reapplies #413, which was removed by mistake in #540. For details, see https://github.com/google/docsy/pull/540/files#r685339766
- Closes #652