### PR TITLE
prevent navbar text wrapping

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -56,6 +56,10 @@
         font-weight: $font-weight-bold;
     }
 
+    .navbar-nav {
+        white-space: nowrap;
+    }
+
     // For .td-search__input styling, see _search.scss
 
     .dropdown {
@@ -81,9 +85,7 @@
             .navbar-nav {
                 padding-bottom: 2rem;
                 overflow-x: auto;
-                white-space: nowrap;
                 -webkit-overflow-scrolling: touch;
-
             }
         }
     }


### PR DESCRIPTION
When a navbar item has multiple words, and there are enough navbar item to cause the flexbox to be full at reduced window widths without transitioning through the lower media breakpoint, the navbar link name can wrap, which causes the alignment of all navbar items to break.

This change forbids navbar text wrapping even at bigger screen sizes.