### PR TITLE
[BSv5] More utility updates

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="td-rss-button" title="RSS" href="{{ .Permalink | safeURL }}" target="_blank" rel="noopener">
               <i class="fa-solid fa-rss" aria-hidden="true"></i>

--- a/layouts/blog/baseof.print.html
+++ b/layouts/blog/baseof.print.html
@@ -14,7 +14,7 @@
           </div>
           <div class="d-none d-xl-block col-xl-2 td-toc d-print-none">
           </div>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5 pr-md-4" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
             {{ block "main" . }}{{ end }}
           </main>
         </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -23,7 +23,7 @@
 								{{ partial "reading-time.html" . }}
 							{{ end }}
 						</header>
-						{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left me-3 pt-1 d-none d-md-block") }}
+						{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") }}
 						<p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
 						<p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
 					</div>
@@ -34,7 +34,7 @@
 		{{ end }}
 	</div>
 </div>
-<div class="row pl-2 pt-2">
+<div class="row ps-2 pt-2">
 	<div class="col">
 		{{ if .Pages }}
 			{{ template "_internal/pagination.html" . }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -18,7 +18,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}

--- a/layouts/docs/baseof.print.html
+++ b/layouts/docs/baseof.print.html
@@ -10,7 +10,7 @@
     <div class="container-fluid td-outer">
       <div class="td-main">
         <div class="row flex-xl-nowrap">
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ block "main" . }}{{ end }}
           </main>
         </div>

--- a/layouts/partials/pager.html
+++ b/layouts/partials/pager.html
@@ -3,6 +3,6 @@
     <a {{if .PrevInSection}}href="{{.PrevInSection.RelPermalink}}" aria-label="{{ T "ui_pager_prev" }} - {{.PrevInSection.Title}}" {{end}}class="btn btn-primary{{if not .PrevInSection}} disabled{{end}}"><span class="me-1">←</span>{{ T "ui_pager_prev" }}</a>
   </li>
   <li>
-    <a {{if .NextInSection}}href="{{.NextInSection.RelPermalink}}" aria-label="{{ T "ui_pager_next" }} - {{.NextInSection.Title}}" {{end}}class="btn btn-primary{{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }}<span class="ml-1">?</span></a>
+    <a {{if .NextInSection}}href="{{.NextInSection.RelPermalink}}" aria-label="{{ T "ui_pager_next" }} - {{.NextInSection.Title}}" {{end}}class="btn btn-primary{{if not .NextInSection}} disabled{{end}}">{{ T "ui_pager_next" }}<span class="ms-1">→</span></a>
   </li>
 </ul>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -28,7 +28,7 @@
     {{ $ulNr := 0 -}}
     {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}
     {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 -}}
