### PR TITLE
Fix readfile not rendering html code

### DIFF
--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -32,7 +32,7 @@ if the file is not found */}}
     {{- highlight ($.Scratch.Get "filepath" | readFile | htmlUnescape |
     safeHTML ) (.Get "lang") "" -}}
   {{ else }}
-    {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | htmlUnescape | safeHTML -}}
+    {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
   {{ end }}
 {{ else }}
 


### PR DESCRIPTION
The current implementation unescapes html tags, which is not necessary because the output was already processed by `RenderString`. This causes html samples to not render correctly.

|  Before  | After  |
|---|---|
| ![Screenshot from 2022-11-08 11-33-47](https://user-images.githubusercontent.com/22261639/200623583-3ecd245f-2d0c-4afe-b90e-f5b2856e5c52.png)  | ![Screenshot from 2022-11-08 11-33-10](https://user-images.githubusercontent.com/22261639/200623660-9e361aaa-67d8-43ca-a856-922e4d4a29e1.png) |


