### PR TITLE
CI: don't clean assets/vendor for local builds

### DIFF
--- a/userguide/package.json
+++ b/userguide/package.json
@@ -1,14 +1,17 @@
 {
   "scripts": {
     "_build": "npm run _hugo-dev",
-    "_hugo": "rm -Rf ../assets/vendor && hugo --cleanDestinationDir --themesDir ../..",
+    "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_serve": "npm run _hugo-dev -- serve",
-    "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
-    "build:production": "npm run _hugo -- --minify",
+    "build:preview": "DOCSY_VENDOR=clean npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
+    "build:production": "DOCSY_VENDOR=clean npm run _hugo -- --minify",
     "build": "npm run _build",
     "clean": "rm -Rf public",
+    "clean:vendor": "rm -Rf ../assets/vendor",
+    "keep:vendor": "echo Keeping ../assets/vendor",
     "make:public": "git init -b main public",
+    "pre_hugo": "set -x && npm run ${DOCSY_VENDOR:-keep}:vendor",
     "prepare": "cd .. && npm install",
     "serve": "npm run _serve"
   },


### PR DESCRIPTION
This change will make it easer for contributors running local build commands since it avoids removing the submodules. (We're still removing the submodules for preview and production builds to ensure that the build isn't using the submodules.)

Advanced dev notes:

- You can also drop the submodules on local builds by running: `DOCSY_VENDOR=clean npm run build`
- To recover the submodules, run `npm run get:submodule` (at the repo root).