### PR TITLE
Fix the search field background color when offline search is enabled.

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -64,6 +64,16 @@
         @include placeholder {
             color: $navbar-dark-color;
         }
+
+        &.offline-search-input {
+            // Set the search field background color to active color when offline search is enabled.
+            // https://github.com/google/docsy/issues/718
+            background: $navbar-dark-active-color;
+
+            @include placeholder {
+                color: inherit;
+            }
+        }
     }
 
     .dropdown {
@@ -122,12 +132,12 @@
             text-rendering: auto;
             -webkit-font-smoothing: antialiased;
             font-family: "Font Awesome 5 Free";
-            font-weight: 900; 
+            font-weight: 900;
             content: "\f0d9";
             padding-left: 0.5em;
             padding-right: 0.5em;
         }
-    }  
+    }
 }
 
 // Foldable sidebar menu
@@ -136,18 +146,18 @@ nav.foldable-nav {
     &#td-section-nav {
         position: relative;
     }
-    
+
     &#td-section-nav label {
         margin-bottom: 0;
         width: 100%;
     }
-    
+
     .td-sidebar-nav__section, .with-child ul {
         list-style: none;
         padding: 0;
         margin: 0;
     }
-    
+
     .ul-1 > li {
         padding-left: 1.5em;
     }
@@ -165,8 +175,8 @@ nav.foldable-nav {
 
     input[type=checkbox] { display: none; }
 
-    .with-child, .without-child { 
-        position: relative; 
+    .with-child, .without-child {
+        position: relative;
         padding-left: 1.5em;
     }
 
@@ -189,30 +199,30 @@ nav.foldable-nav {
         }
     }
 
-    .ul-1 .with-child > input:checked ~ label:before { 
+    .ul-1 .with-child > input:checked ~ label:before {
         color: $primary;
         transform: rotate(90deg);
-        transition: transform 0.5s; 
+        transition: transform 0.5s;
     }
 
     .with-child ul { margin-top: 0.1em; }
-    
-}    
+
+}
 
 @media (hover: hover) and (pointer: fine) {
-    
+
     nav.foldable-nav {
 
-        .ul-1 .with-child > label:hover:before { 
+        .ul-1 .with-child > label:hover:before {
             color: $primary;
             transform: rotate(30deg);
-            transition: transform 0.5s; 
+            transition: transform 0.5s;
         }
 
-        .ul-1 .with-child > input:checked ~ label:hover:before { 
+        .ul-1 .with-child > input:checked ~ label:hover:before {
             color: $primary;
             transform: rotate(60deg) !important;
-            transition: transform 0.5s; 
+            transition: transform 0.5s;
         }
     }
 }

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -10,7 +10,7 @@
 
 <input
   type="search"
-  class="form-control td-search-input"
+  class="form-control td-search-input offline-search-input"
   placeholder="&#xf002; {{ T "ui_search" }}"
   aria-label="{{ T "ui_search" }}"
   autocomplete="off"


### PR DESCRIPTION
Change the search field background color to always be the active color when offline search is enabled to fix #718.

## Before

<img width="1580" alt="before" src="https://user-images.githubusercontent.com/659178/137044874-02257cd8-f379-4c12-aaef-aded05aa1f1d.png">

## After

<img width="1586" alt="after" src="https://user-images.githubusercontent.com/659178/137044876-b1df5f26-1f5d-4396-967b-84574cf41449.png">

