### PR TITLE
Upgrade to Bootstrap 4.6.2 (module install)

### DIFF
--- a/dependencies/go.mod
+++ b/dependencies/go.mod
@@ -3,6 +3,6 @@ module github.com/google/docsy/dependencies
 go 1.12
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
-	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f // indirect
+	github.com/twbs/bootstrap v4.6.2+incompatible // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/google/docsy
 go 1.12
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f // indirect
 	github.com/google/docsy/dependencies v0.5.0 // indirect
-	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
+	github.com/twbs/bootstrap v4.6.2+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f h1:bvkUptSRPZBr3Kxuk+bnWCEmQ5MtEJX5fjezyV0bC3g=
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16 h1:6Ju+wn/ReUk9qmvKU68JlYhnWe48Tq+2HZ4vyeSpNMk=
 github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
-github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
-github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/google/docsy/dependencies v0.4.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/twbs/bootstrap v4.6.2+incompatible h1:TDa+R51BTiy1wEHSYjmqDb8LxNl/zaEjAOpRE9Hwh/o=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "userguide/public"
 command = "npm run docs-install && npm run build:preview"
 
 [build.environment]
-GO_VERSION = "1.19"
+GO_VERSION = "1.19.2"
 HUGO_THEME = "repo"
 
 [context.production]

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "proseWrap": "always"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.1.2",
+    "@fortawesome/fontawesome-free": "6.2.0",
     "bootstrap": "4.6.2"
   },
   "devDependencies": {
-    "hugo-extended": "0.102.3"
+    "hugo-extended": "0.104.3"
   }
 }


### PR DESCRIPTION
This PR syncs the versions of dependencies between Hugo modules and npm packages, as requested in #1182.
More concrete, it
* upgrades module/package FontAwesome to version 6..2.0 (npm + module install),
* upgrades package hugo-extended to hugo version 0..104.3 (npm install).
* updates go to latest version 1.19.2