### PR TITLE
Search styling refactoring, and fix for offline search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,14 @@ notes][0.5.0]. **BREAKING CHANGES** are documented below.
 - **[Upgraded FontAwesome][]** to v6 from v5. While many icons were renamed, the
   v5 names still work. For details about icon renames and more, see [What's
   changed][].
+- **Search-box**: the HTML structure and class names have changed, due to the
+  Font Awesome upgrade, for both online and offline search. This may affect your
+  project if you have overridden search styling or scripts.
 
 **Other changes**:
 
 - By default, Docsy now uses the [gtag.js][] analytics library for all site
   tags. For details, see [Adding Analytics > Setup][].
-- **Navbar search-box** width is narrower, as a result of the FontAwesome (FA)
-  upgrade. In any case, the search-box styling has also been updated.
 
 [Adding Analytics > Setup]: https://www.docsy.dev/docs/adding-content/feedback/#setup
 [v4.6.2 release notes]: https://github.com/twbs/bootstrap/releases/tag/v4.6.2

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -14,7 +14,7 @@
         $searchInput.data('placement', 'bottom');
         $searchInput.data(
             'template',
-            '<div class="popover offline-search-result" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
+            '<div class="td-offline-search-results popover" role="tooltip"><div class="arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
         );
 
         //
@@ -130,11 +130,8 @@
                             .css({ fontWeight: 'bold' })
                     )
                     .append(
-                        $('<i>')
-                            .addClass('fas fa-times search-result-close-button')
-                            .css({
-                                cursor: 'pointer',
-                            })
+                        $('<span>')
+                            .addClass('td-offline-search-results__close-button')
                     )
             );
 
