### PR TITLE
Fix the build for docsy-as-submodule (#858)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,22 +29,4 @@ permalinkable = false
 [module]
 [module.hugoVersion]
 extended = true
-min = "0.77.0"
-# enable imports for sites that are using git submodules 
-replacements = "github.com/FortAwesome/Font-Awesome -> ., github.com/twbs/bootstrap -> ."
-
-# Dependencies are brought in as modules
-# and mount points are declared
-[[module.imports]]
-  path = "github.com/twbs/bootstrap"
-  disable = false
-[[module.imports.mounts]]
-  source = "scss"
-  target = "assets/vendor/bootstrap/scss"
-
-[[module.imports]]
-  path = "github.com/FortAwesome/Font-Awesome"
-  disable = false
-[[module.imports.mounts]]
-  source = "scss"
-  target = "assets/vendor/Font-Awesome/scss"
+min = "0.73.0"


### PR DESCRIPTION
I see our commits crossed. I think essentially, they were the same.
Prepared a patch for reverting the userguide to git submodules already, stay stuned, it will come in shortly.