### PR TITLE
Support for Azure Repositories

### DIFF
--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,8 +1,13 @@
-{{ if and .GitInfo .Site.Params.github_repo -}}
+{{ $repo := .Site.Params.github_repo }}
+{{ if .Site.Params.azure_repo -}}
+  {{ $repo = .Site.Params.azure_repo }}
+{{ end -}}
+
+{{ if and (.GitInfo) (or (.Site.Params.github_repo) (.Site.Params.azure_repo)) -}}
 <div class="td-page-meta__lastmod">
   {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
   {{ with .GitInfo }}: {{/* Trim WS */ -}}
-    <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">
+    <a href="{{ $repo }}/commit/{{ .Hash }}">
       {{- .Subject }} ({{ .AbbreviatedHash }}) {{- /* Trim WS */ -}}
     </a>
   {{- end }}

--- a/layouts/partials/page-meta-links-azure.html
+++ b/layouts/partials/page-meta-links-azure.html
@@ -1,5 +1,4 @@
-{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
-{{ $pathFormatted := replace .File.Path "\\" "/" -}}
+{{ $path := strings.TrimPrefix (add (replace hugo.WorkingDir "\\" "/") "/") (replace $.File.Filename "\\" "/") -}}
 {{ $az_repo := ($.Param "azure_repo") -}}
 {{ $az_subdir := ($.Param "azure_subdir") -}}
 {{ $az_project_repo := ($.Param "azure_project_repo") -}}
@@ -15,14 +14,14 @@
     {{ $azs_base = $azs_base.from -}}
   {{ end -}}
   {{ with $azs_base -}}
-    {{ $path = replaceRE . $azs_rename $az_repo_path -}}
+    {{ $path = replaceRE . $azs_rename $path -}}
   {{ end -}}
 
-  {{ $az_repo_path := printf "%s/%s/%s" $az_branch $az_subdir $path -}}
+  {{ $az_repo_path := printf "%s/%s" $az_subdir $path -}}
   {{ $az_repo_path = replaceRE "//+" "/" $az_repo_path -}}
 
   {{ $baseUrl := replaceRE "/_git/.+$" "" $az_repo }}
-  {{ $viewURL := printf "%s?path=%s&_a=contents" $az_repo $az_repo_path -}}
+  {{ $viewURL := printf "%s?path=%s&version=GB%s&_a=contents" $az_repo $az_repo_path $az_branch -}}
   {{ $issuesURL := printf "%s/_workitems/create/Bug?[title]=%s" $baseUrl (safeURL $.Title ) -}}
   {{ if $az_issue_area -}}
     {{ $issuesURL = printf "%s/_workitems/create/Bug?[title]=%s&[Area Path]=%s" $baseUrl (safeURL $.Title) (safeURL $az_issue_area) -}}

--- a/layouts/partials/page-meta-links-azure.html
+++ b/layouts/partials/page-meta-links-azure.html
@@ -1,0 +1,38 @@
+{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
+{{ $pathFormatted := replace .File.Path "\\" "/" -}}
+{{ $az_repo := ($.Param "azure_repo") -}}
+{{ $az_subdir := ($.Param "azure_subdir") -}}
+{{ $az_project_repo := ($.Param "azure_project_repo") -}}
+{{ $az_branch := (default "main" ($.Param "azure_branch")) -}}
+{{ $az_issue_area := ($.Param "azure_issue_area") -}}
+
+{{ if $az_repo -}}
+  {{/* Adjust $path based on path_base_for_azure_subdir */ -}}
+  {{ $azs_base := $.Param "path_base_for_azure_subdir" -}}
+  {{ $azs_rename := "" -}}
+  {{ if reflect.IsMap $azs_base -}}
+    {{ $azs_rename = $azs_base.to -}}
+    {{ $azs_base = $azs_base.from -}}
+  {{ end -}}
+  {{ with $azs_base -}}
+    {{ $path = replaceRE . $azs_rename $az_repo_path -}}
+  {{ end -}}
+
+  {{ $az_repo_path := printf "%s/%s/%s" $az_branch $az_subdir $path -}}
+  {{ $az_repo_path = replaceRE "//+" "/" $az_repo_path -}}
+
+  {{ $baseUrl := replaceRE "/_git/.+$" "" $az_repo }}
+  {{ $viewURL := printf "%s?path=%s&_a=contents" $az_repo $az_repo_path -}}
+  {{ $issuesURL := printf "%s/_workitems/create/Bug?[title]=%s" $baseUrl (safeURL $.Title ) -}}
+  {{ if $az_issue_area -}}
+    {{ $issuesURL = printf "%s/_workitems/create/Bug?[title]=%s&[Area Path]=%s" $baseUrl (safeURL $.Title) (safeURL $az_issue_area) -}}
+  {{ end -}}
+
+  <a href="{{ $viewURL }}" class="td-page-meta--edit td-page-meta__edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_view_this" }}</a>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
+  {{ with $az_project_repo -}}
+    {{ $project_issueURL := printf "%s/_workitems/create/Bug" (replaceRE "/_git.+$" "" .) -}}
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue td-page-meta__project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+
+{{ end -}}

--- a/layouts/partials/page-meta-links-github.html
+++ b/layouts/partials/page-meta-links-github.html
@@ -1,0 +1,44 @@
+{{/* cSpell:ignore querify subdir */ -}}
+{{/* Class names ending with `--KIND` are deprecated in favor of `__KIND`, but we're keeping them for a few releases after 0.9.0 */ -}}
+
+{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
+{{ $gh_repo := $.Param "github_repo" -}}
+{{ $gh_url := $.Param "github_url" -}}
+{{ $gh_subdir := $.Param "github_subdir" | default "" -}}
+{{ $gh_project_repo := $.Param "github_project_repo" -}}
+{{ $gh_branch := $.Param "github_branch" | default "main" -}}
+{{ if $gh_url -}}
+  {{ warnf "Warning: use of `github_url` is deprecated. For details, see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
+  <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+{{ else if $gh_repo -}}
+
+  {{/* Adjust $path based on path_base_for_github_subdir */ -}}
+  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
+  {{ $ghs_rename := "" -}}
+  {{ if reflect.IsMap $ghs_base -}}
+    {{ $ghs_rename = $ghs_base.to -}}
+    {{ $ghs_base = $ghs_base.from -}}
+  {{ end -}}
+  {{ with $ghs_base -}}
+    {{ $path = replaceRE . $ghs_rename $path -}}
+  {{ end -}}
+
+  {{ $gh_repo_path := printf "%s/%s/%s" $gh_branch $gh_subdir $path -}}
+  {{ $gh_repo_path = replaceRE "//+" "/" $gh_repo_path -}}
+
+  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
+  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
+  {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
+  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
+  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
+  {{ $newPageURL := printf "%s/new/%s?%s" $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}
+
+  <a href="{{ $viewURL }}" class="td-page-meta--view td-page-meta__view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
+  <a href="{{ $editURL }}" class="td-page-meta--edit td-page-meta__edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+  <a href="{{ $newPageURL }}" class="td-page-meta--child td-page-meta__child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
+  {{ with $gh_project_repo -}}
+    {{ $project_issueURL := printf "%s/issues/new" . -}}
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project td-page-meta__project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+{{ end -}}

--- a/layouts/partials/page-meta-links-github.html
+++ b/layouts/partials/page-meta-links-github.html
@@ -1,7 +1,7 @@
 {{/* cSpell:ignore querify subdir */ -}}
 {{/* Class names ending with `--KIND` are deprecated in favor of `__KIND`, but we're keeping them for a few releases after 0.9.0 */ -}}
 
-{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
+{{ $path := strings.TrimPrefix (add (replace hugo.WorkingDir "\\" "/") "/") (replace $.File.Filename "\\" "/") -}}
 {{ $gh_repo := $.Param "github_repo" -}}
 {{ $gh_url := $.Param "github_url" -}}
 {{ $gh_subdir := $.Param "github_subdir" | default "" -}}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,52 +1,10 @@
-{{/* cSpell:ignore querify subdir */ -}}
-{{/* Class names ending with `--KIND` are deprecated in favor of `__KIND`, but we're keeping them for a few releases after 0.9.0 */ -}}
-
-{{ if .File -}}
-{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
-{{ $gh_repo := $.Param "github_repo" -}}
-{{ $gh_url := $.Param "github_url" -}}
-{{ $gh_subdir := $.Param "github_subdir" | default "" -}}
-{{ $gh_project_repo := $.Param "github_project_repo" -}}
-{{ $gh_branch := $.Param "github_branch" | default "main" -}}
+{{ if .File }}
 <div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
-{{ if $gh_url -}}
-  {{ warnf "Warning: use of `github_url` is deprecated. For details, see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
-  <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-{{ else if $gh_repo -}}
+  {{ partial "page-meta-links-azure.html" . }}
+  {{ partial "page-meta-links-github.html" . }}
 
-  {{/* Adjust $path based on path_base_for_github_subdir */ -}}
-  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
-  {{ $ghs_rename := "" -}}
-  {{ if reflect.IsMap $ghs_base -}}
-    {{ $ghs_rename = $ghs_base.to -}}
-    {{ $ghs_base = $ghs_base.from -}}
-  {{ end -}}
-  {{ with $ghs_base -}}
-    {{ $path = replaceRE . $ghs_rename $path -}}
-  {{ end -}}
-
-  {{ $gh_repo_path := printf "%s/%s/%s" $gh_branch $gh_subdir $path -}}
-  {{ $gh_repo_path = replaceRE "//+" "/" $gh_repo_path -}}
-
-  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
-  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
-  {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
-  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
-  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
-  {{ $newPageURL := printf "%s/new/%s?%s" $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}
-
-  <a href="{{ $viewURL }}" class="td-page-meta--view td-page-meta__view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
-  <a href="{{ $editURL }}" class="td-page-meta--edit td-page-meta__edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-  <a href="{{ $newPageURL }}" class="td-page-meta--child td-page-meta__child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
-  <a href="{{ $issuesURL }}" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
-  {{ with $gh_project_repo -}}
-    {{ $project_issueURL := printf "%s/issues/new" . -}}
-    <a href="{{ $project_issueURL }}" class="td-page-meta--project td-page-meta__project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-  {{ end -}}
-
-{{ end -}}
-{{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
-  <a id="print" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
-{{ end }}
+  {{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
+    <a id="print" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+  {{ end }}
 </div>
 {{ end -}}

--- a/userguide/content/en/docs/adding-content/repository-links.md
+++ b/userguide/content/en/docs/adding-content/repository-links.md
@@ -15,13 +15,15 @@ The Docsy [docs and blog layouts](/docs/adding-content/content/#adding-docs-and-
 
 This page shows you how to configure these links.
 
-Currently, Docsy supports only GitHub repository links "out of the box". Since GitLab can handle the same link scheme, it should work as well. If you are using another repository such as Bitbucket and would like generated repository links, feel free to [add a feature request or update our theme](/docs/contribution-guidelines/).
+Currently, Docsy supports GitHub and Azure Devops repository links "out of the box". Since GitLab can handle the same link scheme, it should work as well. If you are using another repository such as Bitbucket and would like generated repository links, feel free to [add a feature request or update our theme](/docs/contribution-guidelines/).
 
 ## Link configuration
 
 There are four site variables you can configure in `hugo.toml`/`hugo.yaml`/`hugo.json` to set up links, as well as one in your page metadata.
 
-### `github_repo`
+### Github
+
+#### `github_repo`
 
 The URL for your site's source repository. This is used to generate the **Edit this page**, **Create child page**, and **Create documentation issue** links.
 
@@ -44,7 +46,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### `github_subdir` (optional)
+#### `github_subdir` (optional)
 
 Specify a value here if your content directory is not in your repo's root directory. For example, this site is in the `userguide` subdirectory of its repo. Setting this value means that your edit links will go to the right page.
 
@@ -67,7 +69,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### `github_project_repo` (optional)
+#### `github_project_repo` (optional)
 
 Specify a value here if you have a separate project repo and you'd like your users to be able to create issues against your project from the relevant docs. The **Create project issue** link appears only if this is set.
 
@@ -90,7 +92,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### `github_branch` (optional)
+#### `github_branch` (optional)
 
 Specify a value here if you have would like to reference a different branch for the other github settings like **Edit this page** or **Create project issue**.
 
@@ -113,7 +115,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### `path_base_for_github_subdir` (optional)
+#### `path_base_for_github_subdir` (optional)
 
 Suppose that the source files for all of the pages under `content/some-section`
 come from another repo, such as a [git submodule][]. Add settings like these to
@@ -285,7 +287,7 @@ path_base_for_github_subdir:
 {{< /tab >}}
 {{< /tabpane >}}
 
-### `github_url` (optional)
+#### `github_url` (optional)
 
 {{% alert title="Deprecation note" color="warning" %}}
   This setting is deprecated. Use [path_base_for_github_subdir][] instead.
@@ -323,6 +325,65 @@ github_url: https://github.com/some-username/another-repo/edit/main/README.md
 This can be useful if you have page source files in multiple Git repositories,
 or require a non-GitHub URL. Pages using this value have **Edit this page**
 links only.
+
+### Azure Devops
+
+#### `azure_repo`
+
+The URL for your site's source repository. This is used to generate the **Edit this page**, **Create child page**, and **Create documentation issue** links.
+
+{{< tabpane persistLang=false >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="config.toml" lang="toml" >}}
+azure_repo = "https://dev.azure.com/google/docsy/_git/docsy"
+{{< /tab >}}
+{{< tab header="config.yaml" lang="yaml" >}}
+azure_repo: 'https://dev.azure.com/google/docsy/_git/docsy'
+{{< /tab >}}
+{{< tab header="config.json" lang="json" >}}
+{
+  "azure_repo": "https://dev.azure.com/google/docsy/_git/docsy"
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+#### `azure_subdir` (optional)
+
+Specify a value here if your content directory is not in your repo's root directory. For example, this site is in the `userguide` subdirectory of its repo. Setting this value means that your edit links will go to the right page.
+
+{{< tabpane persistLang=false >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="config.toml" lang="toml" >}}
+azure_subdir = "userguide"
+{{< /tab >}}
+{{< tab header="config.yaml" lang="yaml" >}}
+azure_subdir: 'userguide'
+{{< /tab >}}
+{{< tab header="config.json" lang="json" >}}
+{
+  "azure_subdir": "userguide"
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+#### `azure_project_repo` (optional)
+
+Specify a value here if you have a separate project repo and you'd like your users to be able to create issues against your project from the relevant docs. The **Create project issue** link appears only if this is set.
+
+{{< tabpane persistLang=false >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="config.toml" lang="toml" >}}
+azure_project_repo = "https://dev.azure.com/google/docsy/_git/docsy"
+{{< /tab >}}
+{{< tab header="config.yaml" lang="yaml" >}}
+azure_project_repo: 'https://dev.azure.com/google/docsy/_git/docsy'
+{{< /tab >}}
+{{< tab header="config.json" lang="json" >}}
+{
+  "azure_project_repo": "https://dev.azure.com/google/docsy/_git/docsy"
+}
+{{< /tab >}}
+{{< /tabpane >}}
 
 ### Disabling links
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -59,6 +59,13 @@ params:
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy
   github_subdir: userguide
+
+  # Added azure links for demo purposes
+  azure_repo: https://dev.azure.com/google/docsy/_git/docsy
+  azure_project_repo: https://dev.azure.com/google/docsy/_git/docsy
+  azure_subdir: userguide
+  azure_issue_area: Docsy\Issues
+
   time_format_blog: Monday, January 02, 2006
   time_format_default: January 2, 2006
   rss_sections: [blog] # TODO: drop since this is the default


### PR DESCRIPTION
Not everybody has their code stored in Github, and I wanted to add support for the links on the right side to Azure as well. 

This PR does that, however, I would suggest a more significant change for source repositories, something along the lines of:

[sourcecontrol]
type = github
repo = <repository url>
project_repo = <project repository url>

[sourcecontrol.github]
<specific github configuration here>

[sourcecontrol.azure]
issue_area = <a default issue area>
<specific github configuration here>

For now, I lack the time to add support for this, but this would be amazing actually.

The configuration in order to utilize this PR is as following:

[params]
azure_repo = <repo url>
azure_project_repo = <project repo url>
azure_subdir = <azure subdirectory for source>
azure_issue_area = <an optional issue area>
