### PR TITLE
Add support for relative links in the footer bar

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,11 +31,13 @@
   {{ $refpage := .refpage }}
   {{ range .links }}
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    {{ $target := "_blank" }}
+    {{ $url := .url }}
     {{ if not (urls.Parse .url).Host }}
-    <a class="text-white" target="_self" rel="noopener" href="{{ relref $refpage .url }}" aria-label="{{ .name }}">
-    {{ else }}
-    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+        {{ $target = "_self" }}
+        {{ $url = (relref $refpage .url) }}
     {{ end }}
+    <a class="text-white" target="{{ $target }}" rel="noopener" href="{{ $url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>
   </li>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,14 +5,14 @@
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
         {{ with $links }}
         {{ with index . "user"}}
-        {{ template "footer-links-block"  . }}
+        {{ template "footer-links-block"  (dict "links" . "refpage" $.Site.Home) }}
         {{ end }}
         {{ end }}
       </div>
       <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
         {{ with $links }}
         {{ with index . "developer"}}
-        {{ template "footer-links-block"  . }}
+        {{ template "footer-links-block"  (dict "links" . "refpage" $.Site.Home) }}
         {{ end }}
         {{ end }}
       </div>
@@ -28,9 +28,14 @@
 </footer>
 {{ define "footer-links-block" }}
 <ul class="list-inline mb-0">
-  {{ range . }}
+  {{ $refpage := .refpage }}
+  {{ range .links }}
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    {{ if not (urls.Parse .url).Host }}
+    <a class="text-white" target="_self" rel="noopener" href="{{ relref $refpage .url }}" aria-label="{{ .name }}">
+    {{ else }}
     <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+    {{ end }}
       <i class="{{ .icon }}"></i>
     </a>
   </li>


### PR DESCRIPTION
In my use case, I have a developer information page in my Docsy site that is not in the normal, user-focused menu. I want this to be able to linked in the footer with the other developer links, but currently only links to external websites are allowed.

This change passes the site home context to the ```footer-links-block``` and makes it so that any relative links defined in the Site.Params.links are looked up and displayed. It also sets the target to ```_self``` for any reference links so that the page opens in the current window instead of another one.