### PR TITLE
Fix overlapping content for root folder pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,9 +8,11 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-default td-outer">
-      <main role="main" class="td-main">
-        {{ block "main" . }}{{ end }}
-      </main>
+      <div class="td-main">
+        <main role="main" class="td-main">
+          {{ block "main" . }}{{ end }}
+        </main>
+      </div>
       {{ partial "footer.html" . }}
     </div>
     {{ partialCached "scripts.html" . }}


### PR DESCRIPTION
If you write simple .md page in the root content folder, or an _index.md in a top level folder that doesn't map to one of the other layout styles, the content will render underneath the titlebar. This is because the scss expects the `<main>` element to be inside a div with class `td-main`.