### PR TITLE
Ensure search input text remains visible when unfocused

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -60,7 +60,7 @@
 
     .td-search-input {
         border: none;
-
+        color: $navbar-dark-color;
         @include placeholder {
             color: $navbar-dark-color;
         }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -7,6 +7,7 @@
     &.form-control:focus {
         border-color: lighten($primary, 60%);
         box-shadow: 0 0 0 2px lighten($primary, 30%);
+        color: inherit;
     }
 
     @if $enable-rounded {


### PR DESCRIPTION
- Closes #718
- Supersedes / closes #719
- Placeholder text color left unchanged, but unfocused text is color-appropriate for the background (top- or side-nav)

Preview: see, for example:

- https://deploy-preview-773--docsydocs.netlify.app/docs/

### Screenshot

Unfocused input text:

> <img width="800" alt="search input" src="https://user-images.githubusercontent.com/4140793/142296908-885e7a5d-50d5-4d5f-b950-ca7be46aa022.png">

Placeholder:

> ![image](https://user-images.githubusercontent.com/4140793/142296986-493c9197-6e5d-43f7-9568-76914bdab5d1.png)

/cc @nate-double-u @celestehorgan