### PR TITLE
Remove `height` attribute on `.td-outer`

### DIFF
--- a/assets/scss/_main-container.scss
+++ b/assets/scss/_main-container.scss
@@ -2,7 +2,6 @@
 .td-outer {
     display: flex;
     flex-direction: column;
-    height: 100vh;
 }
 
 // The outer page container for the default base template.


### PR DESCRIPTION
The presence of this attribute appears to break scroll-anchoring.

Fixes #1116, I hope.