### PR TITLE
adding Powered by Netlify link in footer and config options

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,10 +15,19 @@
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
+        {{ with .Site.Params.netlify_oss.badge_color }}<a href="https://www.netlify.com">
+          <img src="{{ . }}" alt="Deploys by Netlify" />
+        </a> {{end}}
       </div>
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
-        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{end}}
+        {{ if .Site.Params.netlify_oss.link_only }}
+        <br><small class="ml-1"><a href="https://www.netlify.com">
+          This site is powered by Netlify
+        </a></small>{{ end }}
+        
+
 	{{ if not .Site.Params.ui.footer_about_disable }}
 		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
 	{{ end }}

--- a/userguide/config.toml
+++ b/userguide/config.toml
@@ -90,6 +90,7 @@ weight = 1
 copyright = "The Docsy Authors"
 privacy_policy = "https://policies.google.com/privacy"
 
+
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.
 version_menu = "Releases"
@@ -207,6 +208,13 @@ enable = false
 [params.mermaid]
 enable = true
 theme = "default"
+
+# this will add the "This site is powered by Netlify" link in the footer required for the Netlify OSS program (only use one of these two parameters)
+[params.netlify_oss]
+## use link_only for a plain-text link, centered
+ link_only = true
+## use badge_color to select a badge from https://www.netlify.com/press/#badges, on lower right
+# badge_color = "https://www.netlify.com/img/global/badges/netlify-color-bg.svg"
 
 [params.plantuml]
 enable = true


### PR DESCRIPTION
adding Powered by Netlify link to Docsy/userguide so we can participate in the Netlify OSS program
Also added config.toml options to use a Netlify badge instead