### PR TITLE
Adding feature to support persisting tabpane selection

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -5,6 +5,8 @@
 <script src="https://cdn.jsdelivr.net/npm/mermaid@8.9.2/dist/mermaid.min.js" integrity="sha384-uQikAXnCAqsMb3ygtdqBYvcwvHUkzGIpjdGyy9owhURXHUxLC5LgTcSxJQH/RzjK" crossorigin="anonymous"></script>
 {{ end }}
 
+<script src='{{ "/js/tabpane-persist.js" | relURL }}'></script>
+
 <!-- load the deflate.js for plantuml support -->
 {{ if .Site.Params.plantuml.enable }}
 <script src='{{ "/js/deflate.js" | relURL }}'></script>

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -7,8 +7,11 @@
       <!-- Generate the IDs for the <a> and the <div> elements -->
       {{- $tabid := printf "tabs-%v-%v-tab" $.Ordinal $index | anchorize -}}
       {{- $entryid := printf "tabs-%v-%v" $.Ordinal $index | anchorize -}}
-      <a class="nav-link{{ if eq $index "0" }} active{{ end }}"
-        id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
+      <!-- Replace space and + from tabname to set class -->
+      {{- $tabname := replaceRE "(\\s)" "-" $element.header -}}
+      {{- $tabname := replaceRE "(\\+)" "-" $tabname -}}
+      <a class="nav-link{{ if eq $index "0" }} active{{ end }} tab-{{ $tabname }}"
+        id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab" onclick="handleClick({{ $tabname }});"
         aria-controls="{{ $entryid }}" aria-selected="{{- cond (eq $index "0") "true" "false" -}}">
         {{ index . "header" }}
       </a>

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -1,0 +1,18 @@
+if (typeof Storage !== 'undefined') {
+    const activeLanguage = localStorage.getItem('active_language');
+    if (activeLanguage) {
+        document
+            .querySelectorAll('.tab-' + activeLanguage)
+            .forEach((element) => {
+                element.click();
+            });
+    }
+}
+function handleClick(language) {
+    if (typeof Storage !== 'undefined') {
+        localStorage.setItem('active_language', language);
+        document.querySelectorAll('.tab-' + language).forEach((element) => {
+            element.click();
+        });
+    }
+}


### PR DESCRIPTION
Adding a feature to support persisting programming language selection
in `tabpane` for documentation pages.

`tabpane` selection persists across different pages and browser sessions.

fixes #654 