### PR TITLE
Effectively revert #801, removing docsy as a Hugo module

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,26 +25,3 @@ isHTML = true
 mediaType = "text/html"
 path = "_print"
 permalinkable = false
-
-[module]
-[module.hugoVersion]
-extended = true
-min = "0.77.0"
-# enable imports for sites that are using git submodules 
-replacements = "github.com/FortAwesome/Font-Awesome -> ., github.com/twbs/bootstrap -> ."
-
-# Dependencies are brought in as modules
-# and mount points are declared
-[[module.imports]]
-  path = "github.com/twbs/bootstrap"
-  disable = false
-[[module.imports.mounts]]
-  source = "scss"
-  target = "assets/vendor/bootstrap/scss"
-
-[[module.imports]]
-  path = "github.com/FortAwesome/Font-Awesome"
-  disable = false
-[[module.imports.mounts]]
-  source = "scss"
-  target = "assets/vendor/Font-Awesome/scss"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,0 @@
-module github.com/google/docsy
-
-go 1.17
-
-require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
-	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
-github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -64,7 +64,7 @@ anchor = "smart"
     weight = 50
     url = "https://github.com/google/docsy/"
     pre = "<i class='fab fa-github'></i>"
-    post = "<span class='alert'>New!</span>" 
+    post = "<span class='alert'>New!</span>"
 
 [services]
 [services.googleAnalytics]
@@ -101,13 +101,13 @@ privacy_policy = "https://policies.google.com/privacy"
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
 
-# Flag used in the "version-banner" partial to decide whether to display a 
+# Flag used in the "version-banner" partial to decide whether to display a
 # banner on every page indicating that this is an archived version of the docs.
 # Set this flag to "true" if you want to display the banner.
 archived_version = false
 
 # The version number for the version of the docs represented in this doc set.
-# Used in the "version-banner" partial to display a version number for the 
+# Used in the "version-banner" partial to display a version number for the
 # current doc set.
 version = "0.0"
 
@@ -167,7 +167,7 @@ yes = 'Glad to hear it! Please <a href="https://github.com/google/docsy/issues/n
 no = 'Sorry to hear that. Please <a href="https://github.com/google/docsy/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
-# If you want this feature, but occasionally need to remove the Reading time from a single page, 
+# If you want this feature, but occasionally need to remove the Reading time from a single page,
 # add "hide_readingtime: true" to the page's front matter
 [params.ui.readingtime]
 enable = false
@@ -242,14 +242,3 @@ enable = true
 [taxonomies]
 tag = "tags"
 category = "categories"
-
-[module]
-  # uncomment line below for temporary local development of module
-  # replacements = "github.com/google/docsy -> ../../docsy"
-  [module.hugoVersion]
-    extended = true
-    min = "0.75.0"
-  [[module.imports]]
-    path = "github.com/google/docsy"
-    # set disable to false to use theme as module 
-    disable = true

--- a/userguide/go.mod
+++ b/userguide/go.mod
@@ -1,8 +1,0 @@
-module github.com/google/docsy-userguide
-
-go 1.17
-
-require github.com/google/docsy v0.0.0-20211206150914-7dc708374618 // indirect
-
-// uncomment line below for temporary local development of module
-// replace github.com/google/docsy => ../../docsy

--- a/userguide/go.sum
+++ b/userguide/go.sum
@@ -1,2 +1,0 @@
-github.com/google/docsy v0.0.0-20211206150914-7dc708374618 h1:lOpL17zTK4KRHnqHL7h+wHZNzmp/EJQ96a4ctmbSCC0=
-github.com/google/docsy v0.0.0-20211206150914-7dc708374618/go.mod h1:alhAPKceHP14eqO+nJEhYehHeNcPKV8QnduoauTBZhs=


### PR DESCRIPTION
- @deining wrote in https://github.com/google/docsy/issues/858#issuecomment-1018760037:
  > Another idea came to my mind: what about reverting #801, ...
- This PR effectively reverts #801. (I've left the `GO_VERSION` in `netlify.toml`.)
- Closes #850
