### PR TITLE
Offline search: fingerprint data in production only, take 2

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,9 +1,12 @@
-{{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch }}
+{{ if or .Site.Params.gcs_engine_id .Site.Params.algolia_docsearch -}}
 <input type="search" class="form-control td-search-input" placeholder="&#xf002; {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
-{{ else if .Site.Params.offlineSearch }}
-{{- /* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
-{{- $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . | fingerprint "md5" -}}
-{{- $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
+{{ else if .Site.Params.offlineSearch -}}
+{{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . -}}
+{{ if hugo.IsProduction -}}
+{{/* Use `md5` as finger print hash function to shorten file name to avoid `file name too long` error. */ -}}
+{{ $offlineSearchIndex = $offlineSearchIndex | fingerprint "md5" -}}
+{{ end -}}
+{{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
 
 <input
   type="search"
@@ -22,4 +25,4 @@
   data-offline-search-base-href="/"
   data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
 >
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
- Essentially a reapplication of #691 
- Closes #713
- Does a little extra whitespace cleanup

I tested this with and without offline search enabled, in development and production modes and it compiles fine; fingerprints in production mode, and doesn't otherwise.

/cc @celestehorgan @nate-double-u