### PR TITLE
feature: add support for GLFM math blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock-math.html
+++ b/layouts/_default/_markup/render-codeblock-math.html
@@ -1,3 +1,16 @@
-<p>$$
+{{/* set default delimiters */}}
+{{ $delimiter_left := "$$" }}
+{{ $delimiter_right := "$$" }}
+
+{{/* override delimiters if set in config file */}}
+{{ with $.Page.Site.Params.katex.options.delimiters }}
+  {{ range first 1 ( where . "display" true ) }}
+    {{ $delimiter_left = index . "left" }}
+    {{ $delimiter_right = index . "right" }}
+  {{ end }}
+{{end}}
+
+{{/* output of equation */}}
+<p>{{ $delimiter_left }}
 {{ .Inner | safeHTML }}
-$$</p>
+{{ $delimiter_right }}</p>

--- a/layouts/_default/_markup/render-codeblock-math.html
+++ b/layouts/_default/_markup/render-codeblock-math.html
@@ -1,0 +1,3 @@
+<p>$$
+{{ .Inner | safeHTML }}
+$$</p>

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -29,11 +29,15 @@ The following code sample produces an introductory text line followed by a formu
 
 ```tex
 The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
-$$\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}$$
+$$
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+$$
 ```
 
 The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
-$$\tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}$$
+$$
+\tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
+$$
 
 You can also use [GLFM's math blocks](https://docs.gitlab.com/ee/user/markdown.html#math) (requires hugo 0.93 or newer):
 ````markdown

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -35,6 +35,13 @@ $$\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}$$
 The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
 $$\tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}$$
 
+You can also use [GLFM's math blocks](https://docs.gitlab.com/ee/user/markdown.html#math) (requires hugo 0.93 or newer):
+````markdown
+```math
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+```
+````
+
 {{% alert title="Tip" %}}
 This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth information about typesetting mathematical formulae using the \\(\LaTeX\\) typesetting system.
 {{% /alert %}}


### PR DESCRIPTION
This add supports for [GLFM's math blocks](https://docs.gitlab.com/ee/user/markdown.html#math) using [hugo's Markdown render hooks](https://gohugo.io/templates/render-hooks/#render-hooks-for-code-blocks).