### PR TITLE
Math and chem code clocks, autoactivation: fix use with hugo version < 0.93

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,10 +1,12 @@
-{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
-{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem (.Page.Store.Get "hasmhchem") -}}
+{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem -}}
+{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem -}}
 {{ $needmermaid := .Site.Params.mermaid.enable -}}
 {{ if ge hugo.Version "0.93.0" -}}
     {{ with .Site.Params.mermaid }}
         {{ $needmermaid = true }}
     {{ end }}
+  {{ $needKaTeX = or $needKaTeX (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
+  {{ $needmhchem = or $needmhchem (.Page.Store.Get "hasmhchem") -}}
   {{ $needmermaid = or $needmermaid (.Page.Store.Get "hasmermaid") -}}
 {{ else -}}
   {{ if or $needKaTeX $needmhchem $needmermaid -}}

--- a/userguide/config.yaml
+++ b/userguide/config.yaml
@@ -111,11 +111,6 @@ params:
     theme: default
     svg_image_url: https://www.plantuml.com/plantuml/svg/
     svg: false
-  katex:
-    enable: true
-    html_dom_element: document.body
-    mhchem:
-      enable: true
   print:
     disable_toc: false
   markmap:


### PR DESCRIPTION
With #1341, autoactivation of `math` and `chem` code blocks was fixed. I now realized that as unwanted side effect, the build now breaks with hugo versions < 0.93. This PR corrects this. It also removes the `katex` from the config file of the use guide. The recommended approach is now to acticate math on a per page basis via `math=true` in the frontmatter of the page.