### PR TITLE
Fix: hugo serve does not serve Font Awesome anymore #1281

### DIFF
--- a/dependencies/config.toml
+++ b/dependencies/config.toml
@@ -37,3 +37,6 @@ _merge = "deep"
 [[module.imports.mounts]]
   source = "scss"
   target = "assets/vendor/Font-Awesome/scss"
+[[module.imports.mounts]]
+  source = "webfonts"
+  target = "static/webfonts"


### PR DESCRIPTION
This PR closes #1281 by adding the neceessary mount to the module configuration.