### PR TITLE
Add support for Bootstrap and FontAwesome via NPM packages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,3 +30,21 @@ permalinkable = false
 [module.hugoVersion]
 extended = true
 min = "0.73.0"
+  [[module.mounts]]
+    source = 'assets'
+    target = 'assets'
+  [[module.mounts]]
+    source = 'node_modules/bootstrap'
+    target = 'assets/vendor/bootstrap'
+  [[module.mounts]]
+    source = 'node_modules/@fortawesome/fontawesome-free'
+    target = 'assets/vendor/Font-Awesome'
+  [[module.mounts]]
+    source = "i18n"
+    target = "i18n"
+  [[module.mounts]]
+    source = 'layouts'
+    target = 'layouts'
+  [[module.mounts]]
+    source = 'static'
+    target = 'static'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build:production": "npm run _docs build:production",
     "build": "npm run _docs build",
     "docs-install": "cd userguide && npm install",
-    "predocs-install": "npm install",
     "serve": "npm run _docs serve"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "build": "npm run _docs build",
     "docs-install": "cd userguide && npm install",
     "predocs-install": "npm install",
-    "serve": "npm run _docs serve",
-    "submodule:get": "git submodule update --init --recursive --depth 1",
-    "submodule:update": "git submodule update --remote --recursive --depth 1"
+    "serve": "npm run _docs serve"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.4",
+    "bootstrap": "^4.6.1"
   },
   "devDependencies": {
     "hugo-extended": "0.92.2"

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "_build": "npm run _hugo-dev",
-    "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
+    "_hugo": "rm -Rf ../assets/vendor && hugo --cleanDestinationDir --themesDir ../..",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_serve": "npm run _hugo-dev -- serve",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -7,6 +7,7 @@
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "npm run _build",
+    "prepare": "cd .. && npm install",
     "serve": "npm run _serve"
   },
   "devDependencies": {

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -7,14 +7,7 @@
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "npm run _build",
-    "prebuild:preview": "npm run submodule:get",
-    "prebuild:production": "npm run submodule:get",
-    "prebuild": "npm run submodule:get",
-    "preinstall": "npm run submodule:get",
-    "preserve": "npm run submodule:get",
-    "serve": "npm run _serve",
-    "submodule:get": "cd .. && npm run submodule:get",
-    "submodule:update": "cd .. && npm run submodule:update"
+    "serve": "npm run _serve"
   },
   "devDependencies": {
     "autoprefixer": "^9.5.0",


### PR DESCRIPTION
- This is a version of #889 that doesn't remove the git submodules, and hence isn't a breaking change. 
- Closes #870