### PR TITLE
Add protobuf.dev to examples

### DIFF
--- a/userguide/content/en/docs/Examples/_index.md
+++ b/userguide/content/en/docs/Examples/_index.md
@@ -31,6 +31,7 @@ Example sites that have low to no customization:
 | [OpenTelemetry](https://opentelemetry.io) | https://github.com/open-telemetry/opentelemetry.io |
 | [CloudWeGo](https://www.cloudwego.io/) | https://github.com/cloudwego/cloudwego.github.io |
 | [etcd](https://etcd.io/) | https://github.com/etcd-io/website |
+| [protobuf.dev](https://protobuf.dev) | https://github.com/protocolbuffers/protocolbuffers.github.io |
 
 ## Customized Docsy examples
 


### PR DESCRIPTION
Adds the protobuf.dev documentation site to the list of example sites.