### PR TITLE
Shortcode imgproc: add crop command

### DIFF
--- a/layouts/shortcodes/imgproc.html
+++ b/layouts/shortcodes/imgproc.html
@@ -7,8 +7,10 @@
 {{ .Scratch.Set "image" ($original.Resize $options) }}
 {{ else if eq $command "Fill"}}
 {{ .Scratch.Set "image" ($original.Fill $options) }}
+{{ else if eq $command "Crop"}}
+{{ .Scratch.Set "image" ($original.Crop $options) }}
 {{ else }}
-{{ errorf "Invalid image processing command: Must be one of Fit, Fill or Resize."}}
+{{ errorf "Invalid image processing command: Must be one of Fit, Fill, Crop or Resize."}}
 {{ end }}
 {{ $image := .Scratch.Get "image" }}
 <figure class="card rounded p-2 td-post-card mb-4 mt-4" style="max-width: {{ add $image.Width 10 }}px">

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -199,12 +199,12 @@ The **imgproc** shortcode finds an image in the current [Page Bundle](/docs/addi
 
 ```go-html-template
 {{</* imgproc spruce Fill "400x450" */>}}
-Norway Spruce Picea abies shoot with foliage buds.
+Norway Spruce <i>Picea abies</i> shoot with foliage buds.
 {{</* /imgproc */>}}
 ```
 
 {{< imgproc spruce Fill "400x450" >}}
-Norway Spruce Picea abies shoot with foliage buds.
+Norway Spruce <i>Picea abies</i> shoot with foliage buds.
 {{< /imgproc >}}
 
 The example above has also a byline with photo attribution added. When using illustrations with a free license from [WikiMedia](https://commons.wikimedia.org/) and similar, you will in most situations need a way to attribute the author or licensor. You can add metadata to your page resources in the page front matter. The `byline` param is used by convention in this theme:
@@ -245,8 +245,8 @@ resources:
 | Parameter        | Description  |
 | ----------------: |------------|
 | 1 | The image filename or enough of it to identify it (we do Glob matching)
-| 2 | Command. One of `Fit`, `Resize` or `Fill`. See [Image Processing Methods](https://gohugo.io/content-management/image-processing/#image-processing-methods).
-| 3 | Processing options, e.g. `400x450`. See [Image Processing Options](https://gohugo.io/content-management/image-processing/#image-processing-methods).
+| 2 | Command. One of `Fit`, `Resize`, `Fill` or `Crop`. See [Image Processing Methods](https://gohugo.io/content-management/image-processing/#image-processing-methods).
+| 3 | Processing options, e.g. `400x450 r180`. See [Image Processing Options](https://gohugo.io/content-management/image-processing/#image-processing-options).
 
 ### swaggerui
 


### PR DESCRIPTION
This PR adds the `crop`command to the available image processing options of the `imgproc` shortcode. Since hugo uses [Smartcrop](https://github.com/muesli/smartcrop#smartcrop) image analysis to determine the optimal placement of the crop box, I don't see any reason to exclude this option.
This PR also corrects an incorrect link in the documentation of the shortcode.

Preview: https://deploy-preview-1272--docsydocs.netlify.app/docs/adding-content/shortcodes/#imgproc