### PR TITLE
Make git submodules shallow clones to save bandwidth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,8 @@
 	path = assets/vendor/bootstrap
 	url = https://github.com/twbs/bootstrap.git
 	branch = v4-dev
+	shallow = true
 [submodule "assets/vendor/Font-Awesome"]
 	path = assets/vendor/Font-Awesome
 	url = https://github.com/FortAwesome/Font-Awesome.git
+	shallow = true


### PR DESCRIPTION
and speed up builds on CI/CD systems

Unless someone is working on the underlying bootstrap or fontawesome modules,
the entire git tree is not needed