### PR TITLE
Take `td-enable-google-fonts` into account for RTL fonts.

### DIFF
--- a/assets/scss/rtl/_main.scss
+++ b/assets/scss/rtl/_main.scss
@@ -36,11 +36,16 @@ body:lang(fa) {
 }
 
 body:lang(he) {
-    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap');
+    @if $td-enable-google-fonts {
+        @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap');
+    }
     font-family: 'Rubik', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 body:lang(ar) {
-    @import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;500;700&display=swap');
+    @if $td-enable-google-fonts {
+        @import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;500;700&display=swap');
+    }
     font-family: 'Tajawal', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
+


### PR DESCRIPTION
The documentation for the [look and feel](https://github.com/google/docsy/blob/master/userguide/content/en/docs/Adding%20content/lookandfeel.md) mention a way to use a system font instead of a Google font.

> The theme uses [Open Sans](https://fonts.google.com/specimen/Open+Sans) as its primary font. To disable Google Fonts and use a system font, set this SCSS variable in `assets/scss/_variables_project.scss`.

Currently some of the RTL fonts are always loaded from https://fonts.googleapis.com. It's more consistent, if the variable `td-enable-google-fonts` controls the behavior for all used Google fonts.

This PR enables to control the load for RTL fonts from Google or system fonts, similar to the behavior of the primary font "Open Sans".