### PR TITLE
Fix: auto-activation of math and chem blocks

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,5 +1,5 @@
-{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem -}}
-{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem -}}
+{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
+{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem (.Page.Store.Get "hasmhchem") -}}
 {{ $needmermaid := .Site.Params.mermaid.enable -}}
 {{ if ge hugo.Version "0.93.0" -}}
     {{ with .Site.Params.mermaid }}


### PR DESCRIPTION
With this PR applied, auto-activation of math and chem blocks will work properly again.