### PR TITLE
Fix for #801: enable imports for sites that are using git submodules

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,19 +26,25 @@ mediaType = "text/html"
 path = "_print"
 permalinkable = false
 
+[module]
+[module.hugoVersion]
+extended = true
+min = "0.77.0"
+# enable imports for sites that are using git submodules 
+replacements = "github.com/FortAwesome/Font-Awesome -> ., github.com/twbs/bootstrap -> ."
 
 # Dependencies are brought in as modules
 # and mount points are declared
 [[module.imports]]
   path = "github.com/twbs/bootstrap"
-  disable = true
+  disable = false
 [[module.imports.mounts]]
   source = "scss"
   target = "assets/vendor/bootstrap/scss"
 
 [[module.imports]]
   path = "github.com/FortAwesome/Font-Awesome"
-  disable = true
+  disable = false
 [[module.imports.mounts]]
   source = "scss"
   target = "assets/vendor/Font-Awesome/scss"

--- a/userguide/content/en/docs/Getting started/_index.md
+++ b/userguide/content/en/docs/Getting started/_index.md
@@ -22,7 +22,7 @@ follow the instructions below to install Hugo and PostCSS.
 
 ### Install Hugo 
 
-You need a [recent **extended** version](https://github.com/gohugoio/hugo/releases) (we recommend version 0.75.0 or later) of [Hugo](https://gohugo.io/) to do local builds and previews of sites (like this one) that use Docsy. If you install from the release page, make sure to get the `extended` Hugo version, which supports [SCSS](https://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html); you may need to scroll down the list of releases to see it. 
+You need a [recent **extended** version](https://github.com/gohugoio/hugo/releases) (must be version 0.77.0 or later) of [Hugo](https://gohugo.io/) to do local builds and previews of sites (like this one) that use Docsy. If you install from the release page, make sure to get the `extended` Hugo version, which supports [SCSS](https://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html); you may need to scroll down the list of releases to see it. 
 
 For comprehensive Hugo documentation, see [gohugo.io](https://gohugo.io/).
 
@@ -35,12 +35,12 @@ If you've already installed Hugo, check your version:
 ```
 hugo version
 ```
-If the result is `v0.75` or earlier, or if you don't see `Extended`, you'll need to install the latest version. You can see a complete list of Linux installation options in [Install Hugo](https://gohugo.io/getting-started/installing/#linux). The following shows you how to install Hugo from the release page:
+If the result is `v0.77` or earlier, or if you don't see `Extended`, you'll need to install the latest version. You can see a complete list of Linux installation options in [Install Hugo](https://gohugo.io/getting-started/installing/#linux). The following shows you how to install Hugo from the release page:
     
 1.  Go to the [Hugo releases](https://github.com/gohugoio/hugo/releases) page.
 2.  In the most recent release, scroll down until you find a list of
     **Extended** versions.
-3.  Download the latest extended version (`hugo_extended_0.5X_Linux-64bit.tar.gz`).
+3.  Download the latest extended version (`hugo_extended_0.9X_Linux-64bit.tar.gz`).
 4.  Create a new directory:
 
         mkdir hugo


### PR DESCRIPTION
Unfortunately, #801 did not work as expected. This PR will fix these issues, sorry for any inconvenience caused!

**Note:**: Inside the `[module]` section, this fix makes use of the `replacements` configuration setting:

```
[module]
# imports should not apply for sites that are using git submodules 
replacements = "github.com/FortAwesome/Font-Awesome -> ., github.com/twbs/bootstrap -> ."
```

`Replacements` is available as of hugo version [0.77](https://gohugo.io/news/0.77.0-relnotes/).

Currently the user guide [states](https://www.docsy.dev/docs/getting-started/#install-hugo):

```
You need a recent extended version (we recommend version 0.75.0 or later) of Hugo
```

Therefore with this patch we are raising minimum required hugo version from 0.75 to 0.77 (mandatory now). I hope this is o.k.
This PR updates the user guide accordingly.