-    <ul class="td-sidebar-nav__section pr-md-3 ul-{{ $ulNr }}">
+    <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
       {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>
   </nav>
@@ -53,9 +53,9 @@
 <li class="td-sidebar-nav__section-title td-sidebar-nav__section{{ if $withChild }} with-child{{ else }} without-child{{ end }}{{ if $activePath }} active-path{{ end }}{{ if (not (or $show $p.Site.Params.ui.sidebar_menu_foldable )) }} collapse{{ end }}" id="{{ $mid }}-li">
   {{ if (and $p.Site.Params.ui.sidebar_menu_foldable (ge $ulNr 1)) -}}
   <input type="checkbox" id="{{ $mid }}-check"{{ if $activePath}} checked{{ end }}/>
-  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
+  <label for="{{ $mid }}-check"><a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0 {{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a></label>
   {{ else -}}
-  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left pl-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
+  <a href="{{ $manualLink }}"{{ if ne $s.LinkTitle $manualLinkTitle }} title="{{ $manualLinkTitle }}"{{ end }}{{ with $s.Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }} class="align-left ps-0{{ if $active}} active{{ end }} td-sidebar-link{{ if $s.IsPage }} td-sidebar-link__page{{ else }} td-sidebar-link__section{{ end }}{{ if $treeRoot }} tree-root{{ end }}" id="{{ $mid }}">{{ with $s.Params.Icon}}<i class="{{ . }}"></i>{{ end }}<span class="{{ if $active }}td-sidebar-nav-active-item{{ end }}">{{ $s.LinkTitle }}</span></a>
   {{- end }}
   {{- if $withChild }}
   {{- $ulNr := add $ulNr 1 }}

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -79,7 +79,7 @@
 
     {{/* Replace space and +, not valid for css selectors */ -}}
     {{ $lang := replaceRE "[\\s+]" "-" $lang -}}
-    <li class="nav-item{{ if $rightpush }} ml-auto{{ end -}}">
+    <li class="nav-item{{ if $rightpush }} ms-auto{{ end -}}">
       {{/* Generate the IDs for the <a> and the <div> elements */ -}}
       {{ $tabid := printf "tabs-%02v-%v-tab" $Ordinal $index | anchorize -}}
       {{ $entryid := printf "tabs-%02v-%v" $Ordinal $index | anchorize -}}

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -20,7 +20,7 @@
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
-          <main class="col-12 col-md-9 col-xl-8 pl-md-5" role="main">
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             <script src="{{ "js/swagger-ui-bundle.js" | relURL }}"></script>
             <script src="{{ "js/swagger-ui-standalone-preset.js" | relURL }}"></script>

--- a/userguide/config.yaml
+++ b/userguide/config.yaml
@@ -24,7 +24,7 @@ menu:
     - name: Example Site
       weight: 40
       url: https://example.docsy.dev
-      post: <sup><i class="pl-1 fa-solid fa-up-right-from-square fa-xs"
+      post: <sup><i class="ps-1 fa-solid fa-up-right-from-square fa-xs"
         aria-hidden="true"></i></sup>
 
 services:

--- a/userguide/content/en/_index.html
+++ b/userguide/content/en/_index.html
@@ -4,11 +4,11 @@ title: Docsy
 
 {{< blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" color="orange" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/about" >}}">
-		Learn More <i class="fa-solid fa-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary me-3 mb-4" href="{{< relref "/about" >}}">
+		Learn More <i class="fa-solid fa-circle-right ms-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/google/docsy">
-		Download <i class="fa-brands fa-github ml-2 "></i>
+	<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/google/docsy">
+		Download <i class="fa-brands fa-github ms-2 "></i>
 	</a>
 	<p class="lead mt-5">A Hugo theme for creating great technical documentation sites</p>
 	{{< blocks/link-down color="info" >}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -32,11 +32,11 @@ The **blocks/cover** shortcode creates a landing page type of block that fills t
 ```html
 {{</* blocks/cover title="Welcome!" image_anchor="center" height="full" color="primary" */>}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{</* relref "/docs" */>}}">
-		Learn More <i class="fa-solid fa-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary me-3 mb-4" href="{{</* relref "/docs" */>}}">
+		Learn More <i class="fa-solid fa-circle-right ms-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://example.org">
-		Download <i class="fa-brands fa-github ml-2 "></i>
+	<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://example.org">
+		Download <i class="fa-brands fa-github ms-2 "></i>
 	</a>
 	<p class="lead mt-5">This program is now available in <a href="#">AppStore!</a></p>
 	<div class="mx-auto mt-5">


### PR DESCRIPTION
- Contributes to #470
- Renamed .float-left and .float-right to .float-start and .float-end.
- Renamed .ml-* and .mr-* to .ms-* and .me-* (remaining instances).
- Renamed .pl-* and .pr-* to .ps-* and .pe-*.
- Renamed .text-left and .text-right to .text-start and .text-end, except as noted below.

Preview: https://deploy-preview-1361--docsydocs.netlify.app/

---

Note: I've left out the following `text-*` change from the footer because the flex boxes aren't working for some reason, and so the first "developer" icon moves off of the page. I'll fix that separately

```diff
diff --git a/layouts/partials/footer.html b/layouts/partials/footer.html
index 00485a5..a95bdad 100644
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,14 +4,14 @@
     <div class="row">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
         {{ with $links }}
-        {{ with index . "user"}}
+        {{ with index . "user" }}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
+      <div class="col-6 col-sm-4 text-end text-xs-center order-sm-3">
         {{ with $links }}
-        {{ with index . "developer"}}
+        {{ with index . "developer" }}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
```