### PR TITLE
Remove ARIA attributes from taxonomy lists

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -10,9 +10,11 @@
         {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
         <article class="card article-teaser article-type-{{ with .Type }}{{ ( urlize . ) }}{{ end }}">
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
-          {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable }}
-            {{- partial "breadcrumb.html" . -}}
-          {{ end }}
+          {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
+            {{ partial "breadcrumb.html" .
+              | replaceRE ` aria-\w+=\".*?\"|(breadcrumb-item) active|(btn-link) disabled` "$1" | safeHTML
+            -}}
+          {{ end -}}
           <p>{{ .Description | markdownify }}</p>
           <header class="article-meta">
             {{ partial "taxonomy_terms_article_wrapper.html" . }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -11,6 +11,7 @@
         <article class="card article-teaser article-type-{{ with .Type }}{{ ( urlize . ) }}{{ end }}">
           <h3><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></h3>
           {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
+            {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context. */ -}}
             {{ partial "breadcrumb.html" .
               | replaceRE ` aria-\w+=\".*?\"|(breadcrumb-item) active|(btn-link) disabled` "$1" | safeHTML
             -}}


### PR DESCRIPTION
- Closes #1071

I've chosen to avoid complicating the logic of the breadcrumbs partial since it's complicated enough already. This PR implements what I proposed earlier: it strips out unnecessary classes and irrelevant ARIA labels from the "breadcrumbs" used in the taxonomy lists.

You'll notice that I've removed the `disabled` state from the last breadcrumb since it no longer makes sense to disable it (because we're not on that page anymore :)).

Preview: https://deploy-preview-1072--docsydocs.netlify.app/categories/taxonomies/

---

### Screenshots

Before:

> <img width="1215" alt="image" src="https://user-images.githubusercontent.com/4140793/175537299-f1943b4c-3929-419d-8390-d8ca3e497ef3.png">


After:

> <img width="1213" alt="image" src="https://user-images.githubusercontent.com/4140793/175537129-b56b569d-f309-4e07-ad04-6b4f310353eb.png">

/cc @at055612 