### PR TITLE
Hugo relURL fix for CSS and JS paths

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,7 +38,7 @@
 {{ end -}}
 
 {{ if .Site.Params.prism_syntax_highlighting -}}
-<link rel="stylesheet" href="{{ "/css/prism.css" | relURL }}"/>
+<link rel="stylesheet" href="{{ "css/prism.css" | relURL }}"/>
 {{ end -}}
 
 {{ partial "hooks/head-end.html" . -}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -24,11 +24,11 @@ window.markmap = {
 <script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
 {{ end }}
 
-<script src='{{ "/js/tabpane-persist.js" | relURL }}'></script>
+<script src='{{ "js/tabpane-persist.js" | relURL }}'></script>
 
 <!-- load the deflate.js for plantuml support -->
 {{ if .Site.Params.plantuml.enable }}
-<script src='{{ "/js/deflate.js" | relURL }}'></script>
+<script src='{{ "js/deflate.js" | relURL }}'></script>
 {{ end }}
 
 <!-- load stylesheet and scripts for KaTeX support -->
@@ -48,7 +48,7 @@ window.markmap = {
 {{ end }}
 <!-- To automatically render math in text elements, include the auto-render extension: -->
 <script defer src='https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js'
-    integrity='sha512-ZA/RPrAo88DlwRnnoNVqKINnQNcWERzRK03PDaA4GIJiVZvGFIWQbdWCsUebMZfkWohnfngsDjXzU6PokO4jGw==' crossorigin='anonymous' 
+    integrity='sha512-ZA/RPrAo88DlwRnnoNVqKINnQNcWERzRK03PDaA4GIJiVZvGFIWQbdWCsUebMZfkWohnfngsDjXzU6PokO4jGw==' crossorigin='anonymous'
     {{ printf "onload='renderMathInElement(%s, %s);'" (( .Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}></script>
 {{ end }}
 
@@ -71,6 +71,6 @@ window.markmap = {
 {{ end }}
 {{ if .Site.Params.prism_syntax_highlighting }}
 <!-- scripts for prism -->
-<script src='{{ "/js/prism.js" | relURL }}'></script>
+<script src='{{ "js/prism.js" | relURL }}'></script>
 {{ end }}
 {{ partial "hooks/body-end.html" . }}

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -3,7 +3,7 @@
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link rel="stylesheet" type="text/css" href="{{ "/css/swagger-ui.css" | relURL }}">
+    <link rel="stylesheet" type="text/css" href="{{ "css/swagger-ui.css" | relURL }}">
   </head>
   <body class="td-{{ .Kind }}">
     <header>
@@ -22,8 +22,8 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
-            <script src="{{ "/js/swagger-ui-bundle.js" | relURL }}"></script>
-            <script src="{{ "/js/swagger-ui-standalone-preset.js" | relURL }}"></script>
+            <script src="{{ "js/swagger-ui-bundle.js" | relURL }}"></script>
+            <script src="{{ "js/swagger-ui-standalone-preset.js" | relURL }}"></script>
             {{ block "main" . }}{{ end }}
           </main>
         </div>


### PR DESCRIPTION
- Contributes to #1114, and hopefully fixes it
- Addresses CSS and JS path changes only -- though that might be the only thing that we need to address (but I'll confirm later)
- According to a very reliable source (`@dep`), the fix consists of the following -- excerpt from https://github.com/gohugoio/hugo/issues/10049#issuecomment-1165948452 (emphasis mine):
  > The gist of it is, res starting with a / is considered relative to the server host, **remove that and it will work**.

/cc @Marzal @daniel-milchev @deining