### PR TITLE
Improve Reading time format

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -41,6 +41,10 @@ other = "أنشئ مسألة حول الوثائق"
 other = "أنشئ مسألة حول المشروع"
 [post_posts_in]
 other = "منشور في"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/bg.toml
+++ b/i18n/bg.toml
@@ -43,6 +43,10 @@ other = "Създаване на издаване на документ"
 other = "Създаване на издаване на проект"
 [post_posts_in]
 other = "Публикувано в"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/bn.toml
+++ b/i18n/bn.toml
@@ -41,6 +41,10 @@ other = "ডকুমেন্টেশন ইস্যু তৈরি কর�
 other = "প্রকল্পের সমস্যা তৈরি করুন"
 [post_posts_in]
 other = "পোস্ট"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # মুদ্রণ সমর্থন
 [print_printable_section]

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -47,6 +47,10 @@ other = "Problem zu dieser Seite melden"
 other = "Problem melden"
 [post_posts_in]
 other = "Einträge in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -49,6 +49,8 @@ other = "Create project issue"
 other = "Posts in"
 [post_reading_time]
 other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -49,6 +49,8 @@ other = "Notificar una incidencia en un proyecto"
 other = "Añadir entrada"
 [post_reading_time]
 other = "minutos de lectura"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/et.toml
+++ b/i18n/et.toml
@@ -42,3 +42,7 @@ other = "Tõstata dokumentatsiooni kohta ülesanne" # perhaps there is a better 
 other = "Tõstata projekti kohta ülesanne"
 [post_posts_in]
 other = "Postitused" # in Estonian this "in" should be the suffix of the next word, cannot include it to that phrase.
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -43,6 +43,11 @@ other = "ساخت ایشو"
 other = "ساخت ایشو برای پوسته"
 [post_posts_in]
 other = "نوشته ها در"
+[post_reading_time]
+other = "دقیقه برای خواندن"
+[post_less_than_a_minute_read]
+other = "کمتر از یک دقیقه"
+
 
 # Print support
 [print_printable_section]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -45,6 +45,8 @@ other = "Signler un problème dans le projet"
 other = "Messages dans"
 [post_reading_time]
 other = "minutes à lire"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -47,6 +47,10 @@ other = "Projekt issue létrehozása"
 #   so I left it as is
 [post_posts_in]
 other = "Posts in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -43,6 +43,10 @@ other = "Crea issue di documentazione"
 other = "Crea issue di progetto"
 [post_posts_in]
 other = "Post in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -43,6 +43,10 @@ other = "ドキュメントのissueを作成"
 other = "プロジェクトのissueを作成"
 [post_posts_in]
 other = "記事一覧"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -43,6 +43,10 @@ other = "문서에 이슈 생성"
 other = "프로젝트에 이슈 생성"
 [post_posts_in]
 other = "Posts in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -43,6 +43,10 @@ other = "Maak documentatie issue"
 other = "Maak project issue"
 [post_posts_in]
 other = "Posts in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -43,6 +43,10 @@ other = "Opprett dokumentasjon sak"
 other = "Opprett prosjekt sak"
 [post_posts_in]
 other = "Poster i"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -43,6 +43,11 @@ other = "Zgłoś błąd w dokumencie"
 other = "Zgłoś błąd na stronie"
 [post_posts_in]
 other = "Posty"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
+
 
 # Print support
 [print_printable_section]

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -43,6 +43,10 @@ other = "Relatar um problema de documentação"
 other = "Relatar um problema no projeto"
 [post_posts_in]
 other = "Posts em"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -43,6 +43,10 @@ other = "Предложить изменения документации"
 other = "Предложить доработки по проекту"
 [post_posts_in]
 other = "Публикации в"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -43,6 +43,10 @@ other = "Belge konusu oluştur"
 other = "Proje konusu oluştur"
 [post_posts_in]
 other = "Gönderiler in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -43,6 +43,10 @@ other = "提交文档问题"
 other = "提交项目问题"
 [post_posts_in]
 other = "Posts in"
+[post_reading_time]
+other = "minute read"
+[post_less_than_a_minute_read]
+other = "less than a minute"
 
 # Print support
 [print_printable_section]

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,1 +1,1 @@
-<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i>&nbsp;{{ if gt .ReadingTime 0 }} {{ .ReadingTime }} {{ T "post_reading_time" }} {{ else }} {{ T "post_less_than_a_minute_read" }} {{ end }}&nbsp;</p>
+<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i>&nbsp;{{ if gt .ReadingTime 1 }} {{ .ReadingTime }} {{ T "post_reading_time" }} {{ else }} {{ T "post_less_than_a_minute_read" }} {{ end }}&nbsp;</p>

--- a/layouts/partials/reading-time.html
+++ b/layouts/partials/reading-time.html
@@ -1,1 +1,1 @@
-<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i> {{ .ReadingTime }} {{ T "post_reading_time" }}</p>
+<p class="reading-time"><i class="fa fa-clock" aria-hidden="true"></i>&nbsp;{{ if gt .ReadingTime 0 }} {{ .ReadingTime }} {{ T "post_reading_time" }} {{ else }} {{ T "post_less_than_a_minute_read" }} {{ end }}&nbsp;</p>

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -170,7 +170,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/google/docsy/issues
 # If you want this feature, but occasionally need to remove the Reading time from a single page, 
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
-enable = false
+enable = true
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -170,7 +170,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/google/docsy/issues
 # If you want this feature, but occasionally need to remove the Reading time from a single page, 
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
-enable = true
+enable = false
 
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.


### PR DESCRIPTION
Using Zero (`0`) for reading time is not beautiful, and it's better to have a specific phrase for 0 length posts.   
This PR Improves the Reading time format, uses `less than a minute` for short posts (reading time <= 1), and uses local language to represent reading time. 

![image](https://user-images.githubusercontent.com/7028952/131254308-885e126e-a170-4cc2-a60a-01c36b24b2dc.png)


