### PR TITLE
page-meta-lastmod whitespace cleanup

### DIFF
--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,11 +1,10 @@
+{{ if and (.GitInfo) (.Site.Params.github_repo) -}}
 <div class="text-muted mt-5 pt-3 border-top">
-  {{ if and (.GitInfo) (.Site.Params.github_repo) -}}
-    {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
-    {{ with .GitInfo }}: {{/* Trim WS */ -}}
-      <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
-        {{- .Subject }} ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
-      </a>
-    {{- end -}}
-  {{ end }}
+  {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+  {{ with .GitInfo }}: {{/* Trim WS */ -}}
+    <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+      {{- .Subject }} ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
+    </a>
+  {{- end }}
 </div>
-{{/* Trim WS */ -}}
+{{ end -}}

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,7 +1,11 @@
 <div class="text-muted mt-5 pt-3 border-top">
-{{ if and (.GitInfo) (.Site.Params.github_repo) }}
-    {{ T "post_last_mod"}}
-    {{ .Lastmod.Format .Site.Params.time_format_default }}
-    {{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{ end }}
-{{ end }}
+  {{ if and (.GitInfo) (.Site.Params.github_repo) -}}
+    {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
+    {{ with .GitInfo }}: {{/* Trim WS */ -}}
+      <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+        {{- .Subject }} ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
+      </a>
+    {{- end -}}
+  {{ end }}
 </div>
+{{/* Trim WS */ -}}


### PR DESCRIPTION
PR #557 introduced an extra space before the `:`, for example look at https://www.docsy.dev/docs/:

> <img width="506" alt="Screen Shot 2021-09-20 at 6 12 29 PM" src="https://user-images.githubusercontent.com/4140793/134082882-c9bfc5fb-9e75-43e0-bb1a-b82de270f63f.png">

This PR:

- Removes that extraneous whitespace
- Offers a logical layout of the partial content with meaningful indentation
- Uses template comments to strip out extraneous whitespace when other template directives can't be used.
  I'm using "Trim WS" as the comment text here, but I suppose that the comment could just be empty, WDYT @LisaFC?

Here's an example of the resulting change in the generated files of the user guide (if you have `public` setup as a local repo):

```console
$ (cd public && git diff docs/getting-started/index.html)
```

yields

```diff
diff --git a/docs/getting-started/index.html b/docs/getting-started/index.html
index 6c03ce3..3f48ae6 100644
--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -725,11 +725,7 @@ sudo sysctl -w kern.maxfilesperproc<span style="color:#ce5c00;font-weight:bold">
        
        
        <div class="text-muted mt-5 pt-3 border-top">
-
-    Last modified
-    June 15, 2021
-    : <a  href="https://github.com/google/docsy/commit/4d59febf5766d43a9aae879b0f6dd59f809f502a">Known issue for WSL (4d59feb)</a>
-
+  Last modified June 15, 2021: <a href="https://github.com/google/docsy/commit/4d59febf5766d43a9aae879b0f6dd59f809f502a">Known issue for WSL (4d59feb)</a>
 </div>
```

Preview, e.g., visit the end of the following page: https://deploy-preview-699--docsydocs.netlify.app/docs/