### PR TITLE
Fix: Tabpane shows multiple tabs at the same time

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -1,14 +1,17 @@
 .tab-content {
-  .highlight {
-    margin: 0rem 0 2rem 0;
+  .tab-pane {
+    pre {
+      margin: 0rem 0 0rem 0;
+    }
   }
 }
+
 .tab-content {
   .tab-pane {
     .highlight {
-    margin: 0rem 0 0rem 0;
-    border: none;
-    max-width: 100%;
+      margin: 0rem 0 0rem 0;
+      border: none;
+      max-width: 100%;
     }
     margin-top: 0rem;
     margin-bottom: 1.5rem;
@@ -16,7 +19,7 @@
     border-left: 1px solid rgba(0, 0, 0, 0.125);
     border-right: 1px solid rgba(0, 0, 0, 0.125);
     border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-    }
+  }
 }
 
 .tab-body {
@@ -27,10 +30,9 @@
   padding: 1.5rem;
 
   @each $color, $value in $theme-colors {
-      &-#{$color} {
-
-          border-style: solid;
-          border-color: $value;
-      }
+    &-#{$color} {
+      border-style: solid;
+      border-color: $value;
+    }
   }
 }

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -1,3 +1,8 @@
+{{/* Store ordinal, to be retrieved by parent element */}}
+{{ if ge hugo.Version "0.93.0" }}
+  {{ .Page.Store.Add "Ordinal" 1 }}
+{{ end }}
+
 {{/* Handle the "file" named parameter or a single unnamed parameter as the file
 path */}}
 {{ if .IsNamedParams }}
@@ -24,10 +29,10 @@ if the file is not found */}}
 
 {{ if fileExists ($.Scratch.Get "filepath") }}
   {{ if eq (.Get "code") "true" }}
-    {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape | 
+    {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape |
     safeHTML ) (.Get "lang") "" -}}
   {{ else }}
-    {{- $.Scratch.Get "filepath" | readFile | .Page.RenderString | htmlUnescape | safeHTML -}}
+    {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | htmlUnescape | safeHTML -}}
   {{ end }}
 {{ else }}
 

--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -1,52 +1,52 @@
-<!-- Make sure that we are enclosed within a tabpane shortcode block -->
-{{ with $.Parent }}
-  {{- if ne $.Parent.Name "tabpane" -}}
-    {{- errorf "shortcode 'tab' must be used within a 'tabpane' block" -}}
-  {{- end -}}
-{{- end -}}
+{{- /* Make sure that we are enclosed within a tabpane shortcode block */ -}}
+{{ with $.Parent -}}
+{{ if ne $.Parent.Name "tabpane" -}}
+    {{ errorf "shortcode 'tab' must be used within a 'tabpane' block" -}}
+  {{ end -}}
+{{ end -}}
 
-{{ $header := "Tab" }}
-{{ if and (not .IsNamedParams) (.Get 0) }}
-  {{ $header = (.Get 0) }}
-{{ else }}
-  <!-- Prefill header if not given as named or unnamed parameter -->
-  {{ $header = default (printf "Tab %v" ( add $.Ordinal 1)) (.Get "header") }}
-{{ end }}
+{{ $header := "Tab" -}}
+{{ if and (not .IsNamedParams) (.Get 0) -}}
+  {{ $header = (.Get 0) -}}
+{{ else -}}
+  {{/* Prefill header if not given as named or unnamed parameter */ -}}
+  {{ $header = default (printf "Tab %v" ( add $.Ordinal 1)) (.Get "header") -}}
+{{ end -}}
 
