### PR TITLE
Module setup: add mount to make bootstrap.js available

### DIFF
--- a/dependencies/config.toml
+++ b/dependencies/config.toml
@@ -28,6 +28,9 @@ _merge = "deep"
 [[module.imports.mounts]]
   source = "scss"
   target = "assets/vendor/bootstrap/scss"
+[[module.imports.mounts]]
+  source = "dist/js"
+  target = "assets/vendor/bootstrap/dist/js"
 [[module.imports]]
   path = "github.com/FortAwesome/Font-Awesome"
   disable = false


### PR DESCRIPTION
Fixes #1214 by simply adding a mount so that `bootstrap.js` becomes available with module installations.