### PR TITLE
Userguide, installation via npm: correct themes directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "bootstrap": "4.6.2"
   },
   "devDependencies": {
-    "hugo-extended": "0.101.0"
+    "hugo-extended": "0.102.3"
   }
 }

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -266,8 +266,8 @@ instead create a symbolic link to the Docsy theme directory as follows (Linux
 commands shown, executed from the site root folder):
 
 ```sh
-mkdir -p theme
-pushd theme
+mkdir -p themes
+pushd themes
 ln -s ../node_modules/docsy
 popd
 ```


### PR DESCRIPTION
This PR corrects the name of the themes directory (`theme` -> `themes`).
It also bumps hugo version to the latest released version hugo v0.102.3.

Preview: https://deploy-preview-1213--docsydocs.netlify.app/docs/get-started/other-options/#option-3-docsy-as-an-npm-package