### PR TITLE
Add Deploys-by-Netlify badge to UG homepage

### DIFF
--- a/userguide/content/en/_index.html
+++ b/userguide/content/en/_index.html
@@ -16,7 +16,14 @@ title: Docsy
 {{< /blocks/cover >}}
 
 {{% blocks/lead color="primary" %}}
-Docsy is a theme for the Hugo static site generator that's specifically designed for technical documentation sets. Our aim is to help you get a working documentation site up and running as easily as possible, so you can concentrate on creating great content for your users.
+Docsy is a theme for the Hugo static site generator that's specifically designed
+for technical documentation sets. Our aim is to help you get a working
+documentation site up and running as easily as possible, so you can concentrate
+on creating great content for your users.
+
+<a href="https://www.netlify.com" target="_blank" rel="noopener">
+	<img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
+</a>
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" type="features">}}

--- a/userguide/content/en/_index.html
+++ b/userguide/content/en/_index.html
@@ -22,7 +22,7 @@ documentation site up and running as easily as possible, so you can concentrate
 on creating great content for your users.
 
 <a href="https://www.netlify.com" target="_blank" rel="noopener">
-	<img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
+  <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
 </a>
 {{% /blocks/lead %}}
 


### PR DESCRIPTION
- Closes #931
- Proposed alternative to #925, and hence possibly closes #925
- Preview: https://deploy-preview-932--docsydocs.netlify.app/

### Screenshot

> <img width="767" alt="image" src="https://user-images.githubusercontent.com/4140793/158198868-54f55ce4-1b7f-4d1e-a894-5358ad16cdfb.png">