@@ -182,7 +179,7 @@
             }
 
             $targetSearchInput.on('shown.bs.popover', () => {
-                $('.search-result-close-button').on('click', () => {
+                $('.td-offline-search-results__close-button').on('click', () => {
                     $targetSearchInput.val('');
                     $targetSearchInput.trigger('change');
                 });

--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -4,7 +4,7 @@
     'use strict';
 
     $(document).ready(function () {
-        const $searchInput = $('.td-search-input');
+        const $searchInput = $('.td-search input');
 
         //
         // Options for popover

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -21,7 +21,7 @@ limitations under the License.
     var Search = {
         init: function() {
             $(document).ready(function() {
-               $(document).on('keypress', '.td-search-input', function(e) {
+               $(document).on('keypress', '.td-search input', function(e) {
                     if (e.keyCode !== 13) {
                         return
                     }

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -36,7 +36,6 @@
         width: 100%;
     }
 
-
     .navbar-brand {
         text-transform: none;
         text-align: middle;
@@ -57,17 +56,7 @@
         font-weight: $font-weight-bold;
     }
 
-    .td-search-wrapper .fa {
-        color: $navbar-dark-color;
-    }
-
-    .td-search-input {
-        border: none;
-        color: $navbar-dark-color;
-        @include placeholder {
-            color: $navbar-dark-color;
-        }
-    }
+    // For .td-search__input styling, see _search.scss
 
     .dropdown {
         min-width: 100px;

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -1,14 +1,14 @@
 // Search
 
-.td-search-wrapper {
-  position: relative;
+.td-search {
   background: transparent;
+  position: relative;
   width: 90%;
 
-  .fa {
+  // Search icon
+  &__icon {
     // Vertically center the content.
     display: flex;
-    justify-content: center;
     align-items: center;
     height: 100%;
 
@@ -18,9 +18,22 @@
 
     // Click-through to the underlying input.
     pointer-events: none;
+
+    &:before {
+      @extend .fa;
+      content: fa-content($fa-var-search);
+    }
+
+    // Styling adjustments for the navbar
+    @at-root {
+      .td-navbar & {
+        color: $navbar-dark-color;
+      }
+    }
   }
 
-  .td-search-input {
+  // Search input element
+  &__input {
     width: 100%;
     text-indent: 1.25em;
 
@@ -38,12 +51,24 @@
       color: inherit;
     }
 
+    // Styling adjustments for the navbar
+    @at-root {
+      .td-navbar & {
+        border: none;
+        color: $navbar-dark-color;
+
+        @include placeholder {
+          color: $navbar-dark-color;
+        }
+      }
+    }
+
   }
 
+  // Hide icon on focus
   &:focus-within {
-    // Hide icon on focus
 
-    .fa {
+    .td-search__icon {
       display: none;
     }
 
@@ -55,7 +80,6 @@
   &:not(:focus-within) {
     color: $input-placeholder-color;
   }
-
 }
 
 .popover.offline-search-result {

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -1,117 +1,120 @@
 // Search
 
 .td-search {
-  background: transparent;
-  position: relative;
-  width: 90%;
+    background: transparent;
+    position: relative;
+    width: 90%;
 
-  // Search icon
-  &__icon {
-    // Vertically center the content.
-    display: flex;
-    align-items: center;
-    height: 100%;
+    // Search icon
+    &__icon {
+        // Vertically center the content.
+        display: flex;
+        align-items: center;
+        height: 100%;
 
-    // Position this on the left of the input.
-    position: absolute;
-    left: 0.75em;
+        // Position this on the left of the input.
+        position: absolute;
+        left: 0.75em;
 
-    // Click-through to the underlying input.
-    pointer-events: none;
+        // Click-through to the underlying input.
+        pointer-events: none;
 
-    &:before {
-      @extend .fa;
-      content: fa-content($fa-var-search);
-    }
-
-    // Styling adjustments for the navbar
-    @at-root {
-      .td-navbar & {
-        color: $navbar-dark-color;
-      }
-    }
-  }
-
-  // Search input element
-  &__input {
-    width: 100%;
-    text-indent: 1.25em;
-
-    @if $enable-rounded {
-      border-radius: 1rem;
-    }
-
-    &:not(:focus) {
-      background: transparent;
-    }
-
-    &.form-control:focus {
-      border-color: lighten($primary, 60%);
-      box-shadow: 0 0 0 2px lighten($primary, 30%);
-      color: inherit;
-    }
-
-    // Styling adjustments for the navbar
-    @at-root {
-      .td-navbar & {
-        border: none;
-        color: $navbar-dark-color;
-
-        @include placeholder {
-          color: $navbar-dark-color;
+        &:before {
+            @extend .fa;
+            content: fa-content($fa-var-search);
         }
-      }
+
+        // Styling adjustments for the navbar
+        @at-root {
+            .td-navbar & {
+                color: $navbar-dark-color;
+            }
+        }
     }
 
-  }
+    // Search input element
+    &__input {
+        width: 100%;
+        text-indent: 1.25em;
 
-  // Hide icon on focus
-  &:focus-within {
+        @if $enable-rounded {
+            border-radius: 1rem;
+        }
 
-    .td-search__icon {
-      display: none;
+        &:not(:focus) {
+            background: transparent;
+        }
+
+        &.form-control:focus {
+            border-color: lighten($primary, 60%);
+            box-shadow: 0 0 0 2px lighten($primary, 30%);
+            color: inherit;
+        }
+
+        // Styling adjustments for the navbar
+        @at-root {
+            .td-navbar & {
+                border: none;
+                color: $navbar-dark-color;
+
+                @include placeholder {
+                    color: $navbar-dark-color;
+                }
+            }
+        }
+
     }
 
-    .td-search-input {
-      text-indent: 0px;
-    }
-  }
+    // Hide icon on focus
+    &:focus-within {
 
-  &:not(:focus-within) {
-    color: $input-placeholder-color;
-  }
+        .td-search__icon {
+            display: none;
+        }
+
+        .td-search-input {
+            text-indent: 0px;
+        }
+    }
+
+    &:not(:focus-within) {
+        color: $input-placeholder-color;
+    }
 }
 
 // Offline search
 
 .td-search--offline {
-  &:focus-within {
-    // Don't hide the search icon on focus: this gives better UX when user
-    // explores content of search-results popup and focus is lost.
-    .td-search__icon {
-      display: flex;
-      color: $input-placeholder-color;
+
+    &:focus-within {
+        // Don't hide the search icon on focus: this gives better UX when user
+        // explores content of search-results popup and focus is lost.
+
+        .td-search__icon {
+            display: flex;
+            color: $input-placeholder-color;
+        }
     }
-  }
 }
 
 .td-offline-search-results {
-  max-width: 90%;
+    max-width: 90%;
 
-  .card {
-    margin-bottom: $spacer * .5;
+    .card {
+        margin-bottom: $spacer * .5;
 
-    .card-header {
-      font-weight: bold;
+        .card-header {
+            font-weight: bold;
+        }
     }
-  }
 
-  &__close-button {
-    // cursor: pointer;
-    float: right;
-    &:after {
-      @extend .fas;
-      content: fa-content($fa-var-times);
+    &__close-button {
+        // cursor: pointer;
+        float: right;
+
+        &:after {
+            @extend .fas;
+            content: fa-content($fa-var-times);
+        }
     }
-  }
 }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -82,8 +82,20 @@
   }
 }
 
-.popover.offline-search-result {
-  // Override bootstrap default style (max-width: $popover-max-width;)
+// Offline search
+
+.td-search--offline {
+  &:focus-within {
+    // Don't hide the search icon on focus: this gives better UX when user
+    // explores content of search-results popup and focus is lost.
+    .td-search__icon {
+      display: flex;
+      color: $input-placeholder-color;
+    }
+  }
+}
+
+.td-offline-search-results {
   max-width: 90%;
 
   .card {
@@ -91,6 +103,15 @@
 
     .card-header {
       font-weight: bold;
+    }
+  }
+
+  &__close-button {
+    // cursor: pointer;
+    float: right;
+    &:after {
+      @extend .fas;
+      content: fa-content($fa-var-times);
     }
   }
 }

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -1,38 +1,15 @@
 // Search
+
 .td-search-wrapper {
-    position: relative;
-    background: transparent;
-    width: 90%;
-}
+  position: relative;
+  background: transparent;
+  width: 90%;
 
-.td-search-wrapper:not(:focus-within) {
-    color: $input-placeholder-color;
-}
-
-.td-search-wrapper .td-search-input:not(:focus) {
-    background: transparent;
-}
-
-.td-search-wrapper .td-search-input {
-    width: 100%;
-    text-indent: 1.25em;
-
-    &.form-control:focus {
-        border-color: lighten($primary, 60%);
-        box-shadow: 0 0 0 2px lighten($primary, 30%);
-        color: inherit;
-    }
-
-    @if $enable-rounded {
-        border-radius: 1rem;
-    }
-}
-
-.td-search-wrapper .fa {
+  .fa {
     // Vertically center the content.
     display: flex;
     justify-content: center;
-    align-items:center;
+    align-items: center;
     height: 100%;
 
     // Position this on the left of the input.
@@ -41,26 +18,55 @@
 
     // Click-through to the underlying input.
     pointer-events: none;
-}
+  }
 
-// Hide the icon on focus.
-.td-search-wrapper:focus-within .fa {
-    display: none;
-}
+  .td-search-input {
+    width: 100%;
+    text-indent: 1.25em;
 
-.td-search-wrapper:focus-within .td-search-input {
-   text-indent: 0px;
+    @if $enable-rounded {
+      border-radius: 1rem;
+    }
+
+    &:not(:focus) {
+      background: transparent;
+    }
+
+    &.form-control:focus {
+      border-color: lighten($primary, 60%);
+      box-shadow: 0 0 0 2px lighten($primary, 30%);
+      color: inherit;
+    }
+
+  }
+
+  &:focus-within {
+    // Hide icon on focus
+
+    .fa {
+      display: none;
+    }
+
+    .td-search-input {
+      text-indent: 0px;
+    }
+  }
+
+  &:not(:focus-within) {
+    color: $input-placeholder-color;
+  }
+
 }
 
 .popover.offline-search-result {
-    // Override bootstrap default style (max-width: $popover-max-width;)
-    max-width: 90%;
+  // Override bootstrap default style (max-width: $popover-max-width;)
+  max-width: 90%;
 
-    .card {
-        margin-bottom: $spacer * .5;
+  .card {
+    margin-bottom: $spacer * .5;
 
-        .card-header {
-            font-weight: bold;
-        }
+    .card-header {
+      font-weight: bold;
     }
+  }
 }

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.gcs_engine_id -}}
 <div class="td-search-wrapper">
-<i class="fa fa-search"></i>
-<input type="search" class="form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+  <i class="fa fa-search"></i>
+  <input type="search" class="form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 </div>
 {{ else if .Site.Params.algolia_docsearch -}}
 <div id="docsearch"></div>

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.gcs_engine_id -}}
-<div class="td-search-wrapper">
-  <i class="fa fa-search"></i>
-  <input type="search" class="form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+<div class="td-search">
+  <div class="td-search__icon"></div>
+  <input type="search" class="td-search__input form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 </div>
 {{ else if .Site.Params.algolia_docsearch -}}
 <div id="docsearch"></div>
@@ -13,10 +13,11 @@
 {{ end -}}
 {{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
 
+<div class="td-search">
 <input
   type="search"
-  class="form-control td-search-input"
-  placeholder="&#xf002; {{ T "ui_search" }}"
+  class="td-search__input form-control"
+  placeholder="{{ T "ui_search" }}"
   aria-label="{{ T "ui_search" }}"
   autocomplete="off"
   {{/*
@@ -30,4 +31,5 @@
   data-offline-search-base-href="/"
   data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
 >
+</div>
 {{ end -}}

--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -13,23 +13,24 @@
 {{ end -}}
 {{ $offlineSearchLink := $offlineSearchIndex.RelPermalink -}}
 
-<div class="td-search">
-<input
-  type="search"
-  class="td-search__input form-control"
-  placeholder="{{ T "ui_search" }}"
-  aria-label="{{ T "ui_search" }}"
-  autocomplete="off"
-  {{/*
-    The data attribute name of the json file URL must end with `src` since
-    Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
-    If the absurlreplacer is not applied, the URL will start with `/`.
-    It causes the json file loading error when when relativeURLs is enabled.
-    https://github.com/google/docsy/issues/181
-  */}}
-  data-offline-search-index-json-src="{{ $offlineSearchLink }}"
-  data-offline-search-base-href="/"
-  data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
->
+<div class="td-search td-search--offline">
+  <div class="td-search__icon"></div>
+  <input
+    type="search"
+    class="td-search__input form-control"
+    placeholder="{{ T "ui_search" }}"
+    aria-label="{{ T "ui_search" }}"
+    autocomplete="off"
+    {{/*
+      The data attribute name of the json file URL must end with `src` since
+      Hugo's absurlreplacer requires `src`, `href`, `action` or `srcset` suffix for the attribute name.
+      If the absurlreplacer is not applied, the URL will start with `/`.
+      It causes the json file loading error when when relativeURLs is enabled.
+      https://github.com/google/docsy/issues/181
+    */}}
+    data-offline-search-index-json-src="{{ $offlineSearchLink }}"
+    data-offline-search-base-href="/"
+    data-offline-search-max-results="{{ .Site.Params.offlineSearchMaxResults | default 10 }}"
+  >
 </div>
 {{ end -}}

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -491,10 +491,8 @@ The width of the search results popover will automatically widen according to th
 If you want to limit the width, add the following scss into `assets/scss/_variables_project.scss`.
 
 ```scss
-body {
-    .popover.offline-search-result {
-        max-width: 460px;
-    }
+.td-offline-search-results {
+  max-width: 460px;
 }
 ```
 


### PR DESCRIPTION
- Contributes to #783
- Followup to #1247, refactors the search styles, with some cleanup; renamed `td-search-wrapper` to just `td-search`, then followed BEM for the icon and input elements.
- Closes #1256 by fixing the search-box styling for offline search.

@geriom @LisaFC @mkruskal-google - if y'all could **double check** via the [**preview**](https://deploy-preview-1279--docsydocs.netlify.app) that the **styling for online search** hasn't changed, that would be grand.

/cc @tekezo for the offline search changes.

---

### Screenshots for offline search

Base styling for offline search is just like online search:

> <img width="1076" alt="Screen Shot 2022-10-13 at 06 35 44" src="https://user-images.githubusercontent.com/4140793/195578196-c3ba473d-884f-4943-8931-8c1628eba402.png">

Side-nav offline search results:

> <img width="670" alt="Screen Shot 2022-10-13 at 06 35 22" src="https://user-images.githubusercontent.com/4140793/195578275-b2f27087-471c-4a64-8be3-ba75db70a019.png">

Top-nav offline search results:

> <img width="505" alt="Screen Shot 2022-10-13 at 06 34 56" src="https://user-images.githubusercontent.com/4140793/195578344-48f37ea4-d9fd-4d1e-a260-cdf5d6b35359.png">

I created the screenshots shown above by enabling offline search in the user guide through these config edits:

```diff
--- a/userguide/config.yaml
+++ b/userguide/config.yaml
@@ -58,9 +58,9 @@ params:
   time_format_blog: Monday, January 02, 2006
   time_format_default: January 2, 2006
   rss_sections: [blog] # TODO: drop since this is the default
-  gcs_engine_id: 011217106833237091527:la2vtv2emlw
+  # gcs_engine_id: 011217106833237091527:la2vtv2emlw
   algolia_docsearch: false
-  offlineSearch: false
+  offlineSearch: true
   offlineSearchSummaryLength: 70
   offlineSearchMaxResults: 10
   prism_syntax_highlighting: false
```