### PR TITLE
CHANGELOG: add breaking change (tabbed panes, text display)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ notes][0.5.1]. **BREAKING CHANGES** are documented below.
 
 **Breaking changes**:
 
+- **Tabbed panes, text display**. By default, the content of a tab inside a tabbed
+  pane is shown as code. As of version 0.4 of the shortcode, you can add the
+  parameter `code=false` to your `tabpane` or `tab` shortcode  in order to render
+  tab content(s) as text (markdown or html). As of version 0.5 the name of this
+  parameter was changed, we now use `text=true` in order to mark content as text.
 - **Display logo by default**. Most projects show their logo in the navbar. In
   support of this majority, Docsy now displays a logo by default. For details on
   how to hide the logo (or your brand name), see [Styling your project logo and


### PR DESCRIPTION
Docsy version v0.5.0: for tabbed panes, the name of the parameter for textual display changed from `code=false` to `text=true`. This PR documents this breaking change in `CHANGELOG.md` (see#1295). 