### PR TITLE
Offline search: fingerprint data in production only

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -2,8 +2,13 @@
 <input type="search" class="form-control td-search-input" placeholder="&#xf002; {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ else if .Site.Params.offlineSearch }}
 {{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . }}
+{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+{{ if hugo.IsProduction -}}
 {{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */}}
 {{ $offlineSearchIndexFingerprint := $offlineSearchIndex | resources.Fingerprint "md5" }}
+{{ $offlineSearchLink = $offlineSearchIndexFingerprint.RelPermalink -}}
+{{ end -}}
+
 <input
   type="search"
   class="form-control td-search-input"
@@ -17,7 +22,7 @@
     It causes the json file loading error when when relativeURLs is enabled.
     https://github.com/google/docsy/issues/181
   */}}
-  data-offline-search-index-json-src="{{ $offlineSearchIndexFingerprint.RelPermalink }}"
+  data-offline-search-index-json-src="{{ $offlineSearchLink }}"
   data-offline-search-base-href="/"
   data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
 >


### PR DESCRIPTION
Extending #651 to the offline search data file.

/cc @nate-double-u
