### PR TITLE
Show breadcrumbs on mobile too

### DIFF
--- a/assets/scss/_breadcrumb.scss
+++ b/assets/scss/_breadcrumb.scss
@@ -1,7 +1,11 @@
 // Breadcrumb
 
-.breadcrumb {
-	background: none;
-	padding-left: 0;
-	padding-top: 0;
+.td-breadcrumbs {
+	@media print {display: none !important; }
+
+	.breadcrumb {
+		background: inherit;
+		padding-left: 0;
+		padding-top: 0;
+	}
 }

--- a/assets/scss/_breadcrumb.scss
+++ b/assets/scss/_breadcrumb.scss
@@ -1,11 +1,11 @@
 // Breadcrumb
 
 .td-breadcrumbs {
-	@media print {display: none !important; }
+  @media print {display: none !important; }
 
-	.breadcrumb {
-		background: inherit;
-		padding-left: 0;
-		padding-top: 0;
-	}
+  .breadcrumb {
+    background: inherit;
+    padding-left: 0;
+    padding-top: 0;
+  }
 }

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,4 +1,4 @@
-<nav aria-label="breadcrumb" class="d-none d-md-block d-print-none">
+<nav aria-label="breadcrumb" class="td-breadcrumbs">
 	<ol class="breadcrumb spb-1">
 		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
 	</ol>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,18 +1,20 @@
 <nav aria-label="breadcrumb" class="td-breadcrumbs">
-	<ol class="breadcrumb spb-1">
-		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
-	</ol>
-</nav	>
-{{ define "breadcrumbnav" }}
-{{ if .p1.Parent }}
-{{ if not .p1.Parent.IsHome }}
-{{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  }}
-{{ end }}
-{{ else if not .p1.IsHome }}
-{{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
-{{ end }}
-{{ $isActive :=  eq .p1 .p2  }}
-<li class="breadcrumb-item{{ if $isActive }} active{{ end }}" {{ if $isActive }}aria-current="page"{{ end }}>
-	<a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
-</li>
-{{ end }}
+  <ol class="breadcrumb spb-1">
+    {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
+  </ol>
+</nav>
+
+{{- define "breadcrumbnav" -}}
+  {{ if .p1.Parent -}}
+    {{ if not .p1.Parent.IsHome -}}
+      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  -}}
+    {{ end -}}
+  {{ else if not .p1.IsHome -}}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
+  {{ end -}}
+  {{ $isActive :=  eq .p1 .p2 }}
+  <li class="breadcrumb-item{{ if $isActive }} active{{ end }}"
+      {{- if $isActive }} aria-current="page"{{ end }}>
+    <a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
+  </li>
+{{- end -}}


### PR DESCRIPTION
- Closes #780
- Contributes to #783 -- note that the equivalent of the `d-print-none` was moved into the style definition so that clients can override this behavior if they so choose.
- Contributes to #782

Preview, for example visit the following links on mobile or in a browser with a narrow window:

- https://deploy-preview-784--docsydocs.netlify.app/docs
- https://deploy-preview-784--docsydocs.netlify.app/docs/adding-content/shortcodes

For a screenshot, see below.

No net change in the generated site files except for the `nav`'s change in class styles, whitespace being trimmed, and the new style definition:

```console
$ npm run build
...
$ (cd public && git diff -bw --ignore-blank-lines -I 'class="(td-breadcrumbs|d-none d-md-block d-print-none)"' -- . ':(exclude)*.xml' ':(exclude)*.map')
... see below for the syntax-highlighted diff ...
```
```diff
diff --git a/scss/main.css b/scss/main.css
index 5fcf278..b8f8160 100644
--- a/scss/main.css
+++ b/scss/main.css
@@ -13797,8 +13797,12 @@ nav.foldable-nav .with-child ul {
   .btn-sm, .btn-group-sm > .btn {
     border-radius: 1rem; }
 
-.breadcrumb {
-  background: none;
+@media print {
+  .td-breadcrumbs {
+    display: none !important; } }
+
+.td-breadcrumbs .breadcrumb {
+  background: inherit;
   padding-left: 0;
   padding-top: 0; }
```

#### Screenshot

> <img width="350" src="https://user-images.githubusercontent.com/4140793/143502873-2e1f08c9-dbe9-4215-a9f4-71c4dee74426.png">


