### PR TITLE
CI: reintroduce explicit call to npm install

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@
 
 [build]
 publish = "userguide/public"
-command = "npm run build:preview"
+command = "npm install && npm run build:preview"
 
 [build.environment]
 GO_VERSION = "1.17.6"
 HUGO_THEME = "repo"
 
 [context.production]
-command = "npm run build:production"
+command = "npm install && npm run build:production"


### PR DESCRIPTION
Reverting the change to `netlify.toml` as mentioned in https://github.com/google/docsy/pull/841#issuecomment-1015903812.