### PR TITLE
Support hiding single/root breadcrumbs

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,5 +1,6 @@
-<nav aria-label="breadcrumb" class="td-breadcrumbs">
-  <ol class="breadcrumb spb-1">
+<nav aria-label="breadcrumb" class="td-breadcrumbs
+    {{- if .Parent.IsHome }} td-breadcrumbs__single {{- end }}">
+  <ol class="breadcrumb">
     {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
   </ol>
 </nav>


### PR DESCRIPTION
- Closes #781
- Closes #782

To hide, use:

```scss
.td-breadcrumbs__single { display: none !important; }
```

Preview (w/o showing the hiding activated):

- https://deploy-preview-786--docsydocs.netlify.app/docs/adding-content/shortcodes