### PR TITLE
Apply table styling to all tables in td-content, not just direct chil…

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -35,7 +35,7 @@
         @extend .img-fluid;
     }
 
-    > table {
+    table {
         @extend .table-striped;
 
         @extend .table-responsive;


### PR DESCRIPTION
As stated in https://github.com/google/docsy/issues/883, tables were not being styled properly in `<details><summary>` blocks. I found the same issue to affect tables nested in list elements. 
Removing `>` from the table entry enables proper styling to be applied to any table element that's a child of `td-content`.