### PR TITLE
NPM script refactoring and README cmd adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@ being maintained.
 
 The following are basic prerequisites for using Docsy in your site:
 
-- Install a recent release of the Hugo "extended" version (we recommend version
-  0.53 or later). If you install from the [release
-  page](https://github.com/gohugoio/hugo/releases), make sure you download the
-  `_extended` version which supports SCSS.
+- Install a recent release of the Hugo "extended" version. If you install from
+  the [Hugo release page](https://github.com/gohugoio/hugo/releases), make sure
+  you download the `_extended` version which supports SCSS.
 
 - Install `PostCSS` so that the site build can create the final CSS assets. You
   can install it locally by running the following commands from the root
   directory of your project:
 
   ```console
-  $ sudo npm install -D --save autoprefixer
-  $ sudo npm install -D --save postcss-cli
+  $ npm install --save-dev autoprefixer
+  $ npm install --save-dev postcss-cli
   ```
 
 ## Example and usage
@@ -59,11 +58,9 @@ above:
 ```console
 $ git clone --recurse-submodules --depth 1 https://github.com/google/docsy.git
 $ cd docsy/userguide/
-$ hugo server --themesDir ../..
+$ npm install
+$ npm run serve
 ```
-
-Note: you need the `themesDir` flag when running Hugo because the site files are
-inside the theme repo.
 
 ## Contributing ![GitHub](https://img.shields.io/github/contributors/google/docsy)
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "scripts": {
-    "build:preview": "cd userguide && npm run build:preview",
-    "build:production": "cd userguide && npm run build:production",
-    "build": "cd userguide && npm run build",
-    "install": "cd userguide && npm install",
-    "serve": "cd userguide && npm run serve",
+    "_docs": "cd userguide && npm run",
+    "docs-install": "cd userguide && npm install",
+    "build:preview": "npm run _docs build:preview",
+    "build:production": "npm run _docs build:production",
+    "build": "npm run _docs build",
+    "serve": "npm run _docs serve",
     "submodule:get": "git submodule update --init --recursive --depth 1",
     "submodule:update": "git submodule update --remote --recursive --depth 1"
   },

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -1,9 +1,11 @@
 {
   "scripts": {
-    "_build": "hugo --cleanDestinationDir -e dev -DFE --themesDir ../..",
-    "_serve": "hugo serve -DFE --themesDir ../..",
-    "build:preview": "hugo --cleanDestinationDir -e dev -DFE --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\" --themesDir ../..",
-    "build:production": "hugo --cleanDestinationDir --minify --themesDir ../..",
+    "_build": "npm run _hugo-dev",
+    "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
+    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_serve": "npm run _hugo-dev -- serve",
+    "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
+    "build:production": "npm run _hugo -- --minify",
     "build": "npm run _build",
     "prebuild:preview": "npm run submodule:get",
     "prebuild:production": "npm run submodule:get",


### PR DESCRIPTION
Other than cleaning up (refactoring) the user-guide NPM scripts, this also decouples docsy's `npm install` from the user-guide install. This is a better approach for #889.

/cc @geriom @LisaFC @emckean 