### PR TITLE
Module setup: update docsy/dependencies to tip of main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f // indirect
-	github.com/google/docsy/dependencies v0.5.0 // indirect
+	github.com/google/docsy/dependencies v0.5.1-0.20221014161617-be5da07ecff1 // indirect
 	github.com/twbs/bootstrap v4.6.2+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f h1:bvkUptSRPZBr3Kxuk+bnWCEmQ5MtEJX5fjezyV0bC3g=
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy/dependencies v0.4.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
 github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16 h1:6Ju+wn/ReUk9qmvKU68JlYhnWe48Tq+2HZ4vyeSpNMk=
 github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
-github.com/google/docsy/dependencies v0.4.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
+github.com/google/docsy/dependencies v0.5.1-0.20221014161617-be5da07ecff1 h1:DH0NbaXJjODFImfRJGCSXDhnRO/IaD2VTGVlRjULUtc=
+github.com/google/docsy/dependencies v0.5.1-0.20221014161617-be5da07ecff1/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/twbs/bootstrap v4.6.2+incompatible h1:TDa+R51BTiy1wEHSYjmqDb8LxNl/zaEjAOpRE9Hwh/o=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
This PR is the continuation of #1281: now that we have the commit hash from this PR, we update the module `docsy/dependencies` to this commit. Thus module setup will work with tip of branch again. This eventually fixes #1281, which was closed prematurely.