### PR TITLE
Fixing FontAwesome icon handling in search placeholder

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -63,6 +63,7 @@
 
     .td-search-input {
         border: none;
+        color: $navbar-dark-color;
         @include placeholder {
             color: $navbar-dark-color;
         }

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -57,9 +57,12 @@
         font-weight: $font-weight-bold;
     }
 
+    .td-search-wrapper .fa {
+        color: $navbar-dark-color;
+    }
+
     .td-search-input {
         border: none;
-        color: $navbar-dark-color;
         @include placeholder {
             color: $navbar-dark-color;
         }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -1,8 +1,13 @@
 // Search
-
-.td-search-input {
+.td-search-wrapper {
+    position: relative;
     background: transparent;
     max-width: 90%;
+}
+
+.td-search-wrapper .td-search-input {
+    width: 100%;
+    text-indent: 1.25em;
 
     &.form-control:focus {
         border-color: lighten($primary, 60%);
@@ -14,7 +19,25 @@
         border-radius: 1rem;
     }
 
-    font-family: $font-family-base, $font-awesome-font-name;
+    font-family: $font-family-base;
+}
+
+.td-search-wrapper .fa {
+    // Make this consistent with placeholder formatting.
+    color: $input-placeholder-color;
+
+    // Vertically center the content.
+    display: flex;
+    justify-content: center;
+    align-items:center;
+    height: 100%;
+
+    // Position this on the left of the input.
+    position: absolute;
+    left: 0.75em;
+
+    // Click-through to the underlying input.
+    pointer-events: none;
 }
 
 .popover.offline-search-result {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -8,6 +8,7 @@
 .td-search-wrapper .td-search-input {
     width: 100%;
     text-indent: 1.25em;
+    background: transparent;
 
     &.form-control:focus {
         border-color: lighten($primary, 60%);
@@ -18,10 +19,6 @@
     @if $enable-rounded {
         border-radius: 1rem;
     }
-}
-
-.td-search-wrapper .td-search-input::placeholder {
-    color: $input-placeholder-color;
 }
 
 .td-search-wrapper .fa {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -2,7 +2,7 @@
 .td-search-wrapper {
     position: relative;
     background: transparent;
-    max-width: 90%;
+    width: 90%;
 }
 
 .td-search-wrapper .td-search-input {
@@ -38,6 +38,15 @@
 
     // Click-through to the underlying input.
     pointer-events: none;
+}
+
+# Hide the icon on focus.
+.td-search-wrapper:focus-within .fa {
+    display: none;
+}
+
+.td-search-wrapper:focus-within .td-search-input {
+   text-indent: 0px;
 }
 
 .popover.offline-search-result {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -5,14 +5,18 @@
     width: 90%;
 }
 
+.td-search-wrapper .td-search-input:not(:focus) {
+    background: transparent;
+}
+
 .td-search-wrapper .td-search-input {
     width: 100%;
     text-indent: 1.25em;
-    background: transparent;
 
     &.form-control:focus {
         border-color: lighten($primary, 60%);
         box-shadow: 0 0 0 2px lighten($primary, 30%);
+        color: inherit;
     }
 
     @if $enable-rounded {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -40,7 +40,7 @@
     pointer-events: none;
 }
 
-# Hide the icon on focus.
+// Hide the icon on focus.
 .td-search-wrapper:focus-within .fa {
     display: none;
 }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -18,8 +18,10 @@
     @if $enable-rounded {
         border-radius: 1rem;
     }
+}
 
-    font-family: $font-family-base;
+.td-search-wrapper .td-search-input::placeholder {
+    color: $input-placeholder-color;
 }
 
 .td-search-wrapper .fa {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -5,6 +5,10 @@
     width: 90%;
 }
 
+.td-search-wrapper:not(:focus-within) {
+    color: $input-placeholder-color;
+}
+
 .td-search-wrapper .td-search-input:not(:focus) {
     background: transparent;
 }
@@ -25,9 +29,6 @@
 }
 
 .td-search-wrapper .fa {
-    // Make this consistent with placeholder formatting.
-    color: $input-placeholder-color;
-
     // Vertically center the content.
     display: flex;
     justify-content: center;

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -13,7 +13,6 @@
     &.form-control:focus {
         border-color: lighten($primary, 60%);
         box-shadow: 0 0 0 2px lighten($primary, 30%);
-        color: inherit;
     }
 
     @if $enable-rounded {

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,5 +1,8 @@
 {{ if .Site.Params.gcs_engine_id -}}
-<input type="search" class="form-control td-search-input" placeholder="&#xf002; {{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+<div class="td-search-wrapper">
+<i class="fa fa-search"></i>
+<input type="search" class="form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+</div>
 {{ else if .Site.Params.algolia_docsearch -}}
 <div id="docsearch"></div>
 {{ else if .Site.Params.offlineSearch -}}


### PR DESCRIPTION
https://github.com/google/docsy/issues/1169 switched the order of FA6 and default fonts, causing a unicode character to render:
![image](https://user-images.githubusercontent.com/62662355/192907484-0eb67596-e3fc-4cab-8c16-eb399dec04a4.png)

Since FA6 doesn't handle regular text well anymore, putting this icon in the placeholder is just not possible.  Instead, put it in a separate element and position it in the old location.  This looks like:
![image](https://user-images.githubusercontent.com/62662355/192907733-aa3b0286-1e3e-4cac-b655-d1593f095f97.png)

The only appreciable change in behavior is that icon will always be present, and user-supplied input will be shifted slightly to the right.

---

- Closes #1256
