### PR TITLE
Pass correct arguments (TOCSS error)

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -34,7 +34,7 @@
     @include link-variant("#{$parent}--#{$color-name} p > a", $link-color, $link-hover-color, false);
 
     @if $enable-gradients {
-        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value,true);
+        @include bg-gradient-variant("#{$parent}--1#{$color-name}#{$parent}--gradient", $color-value);
     }
 }
 


### PR DESCRIPTION
Fixes a TOCSS error with incorrect arguments:

```txt
> HUGO_ENV=development hugo server

Start building sites …
hugo v0.92.1+extended darwin/amd64 BuildDate=unknown
WARN 2022/02/02 14:39:09 .File.UniqueID on zero object. Wrap it in if or with: {{ with .File }}{{ .UniqueID }}{{ end }}
Error: Error building site: TOCSS: failed to transform "scss/main.scss" (text/x-scss): SCSS processing failed: file ".../themes/docsy/assets/scss/_boxes.scss", line 37, col 18: wrong number of arguments (3 for 2) for `bg-gradient-variant'
```