### PR TITLE
Fix feature block

### DIFF
--- a/layouts/shortcodes/blocks/feature.html
+++ b/layouts/shortcodes/blocks/feature.html
@@ -5,15 +5,13 @@
     <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
   </div>
   <h4 class="h3">
-    {{ if eq .Page.File.Ext "md" }}
-      {{ .Get "title" | markdownify }}
+    {{ if eq .Page.File.Ext "md" }}{{ .Get "title" | markdownify }}
     {{ else }}
       {{ .Get "title" | htmlUnescape | safeHTML }}
     {{ end }}
   </h4>
   <p class="mb-0">
-    {{ if eq .Page.File.Ext "md" }}
-      {{ .Inner | markdownify }}
+    {{ if eq .Page.File.Ext "md" }}{{ .Inner | markdownify }}
     {{ else }}
       {{ .Inner | htmlUnescape | safeHTML }}
     {{ end }}


### PR DESCRIPTION
fix #584 

This PR corrects incorrect display of the `feature` block on pages with the extension .md