### PR TITLE
Breadcrumb fix for sites with docs at the root

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,5 +1,9 @@
+{{ $isSingle := true -}}
+{{ with .Parent -}}
+  {{ $isSingle = .IsHome -}}
+{{ end -}}
 <nav aria-label="breadcrumb" class="td-breadcrumbs
-    {{- if .Parent.IsHome }} td-breadcrumbs__single {{- end }}">
+    {{- if $isSingle }} td-breadcrumbs__single {{- end }}">
   <ol class="breadcrumb">
     {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
   </ol>


### PR DESCRIPTION
- Closes #804
- Tested this over https://graphviz.org/ and Lisa's JustDocs (both of which are mentioned in #804)
- Note that this solution assumes that docs section(s) are either at the site root or at most one level below the root.
- There are no changes to the generated User Guide site files.