### PR TITLE
Apply styling to all elements in td-content

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -35,7 +35,7 @@
         @extend .img-fluid;
     }
 
-    > table {
+    table {
         @extend .table-striped;
 
         @extend .table-responsive;
@@ -43,14 +43,14 @@
         @extend .table;
     }
 
-    > blockquote {
+    blockquote {
         padding: 0 0 0 1rem;
         margin-bottom: $spacer;
         color: $gray-600;
         border-left: 6px solid $secondary;
     }
 
-    > ul li, > ol li {
+    ul li, ol li {
         margin-bottom: .25rem;
     }
 


### PR DESCRIPTION
This PR is based off of [PR 1017](https://github.com/google/docsy/pull/1017), as I could not get clarity on signing the Google CLA from my corporate GH account. I hope the contribution is still useful, my apologies for the overly long wait time.

As stated in https://github.com/google/docsy/issues/883 (and the original PR), tables were not being styled properly in `<details><summary>` blocks. I found the same issue to affect tables nested in list elements.
Removing `>` from the table entry enables proper styling to be applied to any table element that's a child of td-content.

As per the request in the original PR comments, I also removed the `>` selector from `blockquote`, `ul li` and `ol li` elements.