### PR TITLE
Fixing infinite loop when several tabs are present

### DIFF
--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -4,15 +4,16 @@ if (typeof Storage !== 'undefined') {
         document
             .querySelectorAll('.tab-' + activeLanguage)
             .forEach((element) => {
-                element.click();
+              $('#' + element.id).tab('show');
             });
     }
 }
 function handleClick(language) {
     if (typeof Storage !== 'undefined') {
         localStorage.setItem('active_language', language);
-        document.querySelectorAll('.tab-' + language).forEach((element) => {
-            element.click();
+        document.querySelectorAll('.tab-' + language)
+          .forEach((element) => {
+            $('#' + element.id).tab('show');
         });
     }
 }


### PR DESCRIPTION
Based on how Bootstrap suggests to select tabs https://getbootstrap.com/docs/4.6/components/navs/#tabshow

We have an issue on the Selenium docs, where this js script is blocking the navigations. I made the change locally and based on the recommendation from Bootstrap, this is a much better way to select the tab, and to avoid the infinite loop.