### PR TITLE
Support Universal Analytics and Google Analytics 4 IDs simultaneously

### DIFF
--- a/layouts/_internal/google_analytics.html
+++ b/layouts/_internal/google_analytics.html
@@ -1,0 +1,51 @@
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+{{ if hasPrefix . "G-"}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+<script>
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+}
+</script>
+{{ else if hasPrefix . "UA-" }}
+<script type="application/javascript">
+{{ template "__ga_js_set_doNotTrack" $ }}
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	{{- if $pc.UseSessionStorage }}
+	if (window.sessionStorage) {
+		var GA_SESSION_STORAGE_KEY = 'ga:clientId';
+		ga('create', '{{ . }}', {
+	    'storage': 'none',
+	    'clientId': sessionStorage.getItem(GA_SESSION_STORAGE_KEY)
+	   });
+	   ga(function(tracker) {
+	    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, tracker.get('clientId'));
+	   });
+   }
+	{{ else }}
+	ga('create', '{{ . }}', 'auto');
+	{{ end -}}
+	{{ if $pc.AnonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+	ga('send', 'pageview');
+}
+</script>
+{{- end -}}
+{{- end }}{{ end -}}
+
+{{- define "__ga_js_set_doNotTrack" -}}{{/* This is also used in the async version. */}}
+{{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
+{{- if not $pc.RespectDoNotTrack -}}
+var doNotTrack = false;
+{{- else -}}
+var dnt = (navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack);
+var doNotTrack = (dnt == "1" || dnt == "yes");
+{{- end -}}
+{{- end -}}

--- a/layouts/_internal/google_analytics.html
+++ b/layouts/_internal/google_analytics.html
@@ -1,14 +1,25 @@
+{{/* Override of https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics.html
+    At commit https://github.com/gohugoio/hugo/commit/ba16a14c6e884e309380610331aff78213f84751 */ -}}
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
 {{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
-{{ if hasPrefix . "G-"}}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+{{ $ga_ids := split . "," -}}
+{{ if (or (hasPrefix . "G-") (gt (len $ga_ids) 1)) -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ index $ga_ids 0 }}"></script>
 <script>
 {{ template "__ga_js_set_doNotTrack" $ }}
 if (!doNotTrack) {
 	window.dataLayer = window.dataLayer || [];
 	function gtag(){dataLayer.push(arguments);}
 	gtag('js', new Date());
-	gtag('config', '{{ . }}', { 'anonymize_ip': {{- $pc.AnonymizeIP -}} });
+	{{ range $ga_ids }}
+	{{ with trim . " " -}}
+	gtag('config', '{{ . }}'
+	  {{- if and $pc.AnonymizeIP (hasPrefix . "UA-") -}}
+	  , { 'anonymize_ip': {{- $pc.AnonymizeIP -}} }
+	  {{- end -}}
+	);
+	{{- end }}
+	{{- end }}
 }
 </script>
 {{ else if hasPrefix . "UA-" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,7 +46,8 @@
 
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
-  {{ if hasPrefix .Site.GoogleAnalytics "G-" -}}
+  {{ if (or (hasPrefix .Site.GoogleAnalytics "G-")
+            (in .Site.GoogleAnalytics ",")) -}}
     {{ template "_internal/google_analytics.html" . -}}
   {{ else -}}
     {{ template "_internal/google_analytics_async.html" . -}}


### PR DESCRIPTION
This is a proposed solution for:

- #1096

This PRs eases migration from UA to GA4 by allowing both IDs to be specified via the `googleAnalytics` configuration parameter.

I've proposed this change to the Hugo template here:

- https://github.com/gohugoio/hugo/pull/10094

In the meantime, we might want to support a template override as given in the PR.

---

For context, we're in the midst of migrating CNCF projects. For details see:

- https://github.com/cncf/techdocs/issues/108

/cc @nate-double-u
