### PR TITLE
Taxonomy bugfix

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,4 +1,4 @@
-<div class="td-content">DEFAULT/CONTENT
+<div class="td-content">
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -1,17 +1,8 @@
-<div class="td-content">
+<div class="td-content">DEFAULT/CONTENT
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="td-content">
+<div class="td-content">TAXONOMY
   <main class="taxonomy-taxonomy-page">
     <h1>{{ with .Data.Singular }}{{ . | humanize }}: {{ end }}<span>{{ .Title }}</span></h1>
     <div>
@@ -12,16 +12,7 @@
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
           <p>{{ .Description | markdownify }}</p>
           <header class="article-meta">
-            {{ $context := . }}
-            {{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-              {{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-                {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-              {{ end }}
-            {{ else }}
-              {{ range $taxo, $taxo_map := .Site.Taxonomies }}
-                {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-              {{ end }}
-            {{ end }}
+            {{ partial "taxonomy_terms_article_wrapper.html" . }}
             {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
               {{ partial "reading-time.html" . }}
             {{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="td-content">TAXONOMY
+<div class="td-content">
   <main class="taxonomy-taxonomy-page">
     <h1>{{ with .Data.Singular }}{{ . | humanize }}: {{ end }}<span>{{ .Title }}</span></h1>
     <div>

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -1,4 +1,4 @@
-<div class="td-content">BLOG/CONTENT
+<div class="td-content">
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<div class="td-byline mb-4">

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -1,4 +1,4 @@
-<div class="td-content">
+<div class="td-content">BLOG/CONTENT
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<div class="td-byline mb-4">
@@ -6,16 +6,7 @@
 		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,7 +5,7 @@
 {{$.Scratch.Set "blog-pages" .Pages }}
 {{ end }}
 
-<div class="row">BLOG/LIST
+<div class="row">
 	<div class="col-12">
 		{{- if .Pages -}}
 		{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006")}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,7 +5,7 @@
 {{$.Scratch.Set "blog-pages" .Pages }}
 {{ end }}
 
-<div class="row">
+<div class="row">BLOG/LIST
 	<div class="col-12">
 		{{- if .Pages -}}
 		{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006")}}
@@ -18,16 +18,7 @@
 						<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
 						<p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
 						<header class="article-meta">
-							{{ $context := . }}
-							{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-								{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-									{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-								{{ end }}
-							{{ else }}
-								{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-									{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-								{{ end }}
-							{{ end }}
+							{{ partial "taxonomy_terms_article_wrapper.html" . }}
 							{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 								{{ partial "reading-time.html" . }}
 							{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,18 +1,9 @@
 {{ define "main" }}
-<div class="td-content">
+<div class="td-content">DOCS/LIST
 	<h1>{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="td-content">DOCS/LIST
+<div class="td-content">
 	<h1>{{ .Title }}</h1>
   {{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">

--- a/layouts/partials/taxonomy_terms_article.html
+++ b/layouts/partials/taxonomy_terms_article.html
@@ -1,5 +1,5 @@
-{{ $context := .context  }}
-{{ $taxo := .taxo  }}
+{{ $context := .context }}
+{{ $taxo := .taxo }}
 {{ if (gt (len ($context.GetTerms $taxo)) 0)}}
 <div class="taxonomy taxonomy-terms-article taxo-{{ urlize $taxo }}">
   <h5 class="taxonomy-title">{{ humanize $taxo }}:</h5>

--- a/layouts/partials/taxonomy_terms_article_wrapper.html
+++ b/layouts/partials/taxonomy_terms_article_wrapper.html
@@ -1,0 +1,10 @@
+{{ $context := . }}
+{{ if isset .Site.Params.Taxonomy "taxonomypageheader" }}
+  {{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
+    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+  {{ end }}
+{{ else }}
+  {{ range $taxo, $taxo_map := .Site.Taxonomies }}
+    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/taxonomy_terms_article_wrapper.html
+++ b/layouts/partials/taxonomy_terms_article_wrapper.html
@@ -1,10 +1,10 @@
 {{ $context := . }}
 {{ if isset .Site.Params.Taxonomy "taxonomypageheader" }}
   {{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
   {{ end }}
 {{ else }}
   {{ range $taxo, $taxo_map := .Site.Taxonomies }}
-    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
+    {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/taxonomy_terms_cloud.html
+++ b/layouts/partials/taxonomy_terms_cloud.html
@@ -1,8 +1,8 @@
-{{ $context := .context  }}
-{{ $taxo := .taxo  }}
-{{ $title := .title  }}
-{{ if isset $context.Site.Taxonomies ( lower $taxo ) }}
-  {{ $taxonomy := index $context.Site.Taxonomies ( lower $taxo ) }}
+{{ $context := .context }}
+{{ $taxo := .taxo }}
+{{ $title := .title }}
+{{ if isset $context.Site.Taxonomies (lower $taxo) }}
+  {{ $taxonomy := index $context.Site.Taxonomies (lower $taxo) }}
   {{ if (gt (len $taxonomy) 0)}}
     <div class="taxonomy taxonomy-terms-cloud taxo-{{ urlize $taxo }}">
       {{ with $title }}

--- a/layouts/partials/taxonomy_terms_clouds.html
+++ b/layouts/partials/taxonomy_terms_clouds.html
@@ -2,14 +2,14 @@
 {{ if isset .Site.Params.Taxonomy "taxonomycloud" }}
 	{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyCloud }}
 		{{ if isset $.Site.Params.Taxonomy "taxonomycloudtitle" }}
-			{{ $.Scratch.Set "title" ( index $.Site.Params.Taxonomy.taxonomyCloudTitle $index ) }}
+			{{ $.Scratch.Set "title" (index $.Site.Params.Taxonomy.taxonomyCloudTitle $index) }}
 		{{ else }}
-			{{ $.Scratch.Set "title" ( humanize $taxo ) }}
+			{{ $.Scratch.Set "title" (humanize $taxo) }}
 		{{ end }}
-		{{ partial "taxonomy_terms_cloud.html" (dict "context" $context "taxo" $taxo "title" ( $.Scratch.Get "title") ) }}
+		{{ partial "taxonomy_terms_cloud.html" (dict "context" $context "taxo" $taxo "title" ($.Scratch.Get "title")) }}
 	{{ end }}
 {{ else }}
 	{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-		{{ partial "taxonomy_terms_cloud.html" (dict "context" $context "taxo" $taxo "title" ( humanize $taxo ) ) }}
+		{{ partial "taxonomy_terms_cloud.html" (dict "context" $context "taxo" $taxo "title" (humanize $taxo)) }}
 	{{ end }}
 {{ end }}

--- a/layouts/partials/taxonomy_terms_clouds.html
+++ b/layouts/partials/taxonomy_terms_clouds.html
@@ -1,5 +1,5 @@
 {{ $context := . }}
-{{ if .Site.Params.Taxonomy.taxonomyCloud }}
+{{ if isset .Site.Params.Taxonomy "taxonomycloud" }}
 	{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyCloud }}
 		{{ if isset $.Site.Params.Taxonomy "taxonomycloudtitle" }}
 			{{ $.Scratch.Set "title" ( index $.Site.Params.Taxonomy.taxonomyCloudTitle $index ) }}

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -1,18 +1,9 @@
 {{ define "main" }}
-<div class="td-content">
+<div class="td-content"> SWAGGER/LIST
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">
-		{{ $context := . }}
-		{{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
-			{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ else }}
-			{{ range $taxo, $taxo_map := .Site.Taxonomies }}
-				{{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo ) }}
-			{{ end }}
-		{{ end }}
+		{{ partial "taxonomy_terms_article_wrapper.html" . }}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
 			{{ partial "reading-time.html" . }}
 		{{ end }}

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="td-content"> SWAGGER/LIST
+<div class="td-content">
 	<h1>{{ .Title }}</h1>
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<header class="article-meta">

--- a/userguide/content/en/docs/Adding content/taxonomy.md
+++ b/userguide/content/en/docs/Adding content/taxonomy.md
@@ -97,6 +97,10 @@ This will gave you for each in the current page (resp. context) defined taxonomy
 </div>
 ```
 
+### taxonomy_terms_article_wrapper
+
+The partial `taxonomy_terms_article_wrapper` is a wrapper for the partial `taxonomy_terms_article` with the only parameter `context` (most of the time the current page or context `.`) and checks the taxonomy parameters of you projects `config.toml` to loop threw all listed taxonomies in the parameter `taxonomyPageHeader` resp. all defined taxonomies of your page, if `taxonomyPageHeader` isn't set.
+
 ### taxonomy_terms_cloud
 
 The partial `taxonomy_terms_cloud` shows all used terms of an given taxonomy (partial parameter `taxo`) for your site (partial parameter `context`, most of the time the current page or context `.`) and with the parameter `title` as headline.


### PR DESCRIPTION
As reported in #888 the option to remove the taxonomy clouds in the sidebar didn't work anymore.
This PR is a bugfix for issue #888 and fixes also the same problem with the option to remove the taxonomy infos on each article `<header>` holding the meta infos of the current article.

My old github username was @narrenfrei. I'm sorry, but I had to change it.