### PR TITLE
Page-meta-links: address .Path warning

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,5 +1,5 @@
-{{ if .Path }}
-{{ $pathFormatted := replace .Path "\\" "/" -}}
+{{ if .File }}
+{{ $pathFormatted := replace .File.Path "\\" "/" -}}
 {{ $gh_repo := ($.Param "github_repo") -}}
 {{ $gh_url := ($.Param "github_url") -}}
 {{ $gh_subdir := ($.Param "github_subdir") -}}


### PR DESCRIPTION
- Closes #835
- There are no changes to the generated pages of the User Guide:
  ```console
  $ (cd public && git diff) 
  $
  ```

Preview, e.g.: https://deploy-preview-842--docsydocs.netlify.app/docs/

/cc @deining 