### PR TITLE
[BSv5] Adjust media-breakpoint-down() argument

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -66,7 +66,7 @@
         min-width: 100px;
     }
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(lg) {
         padding-right: .5rem;
         padding-left: .75rem;
 

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -154,7 +154,7 @@
     #content-desktop {display: block;}
     #content-mobile {display: none;}
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(lg) {
 
     #content-desktop {display: none;}
     #content-mobile {display: block;}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -37,7 +37,7 @@
 footer {
     min-height: 150px;
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(lg) {
         min-height: 200px;
     }
 }


### PR DESCRIPTION
- Contributes to #470
- `media-breakpoint-down()`: changed argument to be next breakpoint of higher value.

To double check that the breakpoints for say, the `<footer>`, are the [same as before](https://deploy-preview-1356--docsydocs.netlify.app/), inspect the `<footer>` CSS as you change the view width. After this PR lands, the media breakpoint becomes:

```css
@media (max-width: 991.98px)
footer {
    min-height: 200px;
}
```

Vs. `(max-width: 767.98px)`.