### PR TITLE
Blog layout: streamline and fix styling RSS button

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -1,10 +1,14 @@
-// Blog related styles.
-
 .td-blog {
-    .td-rss-button {
-        position: absolute;
-        top: 5.5rem;
-        right: 1rem;
-        z-index: 22;
-    }
+  .td-rss-button {
+    @extend .btn;
+    @extend .btn-lg;
+    @extend .-bg-orange;
+
+    position: absolute;
+    right: 1rem;
+    z-index: 22;
+
+    display: none;
+    @extend .d-lg-block;
+  }
 }

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -20,8 +20,8 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
-            <a class="btn btn-lg -bg-orange td-rss-button d-none d-lg-block" href="{{ .Permalink | safeURL }}" target="_blank">
-              RSS <i class="fa-solid fa-rss"></i>
+            <a class="td-rss-button" title="RSS" href="{{ .Permalink | safeURL }}" target="_blank" rel="noopener">
+              <i class="fa-solid fa-rss" aria-hidden="true"></i>
             </a>
             {{ end -}}
             {{ block "main" . }}{{ end }}


### PR DESCRIPTION
- Moves the button label into the link `title`, leaving only the RSS icon
  - Hovering over the button will show the title.
- Moves all the styling under `.td-rss-button`, i.e.:
  - An example of a contribution to #783
  - So projects will now be able to fully customize the button style
- Prep for #470

Preview: https://deploy-preview-1193--docsydocs.netlify.app/blog/

### Screenshot

Before:

> <img width="1068" alt="image" src="https://user-images.githubusercontent.com/4140793/185634132-a58364fc-77a9-40d2-9ae4-748f6195744c.png">

After:

> <img width="1070" alt="image" src="https://user-images.githubusercontent.com/4140793/185634074-40f86044-6da0-4ef1-81fc-ca3ae697c9f3.png">