-<!-- store all tab info in dict tab -->
-{{ $tab := dict "header" $header }}
-{{ with $.Get "lang" }}
-  {{ $tab = merge $tab (dict "language" ($.Get "lang")) }}
-{{ end }}
-{{ with $.Get "highlight" }}
-  {{ $tab = merge $tab (dict "highlight" ($.Get "highlight")) }}
-{{ end }}
-{{ with $.Get "text" }}
-  {{ if ne ( printf "%T" . ) "bool" }}
-  {{- errorf "shortcode tab: parameter 'text' must be either true or false" -}}
-  {{ end }}
-  {{ $tab = merge $tab (dict "text" ($.Get "text")) }}
-{{ end }}
-{{ with $.Get "right" }}
-  {{ if ne ( printf "%T" . ) "bool" }}
-  {{- errorf "shortcode tab: parameter 'right' must be either true or false" -}}
-  {{ end }}
-  {{ $tab = merge $tab (dict "rightpush" ($.Get "right")) }}
-{{ end }}
-{{ with $.Get "disabled" }}
-  {{ if ne ( printf "%T" . ) "bool" }}
-  {{- errorf "shortcode tab: parameter 'disabled' must be either true or false" -}}
-  {{ end }}
-  {{ $tab = merge $tab (dict "disabled" ($.Get "disabled")) }}
-{{ end }}
+{{/* store all tab info in dict tab */ -}}
+{{ $tab := dict "header" $header -}}
+{{ with $.Get "lang" -}}
+  {{ $tab = merge $tab (dict "language" ($.Get "lang")) -}}
+{{ end -}}
+{{ with $.Get "highlight" -}}
+  {{ $tab = merge $tab (dict "highlight" ($.Get "highlight")) -}}
+{{ end -}}
+{{ with $.Get "text" -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+  {{ errorf "shortcode tab: parameter 'text' must be either true or false" -}}
+  {{ end -}}
+  {{ $tab = merge $tab (dict "text" ($.Get "text")) -}}
+{{ end -}}
+{{ with $.Get "right" -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+  {{ errorf "shortcode tab: parameter 'right' must be either true or false" -}}
+  {{ end -}}
+  {{ $tab = merge $tab (dict "rightpush" ($.Get "right")) -}}
+{{ end -}}
+{{ with $.Get "disabled" -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+  {{ errorf "shortcode tab: parameter 'disabled' must be either true or false" -}}
+  {{ end -}}
+  {{ $tab = merge $tab (dict "disabled" ($.Get "disabled")) -}}
+{{ end -}}
 
-{{ with $.Inner }}
-  <!-- Trim any leading and trailing newlines from .Inner, this avoids
-       spurious lines during syntax highlighting -->
-  {{ $tab = merge $tab (dict "content" $.Inner ) }}
-{{ end }}
+{{ with $.Inner -}}
+  {{/* Trim any leading and trailing newlines from .Inner, this avoids
+       spurious lines during syntax highlighting */ -}}
+  {{ $tab = merge $tab (dict "content" $.Inner) -}}
+{{ end -}}
 
-<!-- add dict tab to parent's scratchpad -->
-{{ with .Parent }}
-  {{- $.Parent.Scratch.SetInMap "tabs" (printf "%02v" $.Ordinal) $tab -}}
-{{ end }}
+{{/* add dict tab to parent's scratchpad */ -}}
+{{ with .Parent -}}
+  {{ $.Parent.Scratch.SetInMap "tabs" (printf "%02v" $.Ordinal) $tab -}}
+{{ end -}}

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -38,7 +38,14 @@
 {{ $duplicate := false -}}
 {{ $duplicateLang := "" -}}
 
-<ul class="nav nav-tabs{{ if $rightPane }} justify-content-end{{ end }}" id="tabs-{{- $.Ordinal -}}" role="tablist">
+{{ $Ordinal := $.Ordinal -}}
+{{ if ge hugo.Version "0.93.0" -}}
+  {{ if .Page.Store.Get "Ordinal" -}}
+    {{ $Ordinal = .Page.Store.Get "Ordinal" -}}
+  {{end -}}
+{{ end -}}
+
+<ul class="nav nav-tabs{{ if $rightPane }} justify-content-end{{ end }}" id="tabs-{{- $Ordinal -}}" role="tablist">
   {{ range $index, $element := $.Scratch.Get "tabs" -}}
 
     {{ $disabled := false -}}
@@ -74,8 +81,8 @@
     {{ $lang := replaceRE "[\\s+]" "-" $lang -}}
     <li class="nav-item{{ if $rightpush }} ml-auto{{ end -}}">
       {{/* Generate the IDs for the <a> and the <div> elements */ -}}
-      {{ $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
-      {{ $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize -}}
+      {{ $tabid := printf "tabs-%02v-%v-tab" $Ordinal $index | anchorize -}}
+      {{ $entryid := printf "tabs-%02v-%v" $Ordinal $index | anchorize -}}
 
       <a class="nav-link{{ if and ( not $activeSet ) ( not $disabled ) }} active{{ end }}{{ if $disabled }} disabled{{ end }}{{ if ne $lang "" }}{{ if and $persistLang (not $duplicate) }} persistLang-{{- $lang -}}{{ end }}{{ end }}"
           id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
@@ -100,7 +107,7 @@
 {{ $activeSet = false -}}
 
 {{/* Inner content */ -}}
-<div class="tab-content" id="tabs-{{ $.Ordinal }}-content">
+<div class="tab-content" id="tabs-{{ $Ordinal }}-content">
   {{- range $index, $element := $.Scratch.Get "tabs" -}}
 
     {{ $lang := $langPane -}}
@@ -126,8 +133,8 @@
       {{ $text = . }}
     {{ end -}}
 
-    {{ $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
-    {{ $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize }}
+    {{ $tabid := printf "tabs-%02v-%v-tab" $Ordinal $index | anchorize -}}
+    {{ $entryid := printf "tabs-%02v-%v" $Ordinal $index | anchorize }}
     <div class="{{ if $text }}tab-body {{end}}tab-pane fade{{ if and ( not $activeSet ) ( not $disabled ) }} show active{{ end }}"
         id="{{ $entryid }}" role="tabpanel" aria-labelled-by="{{ $tabid }}">
         {{ if $text -}}

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -1,130 +1,127 @@
-<!-- Check parameter types -->
-{{ with .Get "langEqualsHeader"  }}
-{{ if ne ( printf "%T" . ) "bool" }}
-{{- errorf "shortcode tabpane: parameter 'langEqualsHeader' must be either true or false" -}}
-{{ end }}
-{{ end }}
+{{/* Check parameter types */ -}}
+{{ with .Get "langEqualsHeader" -}}
+{{ if ne ( printf "%T" . ) "bool" -}}
+{{ errorf "shortcode tabpane: parameter 'langEqualsHeader' must be either true or false" -}}
+{{ end -}}
+{{ end -}}
 
-{{ with .Get "text"  }}
-{{ if ne ( printf "%T" . ) "bool" }}
-{{- errorf "shortcode tabpane: parameter 'text' must be either true or false" -}}
-{{ end }}
-{{ end }}
+{{ with .Get "text" -}}
+{{ if ne ( printf "%T" . ) "bool" -}}
+{{ errorf "shortcode tabpane: parameter 'text' must be either true or false" -}}
+{{ end -}}
+{{ end -}}
 
-{{ with .Get "persistLang"  }}
-{{ if ne ( printf "%T" . ) "bool" }}
-{{- errorf "shortcode tabpane: parameter 'persistLang' must be either true or false" -}}
-{{ end }}
-{{ end }}
+{{ with .Get "persistLang" -}}
+{{ if ne ( printf "%T" . ) "bool" -}}
+{{ errorf "shortcode tabpane: parameter 'persistLang' must be either true or false" -}}
+{{ end -}}
+{{ end -}}
 
-{{ with .Get "right"  }}
-{{ if ne ( printf "%T" . ) "bool" }}
-{{- errorf "shortcode tabpane: parameter 'right' must be either true or false" -}}
-{{ end }}
-{{ end }}
+{{ with .Get "right" -}}
+{{ if ne ( printf "%T" . ) "bool" -}}
+{{ errorf "shortcode tabpane: parameter 'right' must be either true or false" -}}
+{{ end -}}
+{{ end -}}
 
-<!-- Set values given defined within tabpane -->
-{{- $langPane := default "" ($.Get "lang") -}}
-{{- $hloptionsPane := default "" ($.Get "highlight") -}}
-{{- $textPane := default false ($.Get "text") -}}
-{{- $langEqualsHeader := default false ($.Get "langEqualsHeader") -}}
-{{- $persistLang := default true ($.Get "persistLang") -}}
-{{- $rightPane := default false ($.Get "right") -}}
-{{- $disabled := false -}}
-{{- $rightpush := false -}}
-{{- $activeSet := false -}}
-
-<!-- Scratchpad gets populated through call to .Inner -->
+{{/* Set values given defined within tabpane */ -}}
+{{ $langPane := default "" ($.Get "lang") -}}
+{{ $hloptionsPane := default "" ($.Get "highlight") -}}
+{{ $textPane := default false ($.Get "text") -}}
+{{ $langEqualsHeader := default false ($.Get "langEqualsHeader") -}}
+{{ $persistLang := default true ($.Get "persistLang") -}}
+{{ $rightPane := default false ($.Get "right") -}}
+{{ $disabled := false -}}
+{{ $rightpush := false -}}
+{{ $activeSet := false -}}
+{{- /* Scratchpad gets populated through call to .Inner */ -}}
 {{- .Inner -}}
 
 <ul class="nav nav-tabs{{ if $rightPane }} justify-content-end{{ end }}" id="tabs-{{- $.Ordinal -}}" role="tablist">
-  {{- range $index, $element := $.Scratch.Get "tabs" -}}
+  {{ range $index, $element := $.Scratch.Get "tabs" -}}
 
-    {{- $lang := $langPane -}}
-    {{- if $langEqualsHeader -}}
-      {{- $lang = $element.header -}}
-    {{end}}
-    {{- with $element.language -}}
-      {{- $lang = $element.language -}}
-    {{- end -}}
+    {{ $lang := $langPane -}}
+    {{ if $langEqualsHeader -}}
+      {{ $lang = $element.header -}}
+    {{ end -}}
+    {{ with $element.language -}}
+      {{ $lang = $element.language -}}
+    {{ end -}}
 
-    {{- $disabled := false -}}
-    {{- with $element.disabled -}}
-      {{- $disabled = . }}
-    {{- end -}}
+    {{ $disabled := false -}}
+    {{ with $element.disabled -}}
+      {{ $disabled = . -}}
+    {{ end -}}
 
-    {{- $rightpush := false -}}
-    {{- with $element.rightpush -}}
-      {{- $rightpush = . }}
-    {{- end -}}
+    {{ $rightpush := false -}}
+    {{ with $element.rightpush -}}
+      {{ $rightpush = . -}}
+    {{ end -}}
 
-    <!-- Replace space and +, not valid for css selectors -->
-    {{- $lang := replaceRE "[\\s+]" "-" $lang -}}
-
-    <li class="nav-item{{ if $rightpush }} ml-auto{{ end }}">
-      <!-- Generate the IDs for the <a> and the <div> elements -->
-      {{- $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
-      {{- $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize -}}
+    {{/* Replace space and +, not valid for css selectors */ -}}
+    {{ $lang := replaceRE "[\\s+]" "-" $lang -}}
+    <li class="nav-item{{ if $rightpush }} ml-auto{{ end -}}">
+      {{/* Generate the IDs for the <a> and the <div> elements */ -}}
+      {{ $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
+      {{ $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize -}}
 
       <a class="nav-link{{ if and ( not $activeSet ) ( not $disabled ) }} active{{ end }}{{ if $disabled }} disabled{{ end }}{{ if ne $lang "" }}{{ if $persistLang }} persistLang-{{- $lang -}}{{ end }}{{ end }}"
-          id="{{- $tabid -}}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
-          {{ if ne $lang "" }}{{- if $persistLang -}}onclick="persistLang({{- $lang -}});"{{end}}{{end}}
-        aria-controls="{{- $entryid -}}" aria-selected="{{- and ( not $activeSet ) ( not $disabled ) "true" "false" -}}">
-        {{- index . "header" | markdownify -}}
+          id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
+          {{ if ne $lang "" }}{{ if $persistLang }}onclick="persistLang({{ $lang }});"{{ end }}{{ end -}}
+          aria-controls="{{- $entryid -}}" aria-selected="{{- and ( not $activeSet ) ( not $disabled ) "true" "false" -}}">
+        {{ index . "header" | markdownify }}
       </a>
     </li>
 
-    {{ if not $disabled }}
-      {{ $activeSet = true }}
-    {{ end }}
+    {{- if not $disabled -}}
+      {{ $activeSet = true -}}
+    {{ end -}}
 
-  {{- end -}}
+  {{- end }}
 </ul>
 
-{{ $activeSet = false }}
+{{ $activeSet = false -}}
 
-<!-- Inner content -->
-<div class="tab-content" id="tabs-{{- $.Ordinal -}}-content">
+{{/* Inner content */ -}}
+<div class="tab-content" id="tabs-{{ $.Ordinal }}-content">
   {{- range $index, $element := $.Scratch.Get "tabs" -}}
 
-    {{- $lang := $langPane -}}
-    {{- if $langEqualsHeader -}}
-      {{- $lang = $element.header -}}
-    {{end}}
-    {{- with $element.language -}}
-      {{- $lang = $element.language -}}
-    {{- end -}}
+    {{ $lang := $langPane -}}
+    {{ if $langEqualsHeader -}}
+      {{ $lang = $element.header -}}
+    {{ end -}}
+    {{ with $element.language -}}
+      {{ $lang = $element.language -}}
+    {{ end -}}
 
-    {{- $disabled := false -}}
-    {{- with $element.disabled -}}
-      {{- $disabled = . }}
-    {{- end -}}
+    {{ $disabled := false -}}
+    {{ with $element.disabled -}}
+      {{ $disabled = . -}}
+    {{ end -}}
 
-    {{- $hloptions := $hloptionsPane -}}
-    {{- with $element.highlight -}}
-      {{- $hloptions = $element.highlight -}}
-    {{- end -}}
+    {{ $hloptions := $hloptionsPane -}}
+    {{ with $element.highlight -}}
+      {{ $hloptions = $element.highlight -}}
+    {{ end -}}
 
-    {{- $text := $textPane -}}
-    {{- with $element.text -}}
-      {{- $text = . }}
-    {{- end -}}
+    {{ $text := $textPane -}}
+    {{ with $element.text -}}
+      {{ $text = . }}
+    {{ end -}}
 
-    {{- $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
-    {{- $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize -}}
-
+    {{ $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
+    {{ $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize }}
     <div class="{{ if $text }}tab-body {{end}}tab-pane fade{{ if and ( not $activeSet ) ( not $disabled ) }} show active{{ end }}"
         id="{{ $entryid }}" role="tabpanel" aria-labelled-by="{{ $tabid }}">
-        {{ if $text }}
-          {{- index . "content" -}}
-        {{- else -}}
-          {{- highlight (trim (index . "content") "\n") $lang $hloptions -}}
-        {{- end -}}
+        {{ if $text -}}
+          {{ index . "content" -}}
+        {{ else -}}
+          {{ highlight (trim (index . "content") "\n") $lang $hloptions -}}
+        {{ end }}
     </div>
 
-    {{ if not $disabled }}
-      {{ $activeSet = true }}
-    {{ end }}
+    {{- if not $disabled -}}
+      {{ $activeSet = true -}}
+    {{ end -}}
 
-  {{ end }}
+  {{- end }}
 </div>

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -1,26 +1,26 @@
 {{/* Check parameter types */ -}}
 {{ with .Get "langEqualsHeader" -}}
-{{ if ne ( printf "%T" . ) "bool" -}}
-{{ errorf "shortcode tabpane: parameter 'langEqualsHeader' must be either true or false" -}}
-{{ end -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+    {{ errorf "shortcode tabpane: parameter 'langEqualsHeader' must be either true or false" -}}
+  {{ end -}}
 {{ end -}}
 
 {{ with .Get "text" -}}
-{{ if ne ( printf "%T" . ) "bool" -}}
-{{ errorf "shortcode tabpane: parameter 'text' must be either true or false" -}}
-{{ end -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+    {{ errorf "shortcode tabpane: parameter 'text' must be either true or false" -}}
+  {{ end -}}
 {{ end -}}
 
 {{ with .Get "persistLang" -}}
-{{ if ne ( printf "%T" . ) "bool" -}}
-{{ errorf "shortcode tabpane: parameter 'persistLang' must be either true or false" -}}
-{{ end -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+    {{ errorf "shortcode tabpane: parameter 'persistLang' must be either true or false" -}}
+  {{ end -}}
 {{ end -}}
 
 {{ with .Get "right" -}}
-{{ if ne ( printf "%T" . ) "bool" -}}
-{{ errorf "shortcode tabpane: parameter 'right' must be either true or false" -}}
-{{ end -}}
+  {{ if ne ( printf "%T" . ) "bool" -}}
+    {{ errorf "shortcode tabpane: parameter 'right' must be either true or false" -}}
+  {{ end -}}
 {{ end -}}
 
 {{/* Set values given defined within tabpane */ -}}
@@ -30,14 +30,21 @@
 {{ $langEqualsHeader := default false ($.Get "langEqualsHeader") -}}
 {{ $persistLang := default true ($.Get "persistLang") -}}
 {{ $rightPane := default false ($.Get "right") -}}
-{{ $disabled := false -}}
-{{ $rightpush := false -}}
 {{ $activeSet := false -}}
 {{- /* Scratchpad gets populated through call to .Inner */ -}}
 {{- .Inner -}}
 
+{{ $langs := slice -}}
+{{ $duplicate := false -}}
+{{ $duplicateLang := "" -}}
+
 <ul class="nav nav-tabs{{ if $rightPane }} justify-content-end{{ end }}" id="tabs-{{- $.Ordinal -}}" role="tablist">
   {{ range $index, $element := $.Scratch.Get "tabs" -}}
+
+    {{ $disabled := false -}}
+    {{ with $element.disabled -}}
+      {{ $disabled = . -}}
+    {{ end -}}
 
     {{ $lang := $langPane -}}
     {{ if $langEqualsHeader -}}
@@ -47,9 +54,15 @@
       {{ $lang = $element.language -}}
     {{ end -}}
 
-    {{ $disabled := false -}}
-    {{ with $element.disabled -}}
-      {{ $disabled = . -}}
+    {{/* Check for duplicate languages */ -}}
+    {{ if and $persistLang (not $duplicate) -}}
+      {{ if and (not $disabled) (ne $lang "") -}}
+        {{ $langs = $langs | append $lang -}}
+      {{ end -}}
+      {{ if ne $langs (uniq $langs) -}}
+        {{ $duplicate = true -}}
+        {{ $duplicateLang = $lang -}}
+      {{ end -}}
     {{ end -}}
 
     {{ $rightpush := false -}}
@@ -64,9 +77,9 @@
       {{ $tabid := printf "tabs-%02v-%v-tab" $.Ordinal $index | anchorize -}}
       {{ $entryid := printf "tabs-%02v-%v" $.Ordinal $index | anchorize -}}
 
-      <a class="nav-link{{ if and ( not $activeSet ) ( not $disabled ) }} active{{ end }}{{ if $disabled }} disabled{{ end }}{{ if ne $lang "" }}{{ if $persistLang }} persistLang-{{- $lang -}}{{ end }}{{ end }}"
+      <a class="nav-link{{ if and ( not $activeSet ) ( not $disabled ) }} active{{ end }}{{ if $disabled }} disabled{{ end }}{{ if ne $lang "" }}{{ if and $persistLang (not $duplicate) }} persistLang-{{- $lang -}}{{ end }}{{ end }}"
           id="{{ $tabid }}" data-toggle="tab" href="#{{ $entryid }}" role="tab"
-          {{ if ne $lang "" }}{{ if $persistLang }}onclick="persistLang({{ $lang }});"{{ end }}{{ end -}}
+          {{ if ne $lang "" }}{{ if and $persistLang (not $duplicate) }}onclick="persistLang({{ $lang }});"{{ end }}{{ end -}}
           aria-controls="{{- $entryid -}}" aria-selected="{{- and ( not $activeSet ) ( not $disabled ) "true" "false" -}}">
         {{ index . "header" | markdownify }}
       </a>
@@ -79,6 +92,11 @@
   {{- end }}
 </ul>
 
+{{ if $duplicate -}}
+  {{ warnf "Tabpane on page '%s': duplicate language '%s' detected, disabling persistance of language to avoid multiple tab display." .Page.Title $duplicateLang  -}}
+{{ end -}}
+{{ $duplicate = false -}}
+{{ $langs = slice -}}
 {{ $activeSet = false -}}
 
 {{/* Inner content */ -}}

--- a/userguide/content/en/docs/Language/_index.md
+++ b/userguide/content/en/docs/Language/_index.md
@@ -98,7 +98,7 @@ If you configure more than one language in `config.toml`, the Docsy theme adds a
 
 ## Internationalization bundles
 
-All UI strings (text for buttons etc.) are bundled inside `/i18n` in the theme, with a `.toml` file for each language. 
+All UI strings (text for buttons etc.) are bundled inside `/i18n` in the theme, with a `.toml` file for each language.
 
 If your chosen language isn't currently in the theme and you create your own `.toml` file for all the common UI strings (for example, if you translate the UI text into Japanese and create a copy of `en.toml` called `jp.toml`), we recommend you do this **in the theme** rather than in your own project, so it can be reused by others. Any additional strings or overridden values can be added to your project's `/i18n` folder.
 

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -403,7 +403,7 @@ The Docsy template provides two shortcodes `tabpane` and `tab` that let you easi
   {{%/* /tab */%}}
   {{</* tab header="German" lang="de" */>}}
     <b>Herzlich willkommen!</b>
-    <img src="flags/de.png" style="float: right; padding: 0 0 0 0px">
+    <img src="flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
   {{</* /tab */>}}
   {{%/* tab header="Swahili" lang="sw" */%}}
   ![Flag Tanzania](flags/tz.png)
@@ -422,7 +422,7 @@ This code translates to the right aligned tabbed pane below, showing a `Welcome!
   {{% /tab %}}
   {{< tab header="German" lang="de" >}}
     <b>Herzlich willkommen!</b>
-    <img src="flags/de.png" style="float: right; padding: 0 0 0 0px">
+    <img src="flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
   {{< /tab >}}
   {{% tab  header="Swahili" lang="sw" %}}
   ![Flag Tanzania](flags/tz.png)

--- a/userguide/content/en/docs/adding-content/taxonomy.md
+++ b/userguide/content/en/docs/adding-content/taxonomy.md
@@ -8,7 +8,7 @@ description: >
   Structure the content using taxonomies like tags, categories, labels.
 ---
 
-Docsy supports Hugo's Taxonomies (see: https://gohugo.io/content-management/taxonomies/) in its docs and blog section. You can see the default layout and can test the behavior of the generated links on this page. 
+Docsy supports Hugo's Taxonomies (see: https://gohugo.io/content-management/taxonomies/) in its docs and blog section. You can see the default layout and can test the behavior of the generated links on this page.
 
 ## Terminology
 
@@ -125,11 +125,11 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-The settings above would only show a taxonomy cloud for `projects` and `tags` (with the headlines "Our Projects" and "Tag Cloud") in Docsy's right sidebar and the assigned terms for the taxonomies `tags` and `categories` for each page. 
+The settings above would only show a taxonomy cloud for `projects` and `tags` (with the headlines "Our Projects" and "Tag Cloud") in Docsy's right sidebar and the assigned terms for the taxonomies `tags` and `categories` for each page.
 
-To disable any taxonomy cloud you have to set the Parameter `taxonomyCloud = []` resp. if you don't want to show the assigned terms you have to set `taxonomyPageHeader = []`. 
+To disable any taxonomy cloud you have to set the Parameter `taxonomyCloud = []` resp. if you don't want to show the assigned terms you have to set `taxonomyPageHeader = []`.
 
-As default the plural label of a taxonomy is used as it cloud title. You can overwrite the default cloud title with `taxonomyCloudTitle`. But if you do so, you have to define a manual title for each enabled taxonomy cloud (`taxonomyCloud` and `taxonomyCloudTitle` must have the same length!). 
+As default the plural label of a taxonomy is used as it cloud title. You can overwrite the default cloud title with `taxonomyCloudTitle`. But if you do so, you have to define a manual title for each enabled taxonomy cloud (`taxonomyCloud` and `taxonomyCloudTitle` must have the same length!).
 
 If you don't set the parameters `taxonomyCloud` resp. `taxonomyPageHeader` the taxonomy clouds resp. assigned terms for all defined taxonomies will be generated.
 ## Partials

--- a/userguide/content/en/docs/adding-content/versioning.md
+++ b/userguide/content/en/docs/adding-content/versioning.md
@@ -14,8 +14,8 @@ to display an information banner on the archived sites.
 
 ## Adding a version drop-down menu
 
-If you add some `[params.versions]` in `config.toml`/`config.yaml`/`config.json`, the Docsy theme adds a 
-version selector drop down to the top-level menu. You specify a URL and a name 
+If you add some `[params.versions]` in `config.toml`/`config.yaml`/`config.json`, the Docsy theme adds a
+version selector drop down to the top-level menu. You specify a URL and a name
 for each version you would like to add to the menu, as in the following example:
 
 {{< tabpane persistLang=false >}}
@@ -84,7 +84,7 @@ version_menu: 'Releases'
 {{< /tab >}}
 {{< /tabpane >}}
 
-If you set the `version_menu_pagelinks` parameter to `true`, then links in the version drop-down menu 
+If you set the `version_menu_pagelinks` parameter to `true`, then links in the version drop-down menu
 point to the current page in the other version, instead of the main page.
 This can be useful if the document doesn't change much between the different versions.
 Note that if the current page doesn't exist in the other version, the link will be broken.
@@ -94,12 +94,12 @@ You can read more about Docsy menus in the guide to
 
 ## Displaying a banner on archived doc sites
 
-If you create archived snapshots for older versions of your docs, you can add a 
+If you create archived snapshots for older versions of your docs, you can add a
 note at the top of every page in the archived docs to let readers know that
-they’re seeing an unmaintained snapshot and give them a link to the latest 
+they’re seeing an unmaintained snapshot and give them a link to the latest
 version.
 
-For example, see the archived docs for 
+For example, see the archived docs for
 [Kubeflow v0.6](https://v0-6.kubeflow.org/docs/):
 
 <figure>
@@ -145,7 +145,7 @@ version: '0.1'
     {{< /tabpane >}}
 
 1. Make sure that `url_latest_version` contains the URL of the website that you
-  want to point readers to. In most cases, this should be the URL of the latest 
+  want to point readers to. In most cases, this should be the URL of the latest
   version of your docs:
 
     {{< tabpane persistLang=false >}}


### PR DESCRIPTION
This PR addresses and closes #1271. It also closes #1289 . The `tabpane` shortcode was improved in the sense it now detects if the same language is assigned to different tabs. Once a duplicate language is detected, persistance of language is disabled for the affected tabpane, By doing so, we avoid multiple tab display for that tabpane. Additionally, a warning is printed, indicating to the user that duplicate language assignment was deteceted.
Adiitonally this PR improves the whitespace handling of the shortcode, the produced html source code is correctly formatted now and can be read easily. Furthermore the PR includes a few minor fixes and improvements to the user guide.