### PR TITLE
User guide: add "Styles" and "Disabling links"

### DIFF
--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -1,25 +1,45 @@
 ---
-title: "Look and Feel"
-linkTitle: "Look and Feel"
+title: Look and Feel
 date: 2017-01-05
 weight: 2
-description: >
-  Customize colors, fonts, and more for your site.
+description: Customize colors, fonts, and more for your site.
 ---
 
 By default, a site using Docsy has the theme's default fonts, colors, and general look and feel. However, if you want your own color scheme (and you probably will!) you can very easily override the theme defaults with your own project-specific values - Hugo will look in your project files first when looking for information to build your site. Also because Docsy uses Bootstrap 4 and SCSS for styling, you can override just single values in its special SCSS project variables file, or do more serious customization by creating your own versions of entire SCSS files.
+## Styles
 
-## Color palette and other styles
+### Project style files
 
-To quickly change your site's colors, add SCSS variable project overrides to `assets/scss/_variables_project.scss`. A simple example changing the primary and secondary color to two shades of purple:
+To customize your project's styles, override either or both of the following
+Docsy placeholder files (note the **`_project.scss`** suffixes):
+
+- [`assets/scss/`**`_variables_project.scss`**][_variables_project]
+- [`assets/scss/`**`_styles_project.scss`**][_styles_project]
+
+Add project-specific variables definitions to your project's
+`_variables_project.scss` file, such as [site colors](#site-colors).
+
+You'll find Docsy-specific variables and Docsy-Bootstrap overrides, in
+[<code>assets/scss/<strong>_variables.scss</strong></code>][_variables]. For
+information about Bootstrap 4 variables see [Variable defaults][] and
+Bootstrap's [v4-dev/scss/_variables.scss][] file.
+
+[_styles_project]: https://github.com/google/docsy/blob/master/assets/scss/_styles_project.scss
+[_variables_project]: https://github.com/google/docsy/blob/master/assets/scss/_variables_project.scss
+[_variables]: https://github.com/google/docsy/blob/master/assets/scss/_variables.scss
+[v4-dev/scss/_variables.scss]: https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
+[Variable defaults]: https://getbootstrap.com/docs/4.1/getting-started/theming/#variable-defaults
+
+### Site colors
+
+To easily customize your site's colors, add SCSS variable project overrides to
+`assets/scss/_variables_project.scss`. A simple example changing the primary and
+secondary color to two shades of purple:
 
 ```scss
 $primary: #390040;
 $secondary: #A23B72;
 ```
-
-* See `assets/scss/_variables.scss` in the theme for color variables etc. that can be set to change the look and feel.
-* Also see available variables in Bootstrap 4: https://getbootstrap.com/docs/4.0/getting-started/theming/ and https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
 
 The theme has features such as rounded corners and gradient backgrounds enabled by default. These can also be toggled in your project variables file:
 
@@ -32,8 +52,6 @@ $enable-shadows: true;
 {{% alert title="Tip" %}}
 PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in server mode (it is a little slow), so Chrome is the recommended choice for development.
 {{% /alert %}}
-
-Also note that any SCSS import will try the project before the theme, so you can -- as one example -- create your own `_assets/scss/_content.scss` and get full control over how your Markdown content is styled.
 
 ## Fonts
 

--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -19,9 +19,9 @@ Docsy placeholder files (note the **`_project.scss`** suffixes):
 Add project-specific variables definitions to your project's
 `_variables_project.scss` file, such as [site colors](#site-colors).
 
-You'll find Docsy-specific variables and Docsy-Bootstrap overrides, in
+You'll find Docsy-specific variables and Docsy-Bootstrap overrides in
 [<code>assets/scss/<strong>_variables.scss</strong></code>][_variables]. For
-information about Bootstrap 4 variables see [Variable defaults][] and
+information about Bootstrap 4 variables, see [Variable defaults][] and
 Bootstrap's [v4-dev/scss/_variables.scss][] file.
 
 [_styles_project]: https://github.com/google/docsy/blob/master/assets/scss/_styles_project.scss
@@ -32,7 +32,7 @@ Bootstrap's [v4-dev/scss/_variables.scss][] file.
 
 ### Site colors
 
-To easily customize your site's colors, add SCSS variable project overrides to
+To easily customize your site's colors, add SCSS variable overrides to
 `assets/scss/_variables_project.scss`. A simple example changing the primary and
 secondary color to two shades of purple:
 

--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -2,27 +2,20 @@
 title: Look and Feel
 date: 2017-01-05
 weight: 2
-description: Customize colors, fonts, and more for your site.
+description: Customize colors, fonts, code highlighting, and more for your site.
 ---
 
-By default, a site using Docsy has the theme's default fonts, colors, and general look and feel. However, if you want your own color scheme (and you probably will!) you can very easily override the theme defaults with your own project-specific values - Hugo will look in your project files first when looking for information to build your site. Also because Docsy uses Bootstrap 4 and SCSS for styling, you can override just single values in its special SCSS project variables file, or do more serious customization by creating your own versions of entire SCSS files.
-## Styles
+By default, a site using Docsy has the theme's default fonts, colors, and general look and feel. However, if you want your own color scheme (and you probably will!) you can very easily override the theme defaults with your own project-specific values - Hugo will look in your project files first when looking for information to build your site. And because Docsy uses Bootstrap 4 and SCSS for styling, you can override just single values (such as project colors and fonts) in its special SCSS project variables file, or do more serious customization by creating your own styles.
 
-### Project style files
+Docsy also provides options for styling your code blocks, using either Chroma or Prism for highlighting.
 
-To customize your project's styles, override either or both of the following
+## Project style files
+
+To customize your project's look and feel, create your own version of either or both of the following
 Docsy placeholder files (note the **`_project.scss`** suffixes):
 
-- [`assets/scss/`**`_variables_project.scss`**][_variables_project]
-- [`assets/scss/`**`_styles_project.scss`**][_styles_project]
-
-Add project-specific variables definitions to your project's
-`_variables_project.scss` file, such as [site colors](#site-colors).
-
-You'll find Docsy-specific variables and Docsy-Bootstrap overrides in
-[<code>assets/scss/<strong>_variables.scss</strong></code>][_variables]. For
-information about Bootstrap 4 variables, see [Variable defaults][] and
-Bootstrap's [v4-dev/scss/_variables.scss][] file.
+- [`assets/scss/`**`_variables_project.scss`**][_variables_project] is where you add project-specific definitions of theme variables such as [site colors](#site-colors), as well as any additional Bootstrap variable values you want to set. You can find a list of Docsy's theme variables and their default values in [<code>assets/scss/<strong>_variables.scss</strong></code>][_variables].  For information about other Bootstrap 4 variables, see [Variable defaults][] and Bootstrap's [v4-dev/scss/_variables.scss][] file.
+- [`assets/scss/`**`_styles_project.scss`**][_styles_project] is where you can add your own custom SCSS styles, including overriding any of the styles in Docsy's theme SCSS files.
 
 [_styles_project]: https://github.com/google/docsy/blob/master/assets/scss/_styles_project.scss
 [_variables_project]: https://github.com/google/docsy/blob/master/assets/scss/_variables_project.scss
@@ -30,7 +23,11 @@ Bootstrap's [v4-dev/scss/_variables.scss][] file.
 [v4-dev/scss/_variables.scss]: https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
 [Variable defaults]: https://getbootstrap.com/docs/4.1/getting-started/theming/#variable-defaults
 
-### Site colors
+{{% alert title="Tip" %}}
+PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in server mode (it is a little slow), so Chrome is the recommended choice for development.
+{{% /alert %}}
+
+## Site colors
 
 To easily customize your site's colors, add SCSS variable overrides to
 `assets/scss/_variables_project.scss`. A simple example changing the primary and
@@ -48,10 +45,6 @@ $enable-gradients: true;
 $enable-rounded: true;
 $enable-shadows: true;
 ```
-
-{{% alert title="Tip" %}}
-PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in server mode (it is a little slow), so Chrome is the recommended choice for development.
-{{% /alert %}}
 
 ## Fonts
 

--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -6,14 +6,15 @@ description: Help your users interact with your source repository.
 
 The Docsy [docs and blog layouts](/docs/adding-content/content/#adding-docs-and-blog-posts) include links for readers to edit the page or create issues for your docs or project via your site's source repository. The current generated links for each docs or blog page are:
 
+* **View page source**: Brings the user to the page source in your docs repo. 
 * **Edit this page**: Brings the user to an editable version of the page content in their fork (if available) of your docs repo. If the user doesn't have a current fork of your docs repo, they are invited to create one before making their edit. The user can then create a pull request for your docs.
 * **Create child page**: Brings the user to a create new file form in their fork of your docs repo.  The new file will be located as a child of the page they clicked the link on.  The form will be pre-populated with a template the user can edit to create their page.  You can change this by adding `assets/stubs/new-page-template.md` to your own project.
 * **Create documentation issue**: Brings the user to a new issue form in your docs repo with the name of the current page as the issue's title.
 * **Create project issue** (optional): Brings the user to a new issue form in your project repo. This can be useful if you have separate project and docs repos and your users want to file issues against the project feature being discussed rather than your docs.
 
-This page shows you how to configure these links using your `config.toml` file.
+This page shows you how to configure these links.
 
-Currently Docsy supports only GitHub repository links "out of the box". If you are using another repository such as Bitbucket and would like generated repository links, feel free to [add a feature request or update our theme](/docs/contribution-guidelines/).
+Currently, Docsy supports only GitHub repository links "out of the box". If you are using another repository such as Bitbucket and would like generated repository links, feel free to [add a feature request or update our theme](/docs/contribution-guidelines/).
 
 ## Link configuration
 
@@ -138,9 +139,35 @@ github_url: https://github.com/some-username/another-repo/edit/main/README.md
 ---
 ```
 
-This can be useful if you have page source files in multiple Git repositories, or require a non-GitHub URL.  Pages using this value have **Edit this page** links only.
+This can be useful if you have page source files in multiple Git repositories,
+or require a non-GitHub URL. Pages using this value have **Edit this page**
+links only.
+
+## Disabling links
+
+You can use CSS to selectively disable (hide) links. For example, add the
+following to your [projects's `_styles_project.scss`][project-style-files] file
+to hide **Create child page** links from all pages:
+
+```scss
+.td-page-meta--child { display: none !important; }
+```
+
+Each link kind has an associated unique class named `.td-page-meta--KIND`, as
+defined by the following table:
+
+Link kind | Class name
+--- | ---
+View page source | `.td-page-meta--view`
+Edit this page | `.td-page-meta--edit`
+Create child page | `.td-page-meta--child`
+Create documentation issue | `.td-page-meta--issue`
+Create project issue | `.td-page-meta--project-issue`
+
+Of course, you can also use these classes to unique style links.
 
 [DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[multiple languages]: {{< relref "/docs/language/" >}}
+[multiple languages]: {{< relref "language" >}}
+[project-style-files]: {{< relref "lookandfeel#project-style-files" >}}
 [Yaml anchor]: https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/

--- a/userguide/content/en/docs/Adding content/repository-links.md
+++ b/userguide/content/en/docs/Adding content/repository-links.md
@@ -164,7 +164,8 @@ Create child page | `.td-page-meta--child`
 Create documentation issue | `.td-page-meta--issue`
 Create project issue | `.td-page-meta--project-issue`
 
-Of course, you can also use these classes to unique style links.
+Of course, you can also use these classes to give repository links unique styles
+for your project.
 
 [DRY]: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules


### PR DESCRIPTION
- Closes #731
- Document the features added by #675:
  - View page source
  - Disabling links
- Adds a section explaining project style customization a bit better (since "Disabling links" needs it)

Preview:

- https://deploy-preview-771--docsydocs.netlify.app/docs/adding-content/repository-links/#disabling-links
- https://deploy-preview-771--docsydocs.netlify.app/docs/adding-content/lookandfeel/#project-style-files

/cc @nate-double-u @celestehorgan @austinlparker 