### PR TITLE
Simplify setup: install Hugo automatically (and get the right version) using NPM

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@
 
 [build]
 publish = "userguide/public"
-command = "npm install && npm run build:preview"
+command = "npm run build:preview"
 
 [build.environment]
 GO_VERSION = "1.17.6"
 HUGO_THEME = "repo"
 
 [context.production]
-command = "npm install && npm run build:production"
+command = "npm run build:production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,6 @@ publish = "userguide/public"
 command = "npm install && npm run build:preview"
 
 [build.environment]
-HUGO_VERSION = "0.92.0"
 GO_VERSION = "1.17.6"
 HUGO_THEME = "repo"
 

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "serve": "cd userguide && npm run serve",
     "submodule:get": "git submodule update --init --recursive --depth 1",
     "submodule:update": "git submodule update --remote --recursive --depth 1"
+  },
+  "devDependencies": {
+    "hugo-extended": "0.92.0"
   }
 }


### PR DESCRIPTION
This PR introduces the use of the [hugo-extended](https://www.npmjs.com/package/hugo-extended) package, a "Plug-and-play binary wrapper for Hugo Extended".

By doing so we **reduce the burden on contributors**: the _right_ version and variant (_extended_ edition), gets fetched automatically when `npm install` is run. Also, from now on, every version of the website will be associated to the version of Hugo needed to build it, and npm will fetch the proper version on an install.

@LisaFC @emckean et all - WDYT? If you agree with this change, I'll make followup PRs to update the README, etc.