### PR TITLE
Upgrade to Hugo 0.89.4 and ignore .hugo_build.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 package-lock.json
 
+# Hugo
+.hugo_build.lock
+/public
 resources/
 
 # vim temporary files

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "userguide/public"
 command = "npm install && npm run build:preview"
 
 [build.environment]
-HUGO_VERSION = "0.88.1"
+HUGO_VERSION = "0.89.4"
 HUGO_THEME = "repo"
 
 [context.production]

--- a/userguide/.gitignore
+++ b/userguide/.gitignore
@@ -1,2 +1,4 @@
+# Hugo
+.hugo_build.lock
 /public
 resources/


### PR DESCRIPTION
The `.hugo_build.lock` file is new to Hugo [v0.89.0].

[v0.89.0]: https://github.com/gohugoio/hugo/releases/tag/v0.89.0