### PR TITLE
[conditional-text] Avoid linebreaks when using the shortcode inline

### DIFF
--- a/layouts/shortcodes/conditional-text.html
+++ b/layouts/shortcodes/conditional-text.html
@@ -1,36 +1,36 @@
 <!-- Get the current buildcondition from the config and lowercase it -->
-{{ $condition := lower $.Site.Params.buildCondition }}
+{{- $condition := lower $.Site.Params.buildCondition -}}
 
-{{ if ne $condition "" }}
+{{- if ne $condition "" -}}
     
     <!-- Get the parameters from the shortcode invocation and lowercase them.
     TODO: to enable multiple conditions, we could accept comma-separated lists and split them -->
-    {{ $include_if := lower (.Get "include-if") }}
-    {{ $exclude_if := lower (.Get "exclude-if") }}
+    {{- $include_if := lower (.Get "include-if") -}}
+    {{- $exclude_if := lower (.Get "exclude-if") -}}
 
-    {{ if and (in $include_if $condition) (in $exclude_if $condition) }}
+    {{- if and (in $include_if $condition) (in $exclude_if $condition) -}}
         <!-- condition appears in both parameters -->
         {{- errorf "Build condition %q appears in both include-if and exclude-if parameters of conditional-txt shortcode on page %s" $condition .Position -}}
-    {{ end }}
+    {{- end -}}
 
-    {{ if isset $.Params "include-if" }}
+    {{- if isset $.Params "include-if" -}}
         <!-- WARNING substring matches are matches as well! That means, if include-if="foobar", and buildcondition is "foo", you have a match!-->
-        {{ if in $include_if $condition }}
+        {{- if in $include_if $condition -}}
 <!-- Do not indent the next Inner line, because the inner becomes a blockquote if the conditional-text is nested in another shortcode  -->
-{{ .Inner }}
-        {{ else }}
-        {{ end }}
-    {{ else }}
+{{- .Inner -}}
+        {{- else -}}
+        {{- end -}}
+    {{- else -}}
 
-        {{ if isset $.Params "exclude-if" }}
+        {{- if isset $.Params "exclude-if" -}}
             <!-- WARNING substring matches are matches as well! That means, if exclude-if="foobar", and buildcondition is "foo", you have a match!-->
-            {{ if in $exclude_if $condition }}
-            {{ else }}
+            {{- if in $exclude_if $condition -}}
+            {{- else -}}
 <!-- Do not indent the next Inner line, because the inner becomes a blockquote if the conditional-text is nested in another shortcode  -->
-{{ .Inner }}
-            {{ end }}
-        {{ end }}
+{{- .Inner -}}
+            {{- end -}}
+        {{- end -}}
 
-    {{ end }}
+    {{- end -}}
 
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
Until now, using the conditional-text shortcode inside a paragraph
caused linebreaks before and after the conditionally included text.
This patch fixes the issue.