### PR TITLE
FIX: meta description tag creation in head.html (SEO)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,14 @@
 
 {{ partialCached "favicons.html" . }}
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-<meta name="description" content="{{ .Site.Params.Description }}">
+<!-- for search engine optimization and third-party search engines like Elastic App Search-->
+{{ if .Page.Description }}
+  <meta name="description" content="{{ .Page.Description }}">
+{{ else }}
+  {{ $desc := (.Page.Content | safeHTML | truncate 150) }}
+  <meta name="description" content="{{ $desc }}">
+{{ end }}
+
 {{- template "_internal/opengraph.html" . -}}
 {{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}

--- a/userguide/content/en/docs/Adding content/content.md
+++ b/userguide/content/en/docs/Adding content/content.md
@@ -108,7 +108,7 @@ description: >
 ---
 ```
 
-The minimum frontmatter you need to provide is a title: everything else is up to you! (though if you leave out the page weight your [navigation](/docs/adding-content/navigation) may get a little disorganized).
+The minimum frontmatter you need to provide is a title: everything else is up to you! However, if you leave out the page weight, your [navigation](/docs/adding-content/navigation) may get a little disorganized. You may also want to include `description` since Docsy uses that to generate the meta `description` tag used by search engines. See [Search Engine Optimization (SEO) meta tags]({{< ref "feedback#search-engine-optimization-meta-tags" >}}) for details.
 
 
 ## Page contents and markup

--- a/userguide/content/en/docs/Adding content/feedback.md
+++ b/userguide/content/en/docs/Adding content/feedback.md
@@ -1,10 +1,10 @@
 ---
-title: "Analytics and User Feedback"
+title: "Analytics, User Feedback, SEO"
 date: 2019-06-05
 weight: 8
 description: >
   Add Google Analytics tracking to your site, use the "was this page helpful?" widget data, disable the widget on a single
-  page or all pages, and change the response text.
+  page or all pages, and change the response text. See what data is used to create the `meta description` tag for SEO.
 ---
 
 ## Adding Analytics
@@ -131,3 +131,38 @@ Set `params.ui.feedback.enable` to `false` in `config.toml`:
 
     [params.ui.feedback]
     enable = false
+
+## Search Engine Optimization meta tags
+
+Check out Google's [Search Engine Optimization (SEO) Starter Guide](https://developers.google.com/search/docs/beginner/seo-starter-guide) for how to optimize your site for SEO.
+
+Google [recommends](https://developers.google.com/search/docs/beginner/seo-starter-guide?hl=en%2F#descriptionmeta) using the `description` meta tag to tell search engines what your page is about. The Docsy theme creates and populates this meta tag for you in the `layouts/partials/head.html` file:
+
+```html
+{{ if .Page.Description }}
+  <meta name="description" content="{{ .Page.Description }}">
+{{ else }}
+  {{ $desc := (.Page.Content | safeHTML | truncate 150) }}
+  <meta name="description" content="{{ $desc }}">
+{{ end }}
+```
+
+`.Page.Description` is the text from the `description` [frontmatter field]({{< ref "content#page-frontmatter" >}}). If the page's frontmatter does not have a `description`, the first 150 characters of the page content is used instead.
+
+For example, if your front matter `description` is:
+
+```markdown
+---
+description: >
+  Add Google Analytics tracking to your site.
+---
+```
+
+Then the meta `description` tag on the rendered page is:
+
+```html
+<meta name="description" content="Add Google Analytics tracking to your site.">
+```
+
+You can add additional meta tags to your own copy of the `head-end.html` partial. See [Customizing templates]({{< ref "lookandfeel#customizing-templates" >}}) for more information.
+


### PR DESCRIPTION
Change meta `description` tag creation so the content is the actual page description or the first 150 characters of the page content rather than a value defined in `config.toml`.

**Problem**:  
Introduced in PR #540 
`<meta name="description" content="{{ .Site.Params.Description }}">` in `head.html` adds the meta description tag with the _exact same content_ to each page. According to Google's [Search Engine Optimization (SEO) Starter Guide](https://developers.google.com/search/docs/beginner/seo-starter-guide), "A page's description meta tag gives Google and other search engines a summary of what the page is about. A page's title may be a few words or a phrase, whereas a page's description meta tag might be a sentence or two or even a short paragraph." So including the exact same meta description tag on each page causes search engines and third-party search providers (like Elastic App Search) to think every page on your site has the same description. In this case, each page's description is whatever you set in `config.toml`. 

For example, if you have configured:

```yaml
[languages.en]
title = "Armory Docs"
description = "Unlocking Innovation by Making Software Delivery Continuous, Scalable, and Safe "
```

Then every rendered page in your site will have the `<meta name="description" content="Unlocking Innovation by Making Software Delivery Continuous, Scalable, and Safe">` tag. 

I discovered this issue after upgrading Docsy and seeing irregularities in my SEO and Elastic indexing... and consequently poor search results. Last year I had created my meta `description` tag in my copy of `head-end.html`. After recently upgrading Docsy, I noticed that two meta descriptions tag were created for each page: the first tag, created in `head.html`, used the `.Site.Params.Description` and the second (from my custom `head-end.html`) used `.Page.Description`. The indexing engine picked up the first (incorrect) meta tag created in `head.html`.  


**Fix**: 
change the tag creation in `head.html` to use the page's frontmatter `description`. If there isn't a description, use the first 150 characters of the page's content. Add content to the documentation explaining how Docsy creates the meta `description` tag.
