### PR TITLE
Userguide: fixes code example for use of shortcode 'card'

### DIFF
--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -474,7 +474,7 @@ If your content is any kind of text other than programming code, use the univers
 
 ```go-html-template
 {{</* card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono"
-          footer="![SignatureJohnLennon](https://server.tld/…/signature.png 'Signature John Lennon')">*/>}}
+          footer="![SignatureJohnLennon](https://server.tld/…/signature.png 'Signature John Lennon')"*/>}}
 Imagine there's no heaven, It's easy if you try<br/>
 No hell below us, above us only sky<br/>
 Imagine all the people living for today…


### PR DESCRIPTION
The code example for use of shortcode `card` in the user guide erroneously contains two `>` characters for the closing tag. This will be corrected with this PR.