### PR TITLE
Make asset urls configurable

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -78,6 +78,10 @@ $font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mon
 $font-family-base: $font-family-sans-serif !default;
 $font-size-base: 1rem !default;
 
+$font_vazir: "https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v27.0.1/dist/font-face.css";
+$font_rubik: "https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap";
+$font_tajawal: "https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;500;700&display=swap";
+
 // Font weights
 
 $font-weight-light: 300 !default;

--- a/assets/scss/rtl/_main.scss
+++ b/assets/scss/rtl/_main.scss
@@ -31,20 +31,20 @@ body:lang(ur) {
 }
 
 body:lang(fa) {
-    @import url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v27.0.1/dist/font-face.css');
+    @import url($font_vazir);
     font-family: 'Vazir', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 body:lang(he) {
     @if $td-enable-google-fonts {
-        @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap');
+        @import url($font_rubik);
     }
     font-family: 'Rubik', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 body:lang(ar) {
     @if $td-enable-google-fonts {
-        @import url('https://fonts.googleapis.com/css2?family=Tajawal:wght@300;400;500;700&display=swap');
+        @import url($font_tajawal);
     }
     font-family: 'Tajawal', "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }

--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,18 @@ time_format_default = "January 2, 2006"
 # Sections to publish in the main RSS feed.
 rss_sections = ["blog"]
 
+[params.assets]
+jquery = { src = "https://code.jquery.com/jquery-3.6.0.min.js", integrity = "sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" }
+lunr = { src = "https://unpkg.com/lunr@2.3.9/lunr.min.js", integrity = "sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli" }
+popper = { src = "https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js", integrity = "sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" }
+bootstrap = { src = "https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.min.js", integrity = "sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" }
+mermaid = { src = "https://cdn.jsdelivr.net/npm/mermaid@8.13.4/dist/mermaid.min.js", integrity = "sha512-JERecFUBbsm75UpkVheAuDOE8NdHjQBrPACfEQYPwvPG+fjgCpHAz1Jw2ci9EXmd3DdfiWth3O3CQvcfEg8gsA==" }
+markmap_autoloader = { src = "https://cdn.jsdelivr.net/npm/markmap-autoloader" }
+katex_css = { src = "https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css", integrity = "sha512-vJqxkZ+Sugf/6WRlpcxN01qVfX/29hF6qc33eHF1va3NgoV+U+wCi+uTAsQ10sDoGyBxHLdaHvGwDlV3yVYboA==" }
+katex_js = { src = "https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.js", integrity = "sha512-5ufNcHqOYgilGEHPfuRIQ5B/vDS1M8+UC+DESZ5CwVgGTg+b2Ol/15rYL/GiCWJ/Sx8oVo0FPFok1dPk8U9INQ==" }
+katex_auto_render = { src = "https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js", integrity = "sha512-ZA/RPrAo88DlwRnnoNVqKINnQNcWERzRK03PDaA4GIJiVZvGFIWQbdWCsUebMZfkWohnfngsDjXzU6PokO4jGw==" }
+mhchem = { src = "https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/mhchem.min.js", integrity = "sha512-HWb6LyQhO6UkmYLjdSblpgiOvvbdkoMRjln0POPhOVbZu3l4QdqwZnMJ/cuwKScU5pWARejB495TAAAz0WNsXQ==" }
+
 [params.drawio]
 enable = true
 #drawio_server = "https://example.com/"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,13 +28,13 @@
 {{ template "_internal/twitter_cards.html" . -}}
 {{ partialCached "head-css.html" . "asdf" -}}
 <script
-  src="https://code.jquery.com/jquery-3.6.0.min.js"
-  integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK"
+  src="{{ .Site.Params.assets.jquery.src }}"
+  integrity="{{ .Site.Params.assets.jquery.integrity }}"
   crossorigin="anonymous"></script>
 {{ if .Site.Params.offlineSearch -}}
 <script
-  src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
-  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  src="{{ .Site.Params.assets.lunr.src }}"
+  integrity="{{ .Site.Params.assets.lunr.integrity }}"
   crossorigin="anonymous"></script>
 {{ end -}}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,12 +1,12 @@
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
-    integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
+<script src="{{ .Site.Params.assets.popper.src }}"
+    integrity="{{ .Site.Params.assets.popper.integrity }}"
     crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.min.js"
-    integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA=="
+<script src="{{ .Site.Params.assets.bootstrap.src }}"
+    integrity="{{ .Site.Params.assets.bootstrap.integrity }}"
     crossorigin="anonymous"></script>
 
 {{ if .Site.Params.mermaid.enable }}
-<script src="https://cdn.jsdelivr.net/npm/mermaid@8.13.4/dist/mermaid.min.js" integrity="sha512-JERecFUBbsm75UpkVheAuDOE8NdHjQBrPACfEQYPwvPG+fjgCpHAz1Jw2ci9EXmd3DdfiWth3O3CQvcfEg8gsA==" crossorigin="anonymous"></script>
+<script src="{{ .Site.Params.assets.mermaid.src }}" integrity="{{ .Site.Params.assets.mermaid.integrity }}" crossorigin="anonymous"></script>
 {{ end }}
 
 {{ if .Site.Params.markmap.enable }}
@@ -21,7 +21,7 @@ window.markmap = {
   autoLoader: { manual: true },
 };
 </script>
-<script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
+<script src="{{ .Site.Params.assets.markmap_autoloader.src }}"></script>
 {{ end }}
 
 <script src='{{ "/js/tabpane-persist.js" | relURL }}'></script>
@@ -33,22 +33,22 @@ window.markmap = {
 
 <!-- load stylesheet and scripts for KaTeX support -->
 {{ if .Site.Params.katex.enable }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css"
-    integrity="sha512-vJqxkZ+Sugf/6WRlpcxN01qVfX/29hF6qc33eHF1va3NgoV+U+wCi+uTAsQ10sDoGyBxHLdaHvGwDlV3yVYboA==" crossorigin="anonymous">
+<link rel="stylesheet" href="{{ .Site.Params.assets.katex_css.src }}"
+    integrity="{{ .Site.Params.assets.katex_css.integrity }}" crossorigin="anonymous">
 <!-- The loading of KaTeX is deferred to speed up page rendering -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.js"
-    integrity="sha512-5ufNcHqOYgilGEHPfuRIQ5B/vDS1M8+UC+DESZ5CwVgGTg+b2Ol/15rYL/GiCWJ/Sx8oVo0FPFok1dPk8U9INQ=="
+<script src="{{ .Site.Params.assets.katex_js.src }}"
+    integrity="{{ .Site.Params.assets.katex_js.integrity }}"
     crossorigin="anonymous"></script>
 <!-- check whether support of mhchem is enabled in config.toml -->
 {{ if .Site.Params.katex.mhchem.enable }}
 <!-- To add support for displaying chemical equations and physical units, load the mhchem extension: -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/mhchem.min.js"
-    integrity="sha512-HWb6LyQhO6UkmYLjdSblpgiOvvbdkoMRjln0POPhOVbZu3l4QdqwZnMJ/cuwKScU5pWARejB495TAAAz0WNsXQ=="
+<script defer src="{{ .Site.Params.assets.mhchem.src }}"
+    integrity="{{ .Site.Params.assets.mhchem.integrity }}"
     crossorigin="anonymous"></script>
 {{ end }}
 <!-- To automatically render math in text elements, include the auto-render extension: -->
-<script defer src='https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js'
-    integrity='sha512-ZA/RPrAo88DlwRnnoNVqKINnQNcWERzRK03PDaA4GIJiVZvGFIWQbdWCsUebMZfkWohnfngsDjXzU6PokO4jGw==' crossorigin='anonymous' 
+<script defer src='{{ .Site.Params.assets.katex_auto_render.src }}'
+    integrity='{{ .Site.Params.assets.katex_auto_render.integrity }}' crossorigin='anonymous'
     {{ printf "onload='renderMathInElement(%s, %s);'" (( .Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}></script>
 {{ end }}
 


### PR DESCRIPTION
Allows configuration (in `config.toml` and `assets/scss/_variables_project.scss`) of own URLs instead of public CDNs.

advances #605 

One font is still loaded from jsdelivr.net, but I can't find it in the code.