### PR TITLE
Add OpenTelemetry webpage to examples

### DIFF
--- a/userguide/content/en/docs/Examples/_index.md
+++ b/userguide/content/en/docs/Examples/_index.md
@@ -29,6 +29,7 @@ Example sites that have low to no customization:
 | [Selenium](https://www.selenium.dev/) | https://github.com/SeleniumHQ/seleniumhq.github.io |
 | [fission.io](https://fission.io/) | https://github.com/fission/fission.io |
 | [Stroom](https://gchq.github.io/stroom-docs) | https://github.com/gchq/stroom-docs |
+| [OpenTelemetry](https://opentelemetry.io) | https://github.com/open-telemetry/opentelemetry.io |
 
 ## Customized Docsy examples
 


### PR DESCRIPTION
I think it is worth to add OpenTelemetry webpage as an example.
OpenTelemetry is the second most active CNCF project behind Kubernetes.

CC @chalin @svrnm @cartermp @austinlparker