### PR TITLE
community_links: make community_how_to adjustable

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -70,6 +70,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -70,6 +70,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/bg.toml
+++ b/i18n/bg.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -76,6 +76,6 @@ other = "Entwickeln und einen Beitrag leisten"
 [community_contribute]
 other = "Wenn Du aktiv beteiligen und einen Beitrag zu {{ .Site.Title }} leisten möchtest, kannst Du hier mitmachen:"
 [community_how_to]
-other = "Wie Du selbst zu diesen Dokumenten beitragen kannst, kannst Du nachlesen in unseren"
+other = "Wie Du selbst zu {{ .Site.Title }} beitragen kannst, kannst Du nachlesen in unseren"
 [community_guideline]
 other = "Richtlinien für Beiträge"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -76,6 +76,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/et.toml
+++ b/i18n/et.toml
@@ -61,6 +61,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -73,6 +73,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -72,6 +72,6 @@ other = "Développer et Contribuer"
 [community_contribute]
 other = "Si vous voulez vous impliquer davantage en contribuant à {{ .Site.Title }}, joignez-nous sur:"
 [community_how_to]
-other = "Vous pouvez trouver comment contribuer à cette documentation dans nos"
+other = "Vous pouvez trouver comment contribuer à {{ .Site.Title }} dans nos"
 [community_guideline]
 other = "Règles de contribution"

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -76,6 +76,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/nl.toml
+++ b/i18n/nl.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -73,6 +73,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -73,6 +73,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -76,6 +76,6 @@ other = "Utveckla och Medverka"
 [community_contribute]
 other = "Om du vill engagera dig mer genom att medverka till {{ .Site.Title }}, gå med oss här:"
 [community_how_to]
-other = "Du kan ta reda på hur du medverkar till dessa dokument i våra"
+other = "Du kan ta reda på hur du medverkar till {{ .Site.Title }} i våra"
 [community_guideline]
 other = "Riktlinjer för att Medverka"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute to these docs in our"
+other = "You can find out how to contribute {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -72,6 +72,6 @@ other = "Develop and Contribute"
 [community_contribute]
 other = "If you want to get more involved by contributing to {{ .Site.Title }}, join us here:"
 [community_how_to]
-other = "You can find out how to contribute {{ .Site.Title }} in our"
+other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -14,7 +14,7 @@
         {{ with index $links "developer"}}
         {{ template "community-links-list" . }}
         {{ end }}
-        <p>{{ T "community_how_to" }} <a href="/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>
+        <p>{{ T "community_how_to" . }} <a href="/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>
     </div>
 </section>
 


### PR DESCRIPTION
This changes "You can find out how to contribute to these docs in our" on the Community Page to "You can find out how to contribute to {{ .Site.Title }} in our".

This make much more sense IMHO, since the right side is about the project, not the docs of the project. See for example the Docsy page itself (https://www.docsy.dev/community/): the contribution guidelines also refer to the chapter "How to contribute to Docsy" and not just "How to contribute to Docsy's documentation".

I also adjusted the translation for all the languages I'm able to understand.