### PR TITLE
User guide config: use mounts rather than the old contentDir param

### DIFF
--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -1,13 +1,6 @@
 baseURL = "/"
 title = "Docsy Example"
 
-# Language settings
-contentDir = "content/en"
-defaultContentLanguage = "en"
-defaultContentLanguageInSubdir = false
-# Useful when translating.
-enableMissingTranslationPlaceholders = true
-
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
@@ -243,3 +236,8 @@ enable = true
 [taxonomies]
 tag = "tags"
 category = "categories"
+
+[module]
+[[module.mounts]]
+  source = 'content/en'
+  target = 'content'


### PR DESCRIPTION
- Closes #897
- There are no changes to the generated site files:
  ```console
  $ npm run build && gb
  ...
  $ (cd public && git diff)
  $
  ```

/cc @LisaFC @geriom @emckean 