### PR TITLE
Fix EXECUTE-AS-TEMPLATE error with offline-search-index.json (issue #705)

### DIFF
--- a/assets/json/offline-search-index.json
+++ b/assets/json/offline-search-index.json
@@ -1,7 +1,18 @@
 {{- $.Scratch.Add "offline-search-index" slice -}}
 {{- range where .Site.AllPages ".Params.exclude_search" "!=" true -}}
-{{/* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */}}
-{{/* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */}}
-{{- $.Scratch.Add "offline-search-index" (dict "ref" .RelPermalink "title" .Title "categories" (.Params.categories | default "") "tags" (.Params.tags | default "") "description" (.Description | default "") "body" (.Plain | htmlUnescape) "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)) -}}
+{{- /* We have to apply `htmlUnescape` again after `truncate` because `truncate` applies `html.EscapeString` if the argument is not HTML. */ -}}
+{{- /* Indvidual taxonomies can be added in the next line by add '"taxonomy-name" (.Params.taxonomy-name | default "")' to the dict (as seen for categories and tags). */ -}}
+{{- $.Scratch.Add
+    "offline-search-index"
+    (dict
+        "ref" .RelPermalink
+        "title" .Title
+        "categories" (.Params.categories | default "")
+        "tags" (.Params.tags | default "")
+        "description" (.Description | default "")
+        "body" (.Plain | htmlUnescape)
+        "excerpt" ((.Description | default .Plain) | htmlUnescape | truncate (.Site.Params.offlineSearchSummaryLength | default 70) | htmlUnescape)
+    )
+-}}
 {{- end -}}
 {{- $.Scratch.Get "offline-search-index" | jsonify -}}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,13 +1,9 @@
 {{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
 <input type="search" class="form-control td-search-input" placeholder="&#xf002; {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 {{ else if .Site.Params.offlineSearch }}
-{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . }}
-{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
-{{ if hugo.IsProduction -}}
-{{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */}}
-{{ $offlineSearchIndexFingerprint := $offlineSearchIndex | resources.Fingerprint "md5" }}
-{{ $offlineSearchLink = $offlineSearchIndexFingerprint.RelPermalink -}}
-{{ end -}}
+{{- /* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
+{{- $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . | fingerprint "md5" -}}
+{{- $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
 
 <input
   type="search"


### PR DESCRIPTION
Fix the following error with Hugo 0.88.1  when offline search is enabled and the document contains `{{`.

```
Error: Error building site: EXECUTE-AS-TEMPLATE: failed to transform "offline-search-index.json" (application/json): failed to parse Resource "offline-search-index.json" as Template:: template: offline-search-index.json:750: comment ends before closing delimiter
```
