### PR TITLE
Add shortcode rendering in readfile shortcode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM klakegg/hugo:0.95.0-ext-alpine as docsy-user-guide
+FROM klakegg/hugo:0.101.0-ext-alpine as docsy-user-guide
 
 RUN apk update
 RUN apk add git
 COPY package.json /app/docsy/userguide/
 WORKDIR /app/docsy/userguide/
 RUN npm install --production=false
+RUN git config --global --add safe.directory /app/docsy
 
-CMD ["serve", "--cleanDestinationDir", "--themesDir ../..", "--baseURL http://localhost:1313/", "--buildDrafts", "--buildFuture", "--disableFastRender", "--ignoreCache", "--watch"]
+CMD ["serve", "--cleanDestinationDir", "--themesDir", "../..", "--baseURL",  "http://localhost:1313/", "--buildDrafts", "--buildFuture", "--disableFastRender", "--ignoreCache", "--watch"]

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -27,7 +27,7 @@ if the file is not found */}}
     {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape | 
     safeHTML ) (.Get "lang") "" -}}
   {{ else }}
-    {{- $.Scratch.Get "filepath" | readFile | htmlUnescape | safeHTML -}}
+    {{- $.Scratch.Get "filepath" | readFile | .Page.RenderString | htmlUnescape | safeHTML -}}
   {{ end }}
 {{ else }}
 

--- a/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
@@ -1,5 +1,9 @@
 **Installation**
 
+{{% alert title="Note" color="primary" %}}
+Check system compatibility before proceeding.
+{{% /alert %}}
+
 1.  Download the installation files.
 
 1.  Run the installation script

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -594,6 +594,10 @@ contents:
 ```go-html-template
 ## Installation
 
+{{%/* alert title="Note" color="primary" */%}}
+Check system compatibility before proceeding.
+{{%/* /alert */%}}
+
 1.  Download the installation files.
 
 1.  Run the installation script

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -617,7 +617,9 @@ The following section explains how to install the database:
 
 ```
 
-This will be rendered as if the instructions were in the parent document:
+This is rendered as if the instructions were in the parent document. Hugo
+v0.101.0+ is required for imported files containing shortcodes to be rendered
+correctly.
 
 ---
 


### PR DESCRIPTION
This allows importing files that contain shortcodes themselves, and the shortcodes will be rendered correctly.

Requires Hugo v0.101.0+ to work correctly, for older versions this change has no effect on the output.

[The PR docs preview shows an example](https://deploy-preview-1203--docsydocs.netlify.app/docs/adding-content/shortcodes/#include-external-files)

