### PR TITLE
fix docu TL;DR: second module import path

### DIFF
--- a/userguide/content/en/docs/Updating/Convert-site-to-module.md
+++ b/userguide/content/en/docs/Updating/Convert-site-to-module.md
@@ -39,7 +39,7 @@ path = "github.com/google/docsy"^
 
 [[module.imports]]^
 
-path = "github.com/google/docsy")>>config.toml
+path = "github.com/google/docsy/dependencies")>>config.toml
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}

--- a/userguide/content/en/docs/Updating/Convert-site-to-module.md
+++ b/userguide/content/en/docs/Updating/Convert-site-to-module.md
@@ -21,7 +21,7 @@ cat >> config.toml <<EOL
 [[module.imports]]
 path = "github.com/google/docsy"
 [[module.imports]]
-path = "github.com/google/docsy"
+path = "github.com/google/docsy/dependencies"
 EOL
 hugo server
 {{< /tab >}}


### PR DESCRIPTION
path = "github.com/google/docsy" is duplicated, in 'Detailed conversion instructions' the right path is '"github.com/google/docsy/dependencies"'