### PR TITLE
fix: Test for nil parent when generating section list

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -3,6 +3,7 @@
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
     {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
+    {{ $pages = (where $pages ".Parent" "!=" nil) }}
     {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
     {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
     {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}


### PR DESCRIPTION
This fixes an issue where a section may not have a parent resulting in the following error

```
Error: Error building site: failed to render pages: render of "home" failed: execute of template failed:
 template: docs/list.html:21:11: executing "main" at <partial "section-index.html" .>:
   error calling partial: "/workspaces/mostlydocs/themes/docsy/layouts/partials/section-index.html:5:17":
    execute of template failed:
      template: partials/section-index.html:5:17:
        executing "partials/section-index.html" at <where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID>: error calling where: reflect: call of reflect.Value.Type on zero Value
```

fixes #656

Signed-off-by: Brad Beam <brad.beam@b-rad.info>