### PR TITLE
Module setup: update docsy/dependencies to tip of main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac // indirect
-	github.com/google/docsy/dependencies v0.4.0 // indirect
+	github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16 // indirect
 	github.com/twbs/bootstrap v4.6.1+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac h1:AjwgwoaDsNEA1Wtc8pgw/BqG7SEk9bKxXPjEPQQ42vY=
 github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16 h1:6Ju+wn/ReUk9qmvKU68JlYhnWe48Tq+2HZ4vyeSpNMk=
+github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
 github.com/twbs/bootstrap v4.6.1+incompatible h1:75PsBfPU1SS65ag0Z3Cq6JNXVAfUNfB0oCLHh9k9Fu8=
 github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR is the continuation of #1216: now that we have the commit hash from this PR, we update the module `docsy/dependencies` to this commit. Thus module setup will work with tip of branch again. This eventually fixes #1214, which was closed prematurely.