### PR TITLE
Breadcrumbs: restore Aria attribute and link

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -18,11 +18,12 @@
     {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
   {{ end -}}
   {{ $isActive :=  eq .p1 .p2 }}
-  <li class="breadcrumb-item{{ if $isActive }} active{{ end }}">
-    {{- if $isActive }}
-      <span>{{ .p1.LinkTitle }}</span>
-    {{ else -}}
-      <a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
-    {{ end -}}
+  <li class="breadcrumb-item{{ if $isActive }} active{{ end }}"
+      {{- if $isActive }} aria-current="page"{{ end }}>
+    <a href="{{ .p1.Permalink }}"
+      {{- if $isActive }} aria-disabled="true" class="btn-link disabled"{{ end -}}
+    >
+      {{- .p1.LinkTitle -}}
+    </a>
   </li>
 {{- end -}}


### PR DESCRIPTION
This reverts the changes to the breadcrumb partial done in #1011. In particular, this PR:

- Reinstates the [aria-current] attribute
- Reinstates the last breadcrumb as a link

In #1011, @at055612 notes that:

> Making the leaf item not a link is possibly contentious but a quick google suggests this is an accepted practice. I think having a link to the page you are on is confusing and offers no value.

I agree on both points, and ( propose the following (which feels like a win-win): ensure that _all_ breadcrumbs are links, but effectively disable the last breadcrumb. I use Bootstrap's `disabled` class and the Aria [aria-disabled] attribute. The documentation for [aria-disabled] explicitly mentions as a use case the situation of a link/button to a self.

Visually, you'll see no difference, e.g.:

> <img width="1312" alt="image" src="https://user-images.githubusercontent.com/4140793/175503096-47acebbb-4b51-4c50-abc2-22ccaa3b216b.png">

**Preview**: for example see https://deploy-preview-1068--docsydocs.netlify.app/docs/get-started/docsy-as-module/

[aria-current]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current
[aria-disabled]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled

Note that while the last breadcrumb is disabled, its link can still be visited.