### PR TITLE
Upgrade Hugo to 0.93.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "bootstrap": "^4.6.1"
   },
   "devDependencies": {
-    "hugo-extended": "0.92.2"
+    "hugo-extended": "0.93.2"
   }
 }


### PR DESCRIPTION
Changes to the generated user guide files are mainly due to the new version of Chroma, which impacts how HTML for code blocks is generated (as introduced by this PR, in particular, https://github.com/alecthomas/chroma/pull/571).