### PR TITLE
A better alert shortcode more markdown friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,15 @@ For the full list of changes, see the [0.x.y] release notes.
 
 **Breaking changes**:
 
+- **Shortcodes**:
+  - The alert shortcode has been reworked to address [#906] and [#939]. It can
+    now be used with Markdown content, and it can contain calls to other
+    shortcodes. For details, see [Shortcode helpers > alert][] ([#941])
 - ...
+
+[#941]: https://github.com/google/docsy/pull/941
+[Shortcode helpers > alert]:
+  https://www.docsy.dev/docs/adding-content/shortcodes/#alert
 
 **New**:
 

--- a/assets/scss/_alerts.scss
+++ b/assets/scss/_alerts.scss
@@ -5,12 +5,15 @@
   color: inherit;
   border-radius: 0;
 
+  :last-child {
+    margin-bottom: 0;
+  }
+
   @each $color, $value in $theme-colors {
     &-#{$color} {
       & .alert-heading {
         color: $value;
       }
-
       border-style: solid;
       border-color: $value;
       border-width: 0 0 0 4px;

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -1,6 +1,6 @@
 {{/*
 
-@param {string} [title=""] Text rendered as a Bootstrap alert heading.
+@param {string} [title=""] HTML rendered as a Bootstrap alert heading.
 @param {string} [color="primary"] Suffix used for the Bootstrap alert class
                 `alert-{color}`.
 

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -1,10 +1,46 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-{{ $color := .Get "color" | default "primary" }}
-<div class="alert alert-{{ $color }}" role="alert">
-{{ with .Get "title" }}<h4 class="alert-heading">{{ . | safeHTML }}</h4>{{ end }}
-{{ if eq .Page.File.Ext "md" }}
-    {{ .Inner | markdownify }}
-{{ else }}
-    {{ .Inner | htmlUnescape | safeHTML }}
+{{/*
+
+@param {string} [title=""] Text rendered as a Bootstrap alert heading.
+@param {string} [color="primary"] Suffix used for the Bootstrap alert class
+                `alert-{color}`.
+
+Example usage:
+
+```Hugo
+{{% alert title="Note" color="info" %}}
+This is a note.
+{{% /alert %}}
+```
+
+For details, see https://www.docsy.dev/docs/adding-content/shortcodes/#alert.
+
+Dev note: `$leadingSpaces` is prepended to each non-`.Inner` line of this
+shortcode to match the indentation of `.Inner`. This ensures that the full
+generated alert content is indented to match the calling content of the
+shortcode.
+
+*/ -}}
+
+{{ $inner := .Inner -}}
+{{ $leadingSpaces := "" -}}
+{{ with findRE `^\s*` $inner }}
+  {{ $leadingSpaces = index . 0 }}
 {{ end }}
+{{ $color := .Get "color" | default "primary" -}}
+
+{{ $leadingSpaces -}}
+<div class="alert alert-{{ $color }}" role="alert">
+{{ $leadingSpaces -}}
+  {{ with .Get "title" -}}
+    <div class="h4 alert-heading">
+      {{- . | safeHTML -}}
+    </div>
+  {{- end }}
+
+{{/* Do **not** remove the blank line above. It ends the previous HTML block and
+ensures that $inner's Markdown will be treated as Markdown. For details, see
+https://spec.commonmark.org/0.30/#html-blocks, 7. */ -}}
+
+{{ $inner }}
+{{ $leadingSpaces -}}
 </div>

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -21,5 +21,10 @@ For details, see https://www.docsy.dev/docs/adding-content/shortcodes/#alert.
 ensures that any Markdown in .Inner will be treated as Markdown. For details,
 see https://spec.commonmark.org/0.31.2/#html-blocks, 7. */ -}}
 
-{{ .Inner -}}
+{{ .Inner }}
+
+{{- /* Do NOT remove this space trimming comment. It ensures that any Markdown
+that _follows_ this shortcode remains correctly indented, in contexts where this
+is necessary. */ -}}
+
 </div>

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -4,43 +4,22 @@
 @param {string} [color="primary"] Suffix used for the Bootstrap alert class
                 `alert-{color}`.
 
-Example usage:
-
-```Hugo
-{{% alert title="Note" color="info" %}}
-This is a note.
-{{% /alert %}}
-```
-
 For details, see https://www.docsy.dev/docs/adding-content/shortcodes/#alert.
-
-Dev note: `$leadingSpaces` is prepended to each non-`.Inner` line of this
-shortcode to match the indentation of `.Inner`. This ensures that the full
-generated alert content is indented to match the calling content of the
-shortcode.
 
 */ -}}
 
-{{ $inner := .Inner -}}
-{{ $leadingSpaces := "" -}}
-{{ with findRE `^\s*` $inner }}
-  {{ $leadingSpaces = index . 0 }}
-{{ end }}
 {{ $color := .Get "color" | default "primary" -}}
 
-{{ $leadingSpaces -}}
 <div class="alert alert-{{ $color }}" role="alert">
-{{ $leadingSpaces -}}
-  {{ with .Get "title" -}}
-    <div class="h4 alert-heading">
-      {{- . | safeHTML -}}
-    </div>
-  {{- end }}
+{{- with .Get "title" -}}
+  <div class="h4 alert-heading" role="heading">
+    {{- . | safeHTML -}}
+  </div>
+{{- end }}
 
-{{/* Do **not** remove the blank line above. It ends the previous HTML block and
-ensures that $inner's Markdown will be treated as Markdown. For details, see
-https://spec.commonmark.org/0.30/#html-blocks, 7. */ -}}
+{{/* Do NOT remove the blank line above. It ends the previous HTML block and
+ensures that any Markdown in .Inner will be treated as Markdown. For details,
+see https://spec.commonmark.org/0.31.2/#html-blocks, 7. */ -}}
 
-{{ $inner }}
-{{ $leadingSpaces -}}
+{{ .Inner -}}
 </div>

--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -1,8 +1,8 @@
 ---
 title: Adding Content
 weight: 1
-description: >
-  Add different types of content to your Docsy site.
+description: Add different types of content to your Docsy site.
+cSpell:ignore: goldmark Riona MacNamara
 ---
 
 So you've got a new Hugo website with Docsy, now it's time to add some content!
@@ -311,9 +311,7 @@ By default you create pages in a Docsy site as simple
 [Goldmark](https://github.com/yuin/goldmark/) is the only Markdown parser
 supported by Hugo.
 
-<div class="alert alert-primary" role="alert">
-
-<h4 class="alert-heading">Tip</h4>
+{{% alert title="Tip" %}}
 
 If you've been using versions of Hugo before 0.60 that use
 [`BlackFriday`](https://github.com/russross/blackfriday) as its Markdown parser,
@@ -351,7 +349,7 @@ markup:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-</div>
+{{% /alert %}}
 
 In addition to your marked-up text, you can also use Hugo and Docsy's
 [shortcodes](/docs/adding-content/shortcodes): reusable chunks of HTML that you
@@ -852,9 +850,7 @@ disableKinds: [RSS]
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-<div class="alert alert-info" role="alert">
-
-<h4 class="alert-heading">Note</h4>
+{{% alert title=Note color=info %}}
 
 If you have enabled our [print feature](/docs/adding-content/print/) or
 otherwise specified section-level output formats in
@@ -892,7 +888,8 @@ outputs:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
-</div>
+
+{{% /alert %}}
 
 ## Sitemap
 

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -35,7 +35,7 @@ configuration file. For details, see [Configure Google Analytics][].
 
 {{% alert title="Deprecation note and warning" color="warning" %}}
 
-  <!-- Remove this warning once the Hugo docs have been updated to include it. -->
+<!-- Remove this warning once the Hugo docs have been updated to include it. -->
 
 While you can configure your project's analytics ID by setting either the
 top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -215,6 +215,16 @@ accordingly. For example:
 
 This renders as:
 
+{{< comment >}}
+
+<!--
+IMPORTANT: the following lone opening div tag prevents the mis-formatted alert example below from breaking all the rest of the page. DO NOT remove it.
+-->
+
+{{< /comment >}}
+
+<div class="td-max-width-on-larger-screens">
+
 <!-- prettier-ignore -->
 - The following note is part of this list item:
   {{% alert title="Celebrate!" color=success %}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -10,7 +10,7 @@ resources:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
 params:
   message: Some _message_.
-cSpell:ignore: pageinfo Bjørn Pedersen
+cSpell:ignore: imgproc pageinfo Bjørn Pedersen
 ---
 
 Rather than writing all your site pages from scratch, Hugo lets you define and
@@ -178,7 +178,7 @@ Use the **alert** shortcode to display notices and warnings. The shortcode
 renders a [Bootstrap alert component][bs-alert]. It can be used with Markdown
 content and contain other shortcodes. For example:
 
-```go-html-template
+```go-template
 {{%/* alert title="Welcome" */%}} **Hello**, world! {{%/* /alert */%}}
 ```
 
@@ -202,7 +202,7 @@ When the `alert` shortcode is used in a Markdown context that requires
 indentation, such as a list, then the alert _content_ (whether specified as
 text/Markdown or a shortcode) must be indented accordingly. For example:
 
-```go-html-template
+```go-template
 - The following note is part of this list item:
   {{%/* alert title="Celebrate!" color=success */%}}
   This alert content is properly rendered.
@@ -250,7 +250,7 @@ information for a page: for example, letting users know that the page contains
 placeholder content, that the content is deprecated, or that it documents a beta
 feature.
 
-```go-html-template
+```go-template
 {{%/* pageinfo color="info" */%}}
 This is placeholder content.
 {{%/* /pageinfo */%}}
@@ -274,7 +274,7 @@ The **imgproc** shortcode finds an image in the current
 [Page Bundle](/docs/adding-content/content/#page-bundles) and scales it given a
 set of processing instructions.
 
-```go-html-template
+```go-template
 {{%/* imgproc spruce Fill "400x450" */%}}
 Norway Spruce *Picea abies* shoot with foliage buds.
 {{%/* /imgproc */%}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -175,8 +175,8 @@ section. It's meant to be used in combination with the other blocks shortcodes.
 ### alert
 
 Use the **alert** shortcode to display notices and warnings. The shortcode
-renders a [Bootstrap alert][bs-alert]. It can be used with Markdown content and
-contain other shortcodes. For example:
+renders a [Bootstrap alert component][bs-alert]. It can be used with Markdown
+content and contain other shortcodes. For example:
 
 ```go-html-template
 {{%/* alert title="Welcome" */%}} **Hello**, world! {{%/* /alert */%}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -3,12 +3,12 @@ title: Docsy Shortcodes
 linkTitle: Shortcodes
 date: 2017-01-05
 weight: 5
-description: >
-  Use Docsy's Hugo shortcodes to quickly build site pages.
+description: Use Docsy's Hugo shortcodes to quickly build site pages.
 resources:
   - src: '**spruce*.jpg'
     params:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
+cSpell:ignore: pageinfo Bjørn Pedersen
 ---
 
 Rather than writing all your site pages from scratch, Hugo lets you define and
@@ -172,22 +172,54 @@ section. It's meant to be used in combination with the other blocks shortcodes.
 
 ### alert
 
-The **alert** shortcode creates an alert block that can be used to display
-notices or warnings.
+Use the **alert** shortcode to display notices or warnings. The shortcode
+renders a [Bootstrap alert][]. It can be used with Markdown content and contain
+other shortcodes. For example:
 
 ```go-html-template
 {{%/* alert title="Warning" color="warning" */%}}
-This is a warning.
+This is a **warning**.
 {{%/* /alert */%}}
 ```
 
-Renders to:
+Renders as:
 
-{{% alert title="Warning" color="warning" %}} This is a warning. {{% /alert %}}
+{{% alert title="Warning" color="warning" %}} This is a **warning**.
+{{% /alert %}}
 
-| Parameter | Default | Description                                                   |
-| --------- | ------- | ------------------------------------------------------------- |
-| color     | primary | One of the theme colors, eg `primary`, `info`, `warning` etc. |
+Parameters:
+
+- `title` (optional) Renders as a Bootstrap alert heading, at heading level 4,
+  using the `h4` Bootstrap class over a `<div>` element. This prevents the title
+  from appearing in a page's table of contents.
+- `color` (optional) names one of the [Bootstrap alert][] variants: `primary`,
+  `info`, `warning`, etc.
+
+**Important!** When the `alert` shortcode is used in Markdown context that
+requires indentation, such as a list, then the alert _content_ must be indented
+accordingly. For example:
+
+```go-html-template
+- Item 1
+  {{%/* alert title="Note" color=info */%}}
+  This is properly indented alert content.
+  {{%/* /alert */%}}
+- Don't do this, it won't render correctly:
+  {{%/* alert title="Warning" color=warning */%}} This content is not indented properly. {{%/* /alert */%}}
+```
+
+renders as:
+
+<!-- prettier-ignore -->
+- Item 1
+  {{% alert title="Note" color=info %}}
+  This is properly indented alert content.
+  {{% /alert %}}
+- Don't do this, it won't render correctly:
+  {{% alert title="Warning" color=warning %}} This content appears outside of
+  the list! {{% /alert %}}
+
+[Bootstrap alert]: https://getbootstrap.com/docs/5.3/components/alerts/
 
 ### pageinfo
 

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -8,6 +8,9 @@ resources:
   - src: '**spruce*.jpg'
     params:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
+params:
+  greeting: '**Hello**, world!'
+  message: Some _message_.
 cSpell:ignore: pageinfo Bjørn Pedersen
 ---
 
@@ -172,20 +175,17 @@ section. It's meant to be used in combination with the other blocks shortcodes.
 
 ### alert
 
-Use the **alert** shortcode to display notices or warnings. The shortcode
+Use the **alert** shortcode to display notices and warnings. The shortcode
 renders a [Bootstrap alert][]. It can be used with Markdown content and contain
 other shortcodes. For example:
 
 ```go-html-template
-{{%/* alert title="Warning" color="warning" */%}}
-This is a **warning**.
-{{%/* /alert */%}}
+{{%/* alert title="Welcome" */%}} {{%/* param greeting */%}} {{%/* /alert */%}}
 ```
 
-Renders as:
+With the `greeting` param defined as `{{% param greeting %}}`, this renders as:
 
-{{% alert title="Warning" color="warning" %}} This is a **warning**.
-{{% /alert %}}
+{{% alert title="Welcome" %}} {{% param greeting %}} {{% /alert %}}
 
 Parameters:
 
@@ -200,24 +200,33 @@ requires indentation, such as a list, then the alert _content_ must be indented
 accordingly. For example:
 
 ```go-html-template
-- Item 1
-  {{%/* alert title="Note" color=info */%}}
-  This is properly indented alert content.
+- The following note is part of this list item:
+  {{%/* alert title="Celebrate!" color=success */%}}
+  This alert content is properly rendered.
+
+  > {{%/* param message */%}}
   {{%/* /alert */%}}
-- Don't do this, it won't render correctly:
-  {{%/* alert title="Warning" color=warning */%}} This content is not indented properly. {{%/* /alert */%}}
+  More prose.
+
+- Don't do this, it breaks the alert rendering:
+  {{%/* alert title="Warning" color=warning */%}} **This content appears outside of
+  the list!** {{%/* /alert */%}}
 ```
 
-renders as:
+This renders as:
 
 <!-- prettier-ignore -->
-- Item 1
-  {{% alert title="Note" color=info %}}
-  This is properly indented alert content.
+- The following note is part of this list item:
+  {{% alert title="Celebrate!" color=success %}}
+  This alert content is properly rendered.
+
+  > {{% param message %}}
   {{% /alert %}}
-- Don't do this, it won't render correctly:
-  {{% alert title="Warning" color=warning %}} This content appears outside of
-  the list! {{% /alert %}}
+  More prose.
+
+- Don't do this, it breaks the alert rendering:
+  {{% alert title="Warning" color=warning %}} **This content appears outside of
+  the list!** {{% /alert %}}
 
 [Bootstrap alert]: https://getbootstrap.com/docs/5.3/components/alerts/
 

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -9,7 +9,6 @@ resources:
     params:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
 params:
-  greeting: '**Hello**, world!'
   message: Some _message_.
 cSpell:ignore: pageinfo Bjørn Pedersen
 ---
@@ -176,28 +175,32 @@ section. It's meant to be used in combination with the other blocks shortcodes.
 ### alert
 
 Use the **alert** shortcode to display notices and warnings. The shortcode
-renders a [Bootstrap alert][]. It can be used with Markdown content and contain
-other shortcodes. For example:
+renders a [Bootstrap alert][bs-alert]. It can be used with Markdown content and
+contain other shortcodes. For example:
 
 ```go-html-template
-{{%/* alert title="Welcome" */%}} {{%/* param greeting */%}} {{%/* /alert */%}}
+{{%/* alert title="Welcome" */%}} **Hello**, world! {{%/* /alert */%}}
 ```
 
-With the `greeting` param defined as `{{% param greeting %}}`, this renders as:
+Renders as:
 
-{{% alert title="Welcome" %}} {{% param greeting %}} {{% /alert %}}
+{{% alert title="Welcome" %}} **Hello**, world! {{% /alert %}}
 
 Parameters:
 
-- `title` (optional) Renders as a Bootstrap alert heading, at heading level 4,
-  using the `h4` Bootstrap class over a `<div>` element. This prevents the title
-  from appearing in a page's table of contents.
-- `color` (optional) names one of the [Bootstrap alert][] variants: `primary`,
-  `info`, `warning`, etc.
+- `title` (optional): Use this to specify a title for your alert. The title
+  renders as a Bootstrap [alert heading][bs-alert], at heading level 4, using
+  the `h4` Bootstrap class over a `<div>` element. This prevents the title from
+  appearing in a page's table of contents.
+- `color` (optional): Use this parameter to specify one of Bootstrap's
+  predefined [alert variants][bs-alert], each of which has their own color.
+  These include `primary`, `info`, and `warning`.
 
-**Important!** When the `alert` shortcode is used in Markdown context that
-requires indentation, such as a list, then the alert _content_ must be indented
-accordingly. For example:
+#### Alerts and indentation
+
+When the `alert` shortcode is used in a Markdown context that requires
+indentation, such as a list, then the alert _content_ (whether specified as
+text/Markdown or a shortcode) must be indented accordingly. For example:
 
 ```go-html-template
 - The following note is part of this list item:
@@ -206,10 +209,10 @@ accordingly. For example:
 
   > {{%/* param message */%}}
   {{%/* /alert */%}}
-  More prose.
+  The first list item continues.
 
-- Don't do this, it breaks the alert rendering:
-  {{%/* alert title="Warning" color=warning */%}} **This content appears outside of
+- **Don't put content on the same line** as the opening tag, it breaks rendering:
+  {{%/* alert title="Misformed alert!" color=warning */%}} **This content appears outside of
   the list!** {{%/* /alert */%}}
 ```
 
@@ -232,13 +235,13 @@ IMPORTANT: the following lone opening div tag prevents the mis-formatted alert e
 
   > {{% param message %}}
   {{% /alert %}}
-  More prose.
+  The first list item continues.
 
-- Don't do this, it breaks the alert rendering:
-  {{% alert title="Warning" color=warning %}} **This content appears outside of
+- **Don't put content on the same line** as the opening tag, it breaks rendering:
+  {{% alert title="Misformed alert!" color=warning %}} **This alert content appears outside of
   the list!** {{% /alert %}}
 
-[Bootstrap alert]: https://getbootstrap.com/docs/5.3/components/alerts/
+[bs-alert]: https://getbootstrap.com/docs/5.3/components/alerts/
 
 ### pageinfo
 

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -281,7 +281,7 @@ You can use Docsy as an NPM module as follows:
 
     {{% /alert %}}
 
-    {{% alert title="Hugo install tip" color="info" %}}
+    {{% alert title="Hugo install tip" %}}
 
     You can install Docsy's
     officially supported version of [Hugo using NPM](#hugo-extended-npm) at the

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -181,9 +181,12 @@ your project's root directory:
     echo 'theme: docsy' >> hugo.yaml
     ```
 
-    {{% alert title="Tip" %}}As of Hugo 0.110.0, the default config base
+    {{% alert title="Tip" %}}
+
+    As of Hugo 0.110.0, the default config base
     filename was changed to `hugo.*` from `config.*`. If you are using hugo
     0.110 or above, consider renaming your `config.*` to `hugo.*`.
+
     {{% /alert %}}
 
 3.  Get Docsy dependencies:
@@ -270,15 +273,21 @@ You can use Docsy as an NPM module as follows:
     npm install --save-dev google/docsy#semver:{{% param version %}} --omit=peer
     ```
 
-    {{% alert title="Hugo-module compatibility" color="warning" %}} Installing
-    Docsy using NPM creates an empty `github.com` sibling folder. For details,
-    see [Docsy NPM install side-effect](#docsy-npm-install-side-effect). {{%
-    /alert %}}
+    {{% alert title="Hugo-module compatibility" color="warning" %}}
 
-    {{% alert title="Hugo install tip" color="info" %}} You can install Docsy's
+    Installing
+    Docsy using NPM creates an empty `github.com` sibling folder. For details,
+    see [Docsy NPM install side-effect](#docsy-npm-install-side-effect).
+
+    {{% /alert %}}
+
+    {{% alert title="Hugo install tip" color="info" %}}
+
+    You can install Docsy's
     officially supported version of [Hugo using NPM](#hugo-extended-npm) at the
-    same time as Docsy. Just omit the `--omit` flag from the command above. {{%
-    /alert %}}
+    same time as Docsy. Just omit the `--omit` flag from the command above.
+
+    {{% /alert %}}
 
 3.  Build or serve your new site using the usual Hugo commands, specifying the
     path to the Docsy theme files. For example, build your site as follows:
@@ -291,21 +300,21 @@ You can use Docsy as an NPM module as follows:
 
     {{% alert title="Error: failed to load modules" color="warning" %}}
 
-If Hugo reports the following error when building your site ([#2116]):
+    If Hugo reports the following error when building your site ([#2116]):
 
-```
-Error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in ".../myproject/node_modules/github.com/FortAwesome/Font-Awesome" ...
-```
+    ```
+    Error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in ".../myproject/node_modules/github.com/FortAwesome/Font-Awesome" ...
+    ```
 
-Then run the following command and try again:
+    Then run the following command and try again:
 
-```sh
-npm rebuild
-```
+    ```sh
+    npm rebuild
+    ```
 
-[#2116]: https://github.com/google/docsy/issues/2116
+    [#2116]: https://github.com/google/docsy/issues/2116
 
-{{% /alert %}}
+    {{% /alert %}}
 
 As an alternative to specifying a `themesDir`, on some platforms, you can
 instead create a symbolic link to the Docsy theme directory as follows (Linux

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -411,6 +411,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:03:46.341081-05:00"
   },
+  "https://getbootstrap.com/docs/5.3/components/alerts/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-10T21:33:38.654894-04:00"
+  },
   "https://getbootstrap.com/docs/5.3/content/tables/": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:45.464085-04:00"
@@ -1118,6 +1122,10 @@
   "https://github.com/google/docsy/pull/2259": {
     "StatusCode": 206,
     "LastSeen": "2025-05-22T19:21:14.104646-04:00"
+  },
+  "https://github.com/google/docsy/pull/941": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-10T18:59:25.465236-04:00"
   },
   "https://github.com/google/docsy/pulls": {
     "StatusCode": 200,
@@ -2354,6 +2362,10 @@
   "https://www.docsy.dev/docs/adding-content/search/#algolia-docsearch": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:06:43.680938-05:00"
+  },
+  "https://www.docsy.dev/docs/adding-content/shortcodes/#alert": {
+    "StatusCode": 206,
+    "LastSeen": "2025-06-10T21:43:28.870112-04:00"
   },
   "https://www.docsy.dev/docs/adding-content/shortcodes/#blocksfeature": {
     "StatusCode": 206,


### PR DESCRIPTION
- This is a proposed rework of the [alert.html@02df04c0f2] shortcode.
- Fixes #1672
- Contributes to
  - #906 
  - #939

~This doesn't offer as clean a solution as I would have liked, but I feel that it is a step in the right direction. Note that this will introduce a breaking change. I'll continue to explore if/how this shortcode can further be simplified -- ideally, so that we can avoid the use of the `markdownify` shortcode argument -- but any further changes will be submitted through another PR.~

**Edit 2025-06-10**: got it to work the way I want. See the UG alert section for details.

### Preview

- https://deploy-preview-941--docsydocs.netlify.app/docs/adding-content/shortcodes/#alert
- https://deploy-preview-941--docsydocs.netlify.app/docs/adding-content/feedback/#prerequisites
- https://deploy-preview-941--docsydocs.netlify.app/docs/get-started/other-options/#option-3-docsy-as-an-npm-package illustrates how alerts can be inside list elements

### Screenshot

> <img width="888" alt="image" src="https://github.com/user-attachments/assets/156680f6-6602-48d1-a909-e9f1b06869fb" />

[alert.html@02df04c0f2]: https://github.com/google/docsy/blob/02df04c0f2d495104316ce426948069f9a98bd99/layouts/shortcodes/alert.html
