### PR TITLE
fix: add link to migration guide

### DIFF
--- a/userguide/content/en/docs/Get started/Docsy-As-Module/_index.md
+++ b/userguide/content/en/docs/Get started/Docsy-As-Module/_index.md
@@ -9,7 +9,7 @@ description: >
 
 [Hugo modules](https://gohugo.io/hugo-modules/) are the simplest and latest way to use Hugo themes like Docsy when building a website. Hugo uses the modules mechanism to pull in the theme files from the main Docsy repo at your chosen revision, and it’s easy to keep the theme up to date in your site. Our example site uses Docsy as a Hugo module.
 
-To find out about other setup approaches, see our [Get started](/docs/get-started/) overview. If you want to migrate an existing Docsy site to use Hugo Modules, see our [migration guide]().
+To find out about other setup approaches, see our [Get started](/docs/get-started/) overview. If you want to migrate an existing Docsy site to use Hugo Modules, see our [migration guide](/docs/updating/convert-site-to-module/).
 
 ## Setup options with Hugo Modules
 


### PR DESCRIPTION
I'm not sure if I should be using the filepath or a URL. The same link to the migration guide on "Get started: Migration and backward compatibility" uses the URL

```
If you have an existing site that uses Docsy as a Git submodule, and you would like to update it to use Hugo Modules, follow our [migration guide](https://www.docsy.dev/docs/updating/convert-site-to-module/)
```
