### PR TITLE
Drop `shallow=true` config for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "assets/vendor/bootstrap"]
 	path = assets/vendor/bootstrap
 	url = https://github.com/twbs/bootstrap.git
-	shallow = true
 	branch = v4-dev
 [submodule "assets/vendor/Font-Awesome"]
 	path = assets/vendor/Font-Awesome
 	url = https://github.com/FortAwesome/Font-Awesome.git
-	shallow = true


### PR DESCRIPTION
- Reverts #269
- Closes #755, since the submodules have been deprecated.
  - For details, see #950
  - Addresses @ccwienk's concern -- https://github.com/google/docsy/issues/755#issuecomment-1081808648