### PR TITLE
blocks/feature reworked to support use from .md files

### DIFF
--- a/layouts/shortcodes/blocks/feature.html
+++ b/layouts/shortcodes/blocks/feature.html
@@ -1,22 +1,14 @@
-{{ $icon := .Get "icon" | default "fa-lightbulb" }}
-{{ $url_text := .Get "url_text" }}
-<div class="col-lg-4 mb-5 mb-lg-0 text-center ">
-  <div class="mb-4 h1">
-    <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
-  </div>
-  <h4 class="h3">
-    {{ if eq .Page.File.Ext "md" }}
-      {{ .Get "title" | markdownify }}
-    {{ else }}
-      {{ .Get "title" | htmlUnescape | safeHTML }}
-    {{ end }}
-  </h4>
-  <p class="mb-0">
-    {{ if eq .Page.File.Ext "md" }}
-      {{ .Inner | markdownify }}
-    {{ else }}
-      {{ .Inner | htmlUnescape | safeHTML }}
-    {{ end }}
-  </p>
-  {{ with .Get "url" }}<p><a href="{{ . }}">{{ with $url_text }}{{ $url_text }}{{ else }}{{ T "ui_read_more" }}{{ end }} …</a></p>{{ end }}
+{{ $icon := .Get "icon" | default "fa-lightbulb" -}}
+{{ $url_text := .Get "url_text" -}}
+<div class="col-lg-4 mb-5 mb-lg-0 text-center">
+<div class="mb-4 h1">
+  <i class="{{ if not (or (hasPrefix $icon "fas ") (hasPrefix $icon "fab ")) }}fas {{ end }}{{ $icon }}"></i>
+</div>
+<h4 class="h3">
+  {{- .Get "title" | markdownify -}}
+</h4>
+<div class="mb-0">
+{{ .Inner }}
+</div>
+{{ with .Get "url" }}<p><a href="{{ . }}">{{ with $url_text }}{{ $url_text }}{{ else }}{{ T "ui_read_more" }}{{ end }} …</a></p>{{ end }}
 </div>


### PR DESCRIPTION
- It's best to review this [file diff while **ignoring whitespace changes**](https://github.com/google/docsy/pull/727/files?diff=split&w=1)
- Closes #724
- This is a rework of #526, which (IMHO) should have simply changed the `<p>` to a `<div>` to avoid the invalid `<p>` nesting -- https://github.com/google/docsy/issues/724#issuecomment-944823539. This might affect styling, but that can (should?) be handled separately.
- This shortcode needs a few more changes, but I'll keep the focus of this PR on resolving #724.

/cc @nate-double-u @celestehorgan