### PR TITLE
Fix: tab-pane, persistence of language: change load order of .js-scripts

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -23,7 +23,6 @@ window.markmap = {
 <script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
 {{ end -}}
 
-<script src='{{ "js/tabpane-persist.js" | relURL }}'></script>
 {{ if .Site.Params.plantuml.enable -}}
   <script src='{{ "js/deflate.js" | relURL }}'></script>
 {{ end -}}
@@ -72,5 +71,7 @@ window.markmap = {
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
 {{ end -}}
+
+<script src='{{ "js/tabpane-persist.js" | relURL }}'></script>
 
 {{ partial "hooks/body-end.html" . -}}


### PR DESCRIPTION
This PR fixes #1232. The problem mentioned there is caused by the fact that `js/tabpane-persist.js` is loaded prior to the `bootstrap` script. Simply changing the load order of the scripts cures the problem.