### PR TITLE
CHANGELOG: mention new docsy-as-NPM-package option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ For a list of issues targeted for the next release, see the [22Q2][] milestone.
 
 For a full list of the changes to this release, see the [release notes][0.5.0].
 
+**New**:
+
+- Projects can now install and use [Docsy as an NPM package][].
+
 **Breaking changes**:
 
 - ...
+
+[Docsy as an NPM package]: https://www.docsy.dev/docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 
 ## [0.4.0][]
 
@@ -34,15 +40,13 @@ For a full list of the changes to this release, see the [release notes][0.4.0].
       ```console
       $ (cd themes/docsy && npm install)
       ```
-   4. (Optional) If your site project uses NPM, consider getting Docsy
-      dependencies via a `prepare` script, for example:
+   4. (Optional) If your site uses NPM, consider getting Docsy dependencies via
+      a [prepare][] script as follows:
       ```json
       {
         "name": "my-website",
         "scripts": {
-          "get:submodule": "git submodule update --init --depth 1",
-          "_prepare:docsy": "cd themes/docsy && npm install",
-          "prepare": "npm run get:submodule && npm run _prepare:docsy",
+          "prepare": "cd themes/docsy && npm install",
           "...": "..."
         },
         "...": "..."
@@ -50,8 +54,10 @@ For a full list of the changes to this release, see the [release notes][0.4.0].
       ```
    5. Proceed as usual to build or serve your site.
 
+
 [Hugo Modules]: https://www.docsy.dev/docs/get-started/docsy-as-module/
 [other Docsy setups]: https://www.docsy.dev/docs/get-started/other-options/
+[prepare]: https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
 
 ## [0.3.0][]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ For a full list of the changes to this release, see the [release notes][0.5.0].
 
 - ...
 
-[Docsy as an NPM package]: https://www.docsy.dev/docs/get-started/other-options/#option-3-docsy-as-an-npm-package
+[docsy as an npm package]:
+  https://www.docsy.dev/docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 
 ## [0.4.0][]
 
@@ -31,16 +32,16 @@ For a full list of the changes to this release, see the [release notes][0.4.0].
   and FontAwesome. Migrate your site by following these steps (execute commands
   from your project's root directory):
 
-   1. Update Docsy to 0.4.0.
-   2. Delete obsolete Docsy Git submodules:
+  1.  Update Docsy to 0.4.0.
+  2.  Delete obsolete Docsy Git submodules:
       ```console
       $ rm -Rf themes/docsy/assets/vendor
       ```
-   3. Get Docsy dependencies:
+  3.  Get Docsy dependencies:
       ```console
       $ (cd themes/docsy && npm install)
       ```
-   4. (Optional) If your site uses NPM, consider getting Docsy dependencies via
+  4.  (Optional) If your site uses NPM, consider getting Docsy dependencies via
       a [prepare][] script as follows:
       ```json
       {
@@ -52,12 +53,12 @@ For a full list of the changes to this release, see the [release notes][0.4.0].
         "...": "..."
       }
       ```
-   5. Proceed as usual to build or serve your site.
+  5.  Proceed as usual to build or serve your site.
 
-
-[Hugo Modules]: https://www.docsy.dev/docs/get-started/docsy-as-module/
-[other Docsy setups]: https://www.docsy.dev/docs/get-started/other-options/
-[prepare]: https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
+[hugo modules]: https://www.docsy.dev/docs/get-started/docsy-as-module/
+[other docsy setups]: https://www.docsy.dev/docs/get-started/other-options/
+[prepare]:
+  https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
 
 ## [0.3.0][]
 
@@ -65,20 +66,22 @@ For a full list of the changes to this release, see the [release notes][0.3.0].
 
 **Breaking changes**:
 
-- Upgrade to [Algolia DocSearch
-  v3](https://docsearch.algolia.com/docs/DocSearch-v3). If your site uses the
-  deprecated DocSearch v2, you must [update your DocSearch
-  code](https://docsearch.algolia.com/docs/migrating-from-v2).
+- Upgrade to
+  [Algolia DocSearch v3](https://docsearch.algolia.com/docs/DocSearch-v3). If
+  your site uses the deprecated DocSearch v2, you must
+  [update your DocSearch code](https://docsearch.algolia.com/docs/migrating-from-v2).
 
 ## [0.2.0][]
 
 **New**:
 
-- Add official Docsy support for [Hugo modules][]. Many thanks to the dedicated and
-  patient efforts of [@deining][], who researched, experimented, and implemented
-  this feature. Thanks to [@deining][] and [@LisaFC][] for the doc updates.
+- Add official Docsy support for [Hugo modules][]. Many thanks to the dedicated
+  and patient efforts of [@deining][], who researched, experimented, and
+  implemented this feature. Thanks to [@deining][] and [@LisaFC][] for the doc
+  updates.
 
-  For details, see [Migrate to Hugo Modules](https://www.docsy.dev/docs/updating/convert-site-to-module/).
+  For details, see
+  [Migrate to Hugo Modules](https://www.docsy.dev/docs/updating/convert-site-to-module/).
 
 **Details**:
 
@@ -86,7 +89,7 @@ For a full list of the changes to this release, see the [release notes][0.3.0].
 
 ## [0.X.Y][] - next planned release (unpublished yet)
 
-For a full list of the changes to this release, see the [release notes][0.X.Y].
+For a full list of the changes to this release, see the [release notes][0.x.y].
 
 **Breaking changes**:
 
@@ -98,7 +101,7 @@ For a full list of the changes to this release, see the [release notes][0.X.Y].
 [0.3.0]: https://github.com/google/docsy/releases/v0.3.0
 [0.4.0]: https://github.com/google/docsy/releases/v0.4.0
 [0.5.0]: https://github.com/google/docsy/releases/v0.5.0
-[0.X.Y]: #
+[0.x.y]: #
 [22q2]: https://github.com/google/docsy/milestone/3
 [hugo modules]: https://gohugo.io/hugo-modules/
 [latest]: https://github.com/google/docsy/releases/latest


### PR DESCRIPTION
- Contributes to #949
- Also simplified 0.4.0 `prepare` script instructions.