### PR TITLE
Netlify: use docs-install before building the User Guide

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@
 
 [build]
 publish = "userguide/public"
-command = "npm install && npm run build:preview"
+command = "npm run docs-install && npm run build:preview"
 
 [build.environment]
 GO_VERSION = "1.17.7"
 HUGO_THEME = "repo"
 
 [context.production]
-command = "npm install && npm run build:production"
+command = "npm run docs-install && npm run build:production"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "repository": "github:google/docsy",
   "scripts": {
     "_docs": "cd userguide && npm run",
-    "docs-install": "cd userguide && npm install",
     "build:preview": "npm run _docs build:preview",
     "build:production": "npm run _docs build:production",
     "build": "npm run _docs build",
+    "docs-install": "cd userguide && npm install",
+    "predocs-install": "npm install",
     "serve": "npm run _docs serve",
     "submodule:get": "git submodule update --init --recursive --depth 1",
     "submodule:update": "git submodule update --remote --recursive --depth 1"


### PR DESCRIPTION
Follow up to #893 that decoupled the docsy and UG builds (was in preparation for #870).