### PR TITLE
Display non-empty page TOC

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,7 +1,9 @@
-{{ if not .Params.notoc }}
-{{ with .TableOfContents }}
-{{ if ge (len .) 200 }}
-<div class="td-toc">{{ . }}</div>
-{{ end }}
-{{ end }}
-{{ end }}
+{{ if not .Params.notoc -}}
+  {{ with .TableOfContents -}}
+    {{ if ne . `<nav id="TableOfContents"></nav>` -}}
+      <div class="td-toc">
+        {{ . }}
+      </div>
+    {{ end -}}
+  {{ end -}}
+{{ end -}}


### PR DESCRIPTION
Proposes a solution to #853 along the lines of https://github.com/google/docsy/issues/853#issuecomment-1209475444:

> ... show the TOC if and only if it is non-empty. If projects want to refine this behavior (by counting the number of TOC entries for example), they can override the template.

This is an alternative proposal to #1110 which doesn't rely on the (IMHO) faulty TOC character-count metric.

Preview:

- https://deploy-preview-1147--docsydocs.netlify.app/docs/best-practices/ - no TOC
- https://deploy-preview-1147--docsydocs.netlify.app/docs/best-practices/site-guidance/ - TOC with a single entry (which previously would have been hidden)
  - Compare with: https://www.docsy.dev/docs/best-practices/site-guidance/
- https://deploy-preview-1147--docsydocs.netlify.app/docs/ - an example of a TOC that would have been shown before as well.

So if y'all agree, this would be a step forward:

- Fixes #853
- Closes #326 
- Closes #1110 by superseding it