### PR TITLE
Fix: mermaid diagrams with parameters in site config

### DIFF
--- a/assets/js/mermaid.js
+++ b/assets/js/mermaid.js
@@ -1,9 +1,3 @@
-{{ $needmermaid := .Site.Params.mermaid.enable -}}
-{{ if ge hugo.Version "0.93.0" -}}
-    {{ $needmermaid = or $needmermaid (.Page.Store.Get "hasmermaid") -}}
-{{ end }}
-
-{{ if $needmermaid }}
 (function($) {
     var needMermaid = false;
 
@@ -23,7 +17,7 @@
         return;
     }
 
-    var params = {{ . | jsonify | safeJS }};
+    var params = {{ .Site.Params.mermaid | jsonify | safeJS }};
 
     // site params are stored with lowercase keys; lookup correct casing
     // from Mermaid default config.
@@ -45,4 +39,3 @@
     settings.startOnLoad = true;
     mermaid.initialize(settings);
 })(jQuery);
-{{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,11 +1,10 @@
 {{ $needmermaid := .Site.Params.mermaid.enable -}}
 {{ if ge hugo.Version "0.93.0" -}}
+    {{ with .Site.Params.mermaid }}
+        {{ $needmermaid = true }}
+    {{ end }}
     {{ $needmermaid = or $needmermaid (.Page.Store.Get "hasmermaid") -}}
 {{ end }}
-
-{{ if $needmermaid -}}
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@9.1.7/dist/mermaid.min.js" integrity="sha512-1ypa9tdUrJAWv5g28Mb5x0zXaUuI4SBofKff88OGyk5D/oOd4x1IPxYHsx3K81bwBKt8NVUvGgw7TgNZ6PJX2A==" crossorigin="anonymous"></script>
-{{ end -}}
 
 {{ if .Site.Params.markmap.enable -}}
 <style>
@@ -64,7 +63,15 @@ window.markmap = {
 {{ if .Site.Params.offlineSearch -}}
   {{ $jsSearch = resources.Get "js/offline-search.js" -}}
 {{ end -}}
-{{ $js := (slice $jsBs $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsMarkmap $jsDrawio) | resources.Concat "js/main.js" -}}
+
+{{ $jsArray := slice $jsBs $jsBase $jsAnchor $jsSearch $jsPlantuml $jsMarkmap $jsDrawio -}}
+
+{{ if $needmermaid -}}
+{{ $jsArray = $jsArray | append $jsMermaid -}}
+<script src="https://cdn.jsdelivr.net/npm/mermaid@9.2.2/dist/mermaid.min.js" integrity="sha512-IX+bU+wShHqfqaMHLMrtwi4nK6W/Z+QdZoL4kPNtRxI2wCLyHPMAdl3a43Fv1Foqv4AP+aiW6hg1dcrTt3xc+Q==" crossorigin="anonymous"></script>
+{{ end -}}
+
+{{ $js := $jsArray | resources.Concat "js/main.js" -}}
 {{ if hugo.IsProduction -}}
   {{ $js := $js | minify | fingerprint -}}
   <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>

--- a/userguide/config.yaml
+++ b/userguide/config.yaml
@@ -120,6 +120,10 @@ params:
     disable_toc: false
   markmap:
     enable: true
+  mermaid:
+    theme: default
+    flowchart:
+      diagramPadding: 20
 
 taxonomies:
   tag: tags


### PR DESCRIPTION
This PR fixes this two regressions introduced with 90843e360b:

- build breaks if mermaid diagram(s) are displayed on one or more pages **and** parameters for mermaid are given in the site config.
- parameters for mermaid given in the site config were picked up only if `mermaid.enable=true` was given. With auto-activation of mermaid diagrams in place, parameters should be considered event if `mermaid.enable` is missing in the site config.

This PR also bumps mermaid to the latest released version 9.2.2.