### PR TITLE
Reflect renaming of master branch (various places)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ npm run serve
 ## Contributing ![GitHub](https://img.shields.io/github/contributors/google/docsy)
 
 Please read
-[CONTRIBUTING.md](https://github.com/google/docsy/blob/master/CONTRIBUTING.md)
+[CONTRIBUTING.md](https://github.com/google/docsy/blob/main/CONTRIBUTING.md)
 for details on our code of conduct, and the process for submitting pull requests
 to us. See also the list of
 [contributors](https://github.com/google/docsy/graphs/contributors) who
@@ -74,5 +74,5 @@ participated in this project.
 ## License ![GitHub](https://img.shields.io/github/license/google/docsy)
 
 This project is licensed under the Apache License 2.0 - see the
-[LICENSE.md](https://github.com/google/docsy/blob/master/LICENSE) file for
+[LICENSE.md](https://github.com/google/docsy/blob/main/LICENSE) file for
 details

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -4,7 +4,7 @@
 {{ $gh_url := ($.Param "github_url") -}}
 {{ $gh_subdir := ($.Param "github_subdir") -}}
 {{ $gh_project_repo := ($.Param "github_project_repo") -}}
-{{ $gh_branch := (default "master" ($.Param "github_branch")) -}}
+{{ $gh_branch := (default "main" ($.Param "github_branch")) -}}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
 {{ if $gh_url -}}
   {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}

--- a/theme.toml
+++ b/theme.toml
@@ -1,6 +1,6 @@
 name = "Docsy"
 license = "Apache 2.0"
-licenselink = "https://github.com/google/docsy/blob/master/LICENSE"
+licenselink = "https://github.com/google/docsy/blob/main/LICENSE"
 description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]

--- a/userguide/content/en/docs/Adding content/Shortcodes/index.md
+++ b/userguide/content/en/docs/Adding content/Shortcodes/index.md
@@ -226,7 +226,7 @@ resources:
 
 ### swaggerui
 
-The `swaggerui` shortcode can be placed anywhere inside a page with the [`swagger` layout](https://github.com/google/docsy/tree/master/layouts/swagger); it renders [Swagger UI](https://swagger.io/tools/swagger-ui/) using any OpenAPI YAML or JSON file as source. This can be hosted anywhere you like, for example in your site's root [`/static` folder](/docs/adding-content/content/#adding-static-content).
+The `swaggerui` shortcode can be placed anywhere inside a page with the [`swagger` layout](https://github.com/google/docsy/tree/main/layouts/swagger); it renders [Swagger UI](https://swagger.io/tools/swagger-ui/) using any OpenAPI YAML or JSON file as source. This can be hosted anywhere you like, for example in your site's root [`/static` folder](/docs/adding-content/content/#adding-static-content).
 
 ```yaml
 ---

--- a/userguide/content/en/docs/Adding content/content.md
+++ b/userguide/content/en/docs/Adding content/content.md
@@ -18,13 +18,13 @@ You can find out more about Hugo directory structure in [Directory Structure Exp
 
 Hugo builds your site pages using the content files you provide plus any templates provided by your site's theme. These templates (or *"layouts"* in Hugo terminology) include things like your page's headers, footers, navigation, and links to stylesheets: essentially, everything except your page's specific content. The templates in turn can be made up of *partials*: little reusable snippets of HTML for page elements like headers, search boxes, and more.
 
-Because most technical documentation sites have different sections for different types of content, the Docsy theme comes with the [following templates](https://github.com/google/docsy/tree/master/layouts) for top-level site sections that you might need:
+Because most technical documentation sites have different sections for different types of content, the Docsy theme comes with the [following templates](https://github.com/google/docsy/tree/main/layouts) for top-level site sections that you might need:
 
-* [`docs`](https://github.com/google/docsy/tree/master/layouts/docs) is for pages in your site's Documentation section.
-* [`blog`](https://github.com/google/docsy/tree/master/layouts/blog) is for pages in your site's Blog.
-* [`community`](https://github.com/google/docsy/tree/master/layouts/community) is for your site's Community page.
+* [`docs`](https://github.com/google/docsy/tree/main/layouts/docs) is for pages in your site's Documentation section.
+* [`blog`](https://github.com/google/docsy/tree/main/layouts/blog) is for pages in your site's Blog.
+* [`community`](https://github.com/google/docsy/tree/main/layouts/community) is for your site's Community page.
 
-It also provides a [default "landing page" type of template](https://github.com/google/docsy/tree/master/layouts/_default) with the site header and footer, but no left nav, that you can use for any other section. In this site and our example site it's used for the site [home page](/) and the [About](/about/) page.
+It also provides a [default "landing page" type of template](https://github.com/google/docsy/tree/main/layouts/_default) with the site header and footer, but no left nav, that you can use for any other section. In this site and our example site it's used for the site [home page](/) and the [About](/about/) page.
 
 Each top-level **section** in your site corresponds to a **directory** in your site content root. Hugo automatically applies the appropriate **template** for that section, depending on which folder the content is in. For example, this page is in the `docs` subdirectory of the site's content root directory `content/en/`, so Hugo automatically applies the `docs` template. You can override this by explicitly specifying a template or content type for a particular page.
 
@@ -158,7 +158,7 @@ You can find out much more about managing resources with Hugo bundles in [Page B
 
 ## Adding docs and blog posts
 
-The template you'll probably use most often is the [`docs` template](https://github.com/google/docsy/blob/master/layouts/docs/baseof.html) (as used in this page) or the very similar [`blog` template](https://github.com/google/docsy/blob/master/layouts/blog/baseof.html). Both these templates include:
+The template you'll probably use most often is the [`docs` template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html) (as used in this page) or the very similar [`blog` template](https://github.com/google/docsy/blob/main/layouts/blog/baseof.html). Both these templates include:
 
 * a left nav
 * GitHub links (populated from your site config) for readers to edit the page or create issues
@@ -236,7 +236,7 @@ If you've copied the example site and you don't want a blog section, or want to 
 
 ## Working with top-level landing pages.
 
-Docsy's [default page template](https://github.com/google/docsy/blob/master/layouts/docs/baseof.html) has no left nav and is useful for creating a home page for your site or other "landing" type pages.
+Docsy's [default page template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html) has no left nav and is useful for creating a home page for your site or other "landing" type pages.
 
 ### Customizing the example site pages
 

--- a/userguide/content/en/docs/Adding content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/Adding content/diagrams-and-formulae/index.md
@@ -92,7 +92,7 @@ For a complete list of options and their detailed description, have a look at th
 
 ### Display of Chemical Equations and Physical Units
 
-[mhchem](https://www.ctan.org/pkg/mhchem) is a \\(\LaTeX\\) package for typesetting chemical molecular formulae and equations. Fortunately, \\(\KaTeX\\) provides the `mhchem` [extension](https://github.com/KaTeX/KaTeX/tree/master/contrib/mhchem) that makes the `mhchem` package accessible when authoring content for the web. Since this extension was integrated into the Docsy theme, you can write beautiful chemical equations easily once `mhchem` support is enabled inside your `config.toml`:
+[mhchem](https://www.ctan.org/pkg/mhchem) is a \\(\LaTeX\\) package for typesetting chemical molecular formulae and equations. Fortunately, \\(\KaTeX\\) provides the `mhchem` [extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes the `mhchem` package accessible when authoring content for the web. Since this extension was integrated into the Docsy theme, you can write beautiful chemical equations easily once `mhchem` support is enabled inside your `config.toml`:
 
 ```toml
 [params.katex]

--- a/userguide/content/en/docs/Adding content/iconsimages.md
+++ b/userguide/content/en/docs/Adding content/iconsimages.md
@@ -22,7 +22,7 @@ navbar_logo = true
 ```
 
 {{% alert title="Tip" %}}
-Your logo is included in the default Docsy navbar as an inline SVG with the following CSS styling (from [`_nav.scss`](https://github.com/google/docsy/blob/master/assets/scss/_nav.scss)):
+Your logo is included in the default Docsy navbar as an inline SVG with the following CSS styling (from [`_nav.scss`](https://github.com/google/docsy/blob/main/assets/scss/_nav.scss)):
 
 ```
 svg {

--- a/userguide/content/en/docs/Adding content/lookandfeel.md
+++ b/userguide/content/en/docs/Adding content/lookandfeel.md
@@ -17,9 +17,9 @@ Docsy placeholder files (note the **`_project.scss`** suffixes):
 - [`assets/scss/`**`_variables_project.scss`**][_variables_project] is where you add project-specific definitions of theme variables such as [site colors](#site-colors), as well as any additional Bootstrap variable values you want to set. You can find a list of Docsy's theme variables and their default values in [<code>assets/scss/<strong>_variables.scss</strong></code>][_variables].  For information about other Bootstrap 4 variables, see [Variable defaults][] and Bootstrap's [v4-dev/scss/_variables.scss][] file.
 - [`assets/scss/`**`_styles_project.scss`**][_styles_project] is where you can add your own custom SCSS styles, including overriding any of the styles in Docsy's theme SCSS files.
 
-[_styles_project]: https://github.com/google/docsy/blob/master/assets/scss/_styles_project.scss
-[_variables_project]: https://github.com/google/docsy/blob/master/assets/scss/_variables_project.scss
-[_variables]: https://github.com/google/docsy/blob/master/assets/scss/_variables.scss
+[_styles_project]: https://github.com/google/docsy/blob/main/assets/scss/_styles_project.scss
+[_variables_project]: https://github.com/google/docsy/blob/main/assets/scss/_variables_project.scss
+[_variables]: https://github.com/google/docsy/blob/main/assets/scss/_variables.scss
 [v4-dev/scss/_variables.scss]: https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss
 [Variable defaults]: https://getbootstrap.com/docs/4.1/getting-started/theming/#variable-defaults
 
@@ -184,7 +184,7 @@ If you need to add some code (CSS import, cookie consent, or similar) to the `he
 layouts/partials/hooks/head-end.html
 ```
 
-And add the code you need in that file. Your partial code is automatically included just before the end of the theme partial [`head.html`](https://github.com/google/docsy/blob/master/layouts/partials/head.html). The theme version of [`head-end.html`](https://github.com/google/docsy/blob/master/layouts/partials/hooks/head-end.html) is empty.
+And add the code you need in that file. Your partial code is automatically included just before the end of the theme partial [`head.html`](https://github.com/google/docsy/blob/main/layouts/partials/head.html). The theme version of [`head-end.html`](https://github.com/google/docsy/blob/main/layouts/partials/hooks/head-end.html) is empty.
 
 
 Similarly, if you want to add some code right before the `body` end, create your own version of the following file:
@@ -193,9 +193,9 @@ Similarly, if you want to add some code right before the `body` end, create your
 layouts/partials/hooks/body-end.html
 ```
 
-Any code in this file is included automatically at the end of the theme partial [`scripts.html`](https://github.com/google/docsy/blob/master/layouts/partials/head.html).
+Any code in this file is included automatically at the end of the theme partial [`scripts.html`](https://github.com/google/docsy/blob/main/layouts/partials/head.html).
 
-Both `head.html` and `scripts.html` are then used to build Docsy's [base page layout](https://github.com/google/docsy/blob/master/layouts/_default/baseof.html), which is used by all the other page templates:
+Both `head.html` and `scripts.html` are then used to build Docsy's [base page layout](https://github.com/google/docsy/blob/main/layouts/_default/baseof.html), which is used by all the other page templates:
 
 ```html
 <!doctype html>

--- a/userguide/content/en/docs/Best practices/organizing-content.md
+++ b/userguide/content/en/docs/Best practices/organizing-content.md
@@ -29,7 +29,7 @@ You may also want to create some tasks/how-tos for your project's features. Feel
 site or even just the docs section instead if you like this simpler structure better. 
 
 {{% alert title="Tip" %}}
-If you want to copy this guide, be aware that its [source files](https://github.com/google/docsy/tree/master/userguide) are *inside* the Docsy theme repo, and so it doesn't have its own `themes/` directory: instead, we run `hugo server --themesDir ../..` to use Docsy from its parent directory. You may want to either copy the site and [add a `themes/` directory with Docsy](/docs/getting-started/#option-2-use-the-docsy-theme-in-your-own-site), or just copy the `docs/` folder into your existing site's content root.
+If you want to copy this guide, be aware that its [source files](https://github.com/google/docsy/tree/main/userguide) are *inside* the Docsy theme repo, and so it doesn't have its own `themes/` directory: instead, we run `hugo server --themesDir ../..` to use Docsy from its parent directory. You may want to either copy the site and [add a `themes/` directory with Docsy](/docs/getting-started/#option-2-use-the-docsy-theme-in-your-own-site), or just copy the `docs/` folder into your existing site's content root.
 {{% /alert %}}
 
 [Learn more about how Hugo and Docsy use folders and other files to organize your site](/docs/adding-content/content/#organizing-your-documentation).

--- a/userguide/content/en/docs/Deployment/_index.md
+++ b/userguide/content/en/docs/Deployment/_index.md
@@ -66,14 +66,14 @@ For example, if you want to use a version of `postcss-cli` later than version 8.
 
 ```
   "devDependencies": {
-    "autoprefixer": "^9.8.6",
+    "autoprefixer": "^9.8.8",
     "postcss-cli": "^8.0.0",
     "postcss": "^8.0.0"
   }
 ```
 {{% /alert %}}
 
-Alternatively, you can follow the same instructions but specify your **Deploy settings** in a [`netlify.toml` file](https://docs.netlify.com/configure-builds/file-based-configuration/) in your repo rather than in the **Deploy settings** page. You can see an example of this in the [Docsy theme repo](https://github.com/google/docsy/blob/master/netlify.toml) (though note that the build command here is a little unusual because the Docsy user guide is *inside* the theme repo).
+Alternatively, you can follow the same instructions but specify your **Deploy settings** in a [`netlify.toml` file](https://docs.netlify.com/configure-builds/file-based-configuration/) in your repo rather than in the **Deploy settings** page. You can see an example of this in the [Docsy theme repo](https://github.com/google/docsy/blob/main/netlify.toml) (though note that the build command here is a little unusual because the Docsy user guide is *inside* the theme repo).
 
 If you have an existing deployment you can view and update the relevant information by selecting the site from your list of sites in Netlify, then clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Xenial 16.04** is selected in the **Build image selection** section - if you're creating a new deployment this is used by default. You need to use this image to run the extended version of Hugo.
 

--- a/userguide/content/en/docs/Examples/_index.md
+++ b/userguide/content/en/docs/Examples/_index.md
@@ -16,8 +16,8 @@ Example sites that have low to no customization:
 | [This Docsy documentation site](/docs) | https://github.com/google/docsy |
 | ["Goldydocs" - a Docsy example site](https://example.docsy.dev) | https://github.com/google/docsy-example  |
 | https://www.kubeflow.org/  | https://github.com/kubeflow/website  |
-| https://agones.dev/site/ | https://github.com/googleforgames/agones/tree/master/site |
-| https://googlecontainertools.github.io/kpt/ | https://github.com/GoogleContainerTools/kpt/tree/master/docs | 
+| https://agones.dev/site/ | https://github.com/googleforgames/agones/tree/main/site |
+| https://googlecontainertools.github.io/kpt/ | https://github.com/GoogleContainerTools/kpt/tree/main/docs |
 | [Navidrome Music Server](https://www.navidrome.org) | https://github.com/navidrome/website | 
 | https://docs.agilebase.co.uk/ | https://github.com/okohll/abdocs | 
 | https://jvmperf.net/ | https://github.com/cchesser/java-perf-workshop | 

--- a/userguide/content/en/docs/Updating/_index.md
+++ b/userguide/content/en/docs/Updating/_index.md
@@ -15,7 +15,7 @@ all the new commits or changes that have been merged since the point in time tha
 submodule, or last updated. Updating won't affect any modifications that you made in your own project to 
 [override the Docsy look and feel](/docs/adding-content/lookandfeel/), as your overrides 
 don't modify the theme itself. For details about what has changed in the theme, see the list of 
-[Docsy commits](https://github.com/google/docsy/commits/master).
+[Docsy commits](https://github.com/google/docsy/commits/main).
 
 Depending on how you chose to use Docsy, follow the corresponding steps to update the theme:
 
@@ -36,7 +36,7 @@ If you are using the Docsy theme as a submodule in your project (for example, if
 
 1. Push the commit to your project repo. For example, run:
 
-        git push origin master
+        git push origin main
 
     
 ## Update your Docsy clone
@@ -54,7 +54,6 @@ the `themes` folder in your project, then you use the `git pull` command:
 
 1. Update your local clone:
 
-        git pull origin master
+        git pull origin main
 
 If you have made any local changes to the cloned theme, you must manually resolve any merge conflicts.
-


### PR DESCRIPTION
Renaming default branch from `master` to `main` (#913) result in various quirks. This PR corrects these deficiencies, e.g.:

- `Edit page` links in right sidebar
- Various other links
- ...