### PR TITLE
Avoid tabbed-pane.scss style leakage

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -1,4 +1,4 @@
-.td-content {
+.tab-content {
   .highlight {
     margin: 0rem 0 2rem 0;
   }


### PR DESCRIPTION
This PR applies minimal style changes in order to address the `highlight` style override reported in:

- #1154

---

Preview: https://deploy-preview-1157--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes

### Screenshots

Note the equal amount of spacing before and after the code block in the **After** screenshot.

| Before | After |
|--|--|
| <img width="565" alt="image" src="https://user-images.githubusercontent.com/4140793/184602882-1c43d59c-971f-45e8-b6fe-7e09bbe466c1.png"> | <img width="567" alt="image" src="https://user-images.githubusercontent.com/4140793/184602961-bd7b9b4f-e0b3-4763-bd66-4df2fd4b8cf1.png"> |