### PR TITLE
[BSv5] YIQ color - final changes

### DIFF
--- a/assets/scss/_colors.scss
+++ b/assets/scss/_colors.scss
@@ -2,7 +2,7 @@
 @mixin palette-variant($color-name, $color-value) {
     $text-color: color-contrast($color-value);
     $link-color: mix($blue, $text-color, lightness($color-value));
-   
+
     $link-hover-color: rgba($link-color, .5) !default;
 
     .-bg-#{$color-name} {
@@ -12,7 +12,7 @@
 
     // Make links in paragraphs stand out more.
     @include link-variant(".-bg-#{$color-name} p > a", $link-color, $link-hover-color, false);
-   
+
 
     .-text-#{$color-name} {
         color: $color-value;
@@ -35,7 +35,7 @@
 @for $i from 1 through length($td-box-colors) {
     $value: nth($td-box-colors, $i);
     $name: $i - 1;
-    $text-color: color-yiq($value);
+    $text-color: color-contrast($value);
 
     @include palette-variant($name, $value);
 }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -126,6 +126,3 @@ $navbar-dark-color: rgba($white, 0.75) !default;
 $navbar-dark-hover-color: rgba($white, 0.5) !default;
 $navbar-dark-active-color: $white !default;
 $navbar-dark-disabled-color: rgba($white, 0.25) !default;
-
-// The yiq lightness value that determines when the lightness of color changes from "dark" to "light".
-$yiq-contrasted-threshold: 200 !default;


### PR DESCRIPTION
- Contributes to #470
- Renamed `color-yiq()` function and related variables to `color-contrast()`, etc. For details, see corresponding [Sass](https://getbootstrap.com/docs/5.0/migration/#sass) entry.
- Dropped the `$min-contrast-ratio` (formerly `$yiq-contrasted-threshold`) override in favor of the BS default

Preview: https://deploy-preview-1363--docsydocs.netlify.app/ -- I don't think that the UG illustrates any Docsy feature that uses the styling affected by this PR 🤷🏼‍♂️ 