### PR TITLE
Scripts tweak to cleanup whitespace etc

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -71,8 +71,13 @@ window.markmap = {
 {{ if .Site.Params.prism_syntax_highlighting -}}
   <script src='{{ "js/prism.js" | relURL }}'></script>
 {{ else -}}
-  {{ $c2cJS := resources.Get "js/click-to-copy.js" | minify |  fingerprint }}
-  <script defer src="{{ $c2cJS.RelPermalink }}" integrity="{{ $c2cJS.Data.Integrity }}" crossorigin="anonymous"></script>
+  {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
+  {{ if hugo.IsProduction -}}
+    {{ $c2cJS = $c2cJS | minify | fingerprint -}}
+  {{ end -}}
+  <script defer src="{{ $c2cJS.RelPermalink }}" {{ with $c2cJS.Data.Integrity -}}
+    integrity="{{ . }}" {{ end -}}
+    crossorigin="anonymous"></script>
 {{ end -}}
 
 <script src='{{ "js/tabpane-persist.js" | relURL }}'></script>


### PR DESCRIPTION
- Addresses https://github.com/google/docsy/commit/de7048f920d410c3fb33f4522da8bc94bdd9fcc0#r86131677 - #1245
- Cleans up generated whitespace (to help minimize diffs of non-production sites)
- There are no changes to the generated site files in production

/cc @geriom 