### PR TITLE
User guide, package.json: add name and version

### DIFF
--- a/userguide/package.json
+++ b/userguide/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "docsy-user-guide",
+  "version": "0.2.0",
   "scripts": {
     "_build": "npm run _hugo-dev",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",


### PR DESCRIPTION
From the [npm docs](https://docs.npmjs.com/creating-a-package-json-file):

```
A package.json file must contain "name" and "version" fields.
```

`package.json` inside the `userguide` directory does not have this fields.

As a consequence users may be confronted with poor output like this:

```
/path/to/docsy/userguide$ npm run-script
Scripts available in undefined via `npm run-script`:
  _build
  ...
```

This PR corrects this.