### PR TITLE
[BSv5] Docsy depencendies: bump _rfs.scss to bootstrap version 5.2.3

### DIFF
--- a/dependencies/assets/bootstrap/scss/_vendor/_rfs.scss
+++ b/dependencies/assets/bootstrap/scss/_vendor/_rfs.scss
@@ -2,21 +2,21 @@
 
 // SCSS RFS mixin
 //
-// Automated responsive font sizes
+// Automated responsive values for font sizes, paddings, margins and much more
 //
-// Licensed under MIT (https://github.com/twbs/rfs/blob/v8.x/LICENSE)
+// Licensed under MIT (https://github.com/twbs/rfs/blob/main/LICENSE)
 
 // Configuration
 
-// Base font size
-$rfs-base-font-size: 1.25rem !default;
-$rfs-font-size-unit: rem !default;
+// Base value
+$rfs-base-value: 1.25rem !default;
+$rfs-unit: rem !default;
 
-@if $rfs-font-size-unit != rem and $rfs-font-size-unit != px {
-  @error "`#{$rfs-font-size-unit}` is not a valid unit for $rfs-font-size-unit. Use `px` or `rem`.";
+@if $rfs-unit != rem and $rfs-unit != px {
+  @error "`#{$rfs-unit}` is not a valid unit for $rfs-unit. Use `px` or `rem`.";
 }
 
-// Breakpoint at where font-size starts decreasing if screen width is smaller
+// Breakpoint at where values start decreasing if screen width is smaller
 $rfs-breakpoint: 1200px !default;
 $rfs-breakpoint-unit: px !default;
 
@@ -24,15 +24,18 @@ $rfs-breakpoint-unit: px !default;
   @error "`#{$rfs-breakpoint-unit}` is not a valid unit for $rfs-breakpoint-unit. Use `px`, `em` or `rem`.";
 }
 
-// Resize font size based on screen height and width
+// Resize values based on screen height and width
 $rfs-two-dimensional: false !default;
 
 // Factor of decrease
 $rfs-factor: 10 !default;
 
-@if type-of($rfs-factor) != "number" or $rfs-factor <= 1 {
+@if type-of($rfs-factor) != number or $rfs-factor <= 1 {
   @error "`#{$rfs-factor}` is not a valid  $rfs-factor, it must be greater than 1.";
 }
+
+// Mode. Possibilities: "min-media-query", "max-media-query"
+$rfs-mode: min-media-query !default;
 
 // Generate enable or disable classes. Possibilities: false, "enable" or "disable"
 $rfs-class: false !default;
@@ -43,11 +46,11 @@ $rfs-rem-value: 16 !default;
 // Safari iframe resize bug: https://github.com/twbs/rfs/issues/14
 $rfs-safari-iframe-resize-bug-fix: false !default;
 
-// Disable RFS by setting $enable-responsive-font-sizes to false
-$enable-responsive-font-sizes: true !default;
+// Disable RFS by setting $enable-rfs to false
+$enable-rfs: true !default;
 
-// Cache $rfs-base-font-size unit
-$rfs-base-font-size-unit: unit($rfs-base-font-size);
+// Cache $rfs-base-value unit
+$rfs-base-value-unit: unit($rfs-base-value);
 
 @function divide($dividend, $divisor, $precision: 10) {
   $sign: if($dividend > 0 and $divisor > 0 or $dividend < 0 and $divisor < 0, 1, -1);
@@ -91,32 +94,64 @@ $rfs-base-font-size-unit: unit($rfs-base-font-size);
   @return $result;
 }
 
-// Remove px-unit from $rfs-base-font-size for calculations
-@if $rfs-base-font-size-unit == "px" {
-  $rfs-base-font-size: divide($rfs-base-font-size, $rfs-base-font-size * 0 + 1);
+// Remove px-unit from $rfs-base-value for calculations
+@if $rfs-base-value-unit == px {
+  $rfs-base-value: divide($rfs-base-value, $rfs-base-value * 0 + 1);
 }
-@else if $rfs-base-font-size-unit == "rem" {
-  $rfs-base-font-size: divide($rfs-base-font-size, divide($rfs-base-font-size * 0 + 1, $rfs-rem-value));
+@else if $rfs-base-value-unit == rem {
+  $rfs-base-value: divide($rfs-base-value, divide($rfs-base-value * 0 + 1, $rfs-rem-value));
 }
 
 // Cache $rfs-breakpoint unit to prevent multiple calls
 $rfs-breakpoint-unit-cache: unit($rfs-breakpoint);
 
 // Remove unit from $rfs-breakpoint for calculations
-@if $rfs-breakpoint-unit-cache == "px" {
+@if $rfs-breakpoint-unit-cache == px {
   $rfs-breakpoint: divide($rfs-breakpoint, $rfs-breakpoint * 0 + 1);
 }
-@else if $rfs-breakpoint-unit-cache == "rem" or $rfs-breakpoint-unit-cache == "em" {
+@else if $rfs-breakpoint-unit-cache == rem or $rfs-breakpoint-unit-cache == "em" {
   $rfs-breakpoint: divide($rfs-breakpoint, divide($rfs-breakpoint * 0 + 1, $rfs-rem-value));
 }
 
+// Calculate the media query value
+$rfs-mq-value: if($rfs-breakpoint-unit == px, #{$rfs-breakpoint}px, #{divide($rfs-breakpoint, $rfs-rem-value)}#{$rfs-breakpoint-unit});
+$rfs-mq-property-width: if($rfs-mode == max-media-query, max-width, min-width);
+$rfs-mq-property-height: if($rfs-mode == max-media-query, max-height, min-height);
+
+// Internal mixin used to determine which media query needs to be used
+@mixin _rfs-media-query {
+  @if $rfs-two-dimensional {
+    @if $rfs-mode == max-media-query {
+      @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}), (#{$rfs-mq-property-height}: #{$rfs-mq-value}) {
+        @content;
+      }
+    }
+    @else {
+      @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}) and (#{$rfs-mq-property-height}: #{$rfs-mq-value}) {
+        @content;
+      }
+    }
+  }
+  @else {
+    @media (#{$rfs-mq-property-width}: #{$rfs-mq-value}) {
+      @content;
+    }
+  }
+}
+
 // Internal mixin that adds disable classes to the selector if needed.
-@mixin _rfs-disable-class {
-  @if $rfs-class == "disable" {
-    // Adding an extra class increases specificity, which prevents the media query to override the font size
+@mixin _rfs-rule {
+  @if $rfs-class == disable and $rfs-mode == max-media-query {
+    // Adding an extra class increases specificity, which prevents the media query to override the property
     &,
-    .disable-responsive-font-size &,
-    &.disable-responsive-font-size {
+    .disable-rfs &,
+    &.disable-rfs {
+      @content;
+    }
+  }
+  @else if $rfs-class == enable and $rfs-mode == min-media-query {
+    .enable-rfs &,
+    &.enable-rfs {
       @content;
     }
   }
@@ -126,103 +161,194 @@ $rfs-breakpoint-unit-cache: unit($rfs-breakpoint);
 }
 
 // Internal mixin that adds enable classes to the selector if needed.
-@mixin _rfs-enable-class {
-  @if $rfs-class == "enable" {
-    .enable-responsive-font-size &,
-    &.enable-responsive-font-size {
+@mixin _rfs-media-query-rule {
+
+  @if $rfs-class == enable {
+    @if $rfs-mode == min-media-query {
       @content;
+    }
+
+    @include _rfs-media-query {
+      .enable-rfs &,
+      &.enable-rfs {
+        @content;
+      }
     }
   }
   @else {
-    @content;
+    @if $rfs-class == disable and $rfs-mode == min-media-query {
+      .disable-rfs &,
+      &.disable-rfs {
+        @content;
+      }
+    }
+    @include _rfs-media-query {
+      @content;
+    }
   }
 }
 
-// Internal mixin used to determine which media query needs to be used
-@mixin _rfs-media-query($mq-value) {
-  @if $rfs-two-dimensional {
-    @media (max-width: #{$mq-value}), (max-height: #{$mq-value}) {
-      @content;
-    }
-  }
-  @else {
-    @media (max-width: #{$mq-value}) {
-      @content;
-    }
-  }
-}
+// Helper function to get the formatted non-responsive value
+@function rfs-value($values) {
+  // Convert to list
+  $values: if(type-of($values) != list, ($values,), $values);
 
-// Responsive font size mixin
-@mixin rfs($fs, $important: false) {
-  // Cache $fs unit
-  $fs-unit: if(type-of($fs) == "number", unit($fs), false);
+  $val: '';
 
-  // Add !important suffix if needed
-  $rfs-suffix: if($important, " !important", "");
-
-  // If $fs isn't a number (like inherit) or $fs has a unit (not px or rem, like 1.5em) or $ is 0, just print the value
-  @if not $fs-unit or $fs-unit != "" and $fs-unit != "px" and $fs-unit != "rem" or $fs == 0 {
-    font-size: #{$fs}#{$rfs-suffix};
-  }
-  @else {
-    // Remove unit from $fs for calculations
-    @if $fs-unit == "px" {
-      $fs: divide($fs, $fs * 0 + 1);
-    }
-    @else if $fs-unit == "rem" {
-      $fs: divide($fs, divide($fs * 0 + 1, $rfs-rem-value));
-    }
-
-    // Set default font size
-    $rfs-static: if($rfs-font-size-unit == rem, #{divide($fs, $rfs-rem-value)}rem, #{$fs}px);
-
-    // Only add the media query if the font size is bigger than the minimum font size
-    @if $fs <= $rfs-base-font-size or not $enable-responsive-font-sizes {
-      font-size: #{$rfs-static}#{$rfs-suffix};
+  // Loop over each value and calculate value
+  @each $value in $values {
+    @if $value == 0 {
+      $val: $val + ' 0';
     }
     @else {
-      // Calculate the minimum font size for $fs
-      $fs-min: $rfs-base-font-size + divide($fs - $rfs-base-font-size, $rfs-factor);
+      // Cache $value unit
+      $unit: if(type-of($value) == "number", unit($value), false);
 
-      // Calculate difference between $fs and the minimum font size
-      $fs-diff: $fs - $fs-min;
+      @if $unit == px {
+        // Convert to rem if needed
+        $val: $val + ' ' + if($rfs-unit == rem, #{divide($value, $value * 0 + $rfs-rem-value)}rem, $value);
+      }
+      @else if $unit == rem {
+        // Convert to px if needed
+        $val: $val + ' ' + if($rfs-unit == px, #{divide($value, $value * 0 + 1) * $rfs-rem-value}px, $value);
+      }
+      @else {
+        // If $value isn't a number (like inherit) or $value has a unit (not px or rem, like 1.5em) or $ is 0, just print the value
+        $val: $val + ' ' + $value;
+      }
+    }
+  }
 
-      // Base font-size formatting
-      $min-width: if($rfs-font-size-unit == rem, #{divide($fs-min, $rfs-rem-value)}rem, #{$fs-min}px);
+  // Remove first space
+  @return unquote(str-slice($val, 2));
+}
 
-      // Use `vmin` if two-dimensional is enabled
-      $variable-unit: if($rfs-two-dimensional, vmin, vw);
+// Helper function to get the responsive value calculated by RFS
+@function rfs-fluid-value($values) {
+  // Convert to list
+  $values: if(type-of($values) != list, ($values,), $values);
 
-      // Calculate the variable width between 0 and $rfs-breakpoint
-      $variable-width: #{divide($fs-diff * 100, $rfs-breakpoint)}#{$variable-unit};
+  $val: '';
 
-      // Set the calculated font-size
-      $rfs-fluid: calc(#{$min-width} + #{$variable-width}) #{$rfs-suffix};
+  // Loop over each value and calculate value
+  @each $value in $values {
+    @if $value == 0 {
+      $val: $val + ' 0';
+    }
 
-      // Breakpoint formatting
-      $mq-value: if($rfs-breakpoint-unit == px, #{$rfs-breakpoint}px, #{divide($rfs-breakpoint, $rfs-rem-value)}#{$rfs-breakpoint-unit});
+    @else {
+      // Cache $value unit
+      $unit: if(type-of($value) == "number", unit($value), false);
 
-      @include _rfs-disable-class {
-        font-size: #{$rfs-static}#{$rfs-suffix};
+      // If $value isn't a number (like inherit) or $value has a unit (not px or rem, like 1.5em) or $ is 0, just print the value
+      @if not $unit or $unit != px and $unit != rem {
+        $val: $val + ' ' + $value;
       }
 
-      @include _rfs-media-query($mq-value) {
-        @include _rfs-enable-class {
-          font-size: $rfs-fluid;
+      @else {
+        // Remove unit from $value for calculations
+        $value: divide($value, $value * 0 + if($unit == px, 1, divide(1, $rfs-rem-value)));
+
+        // Only add the media query if the value is greater than the minimum value
+        @if abs($value) <= $rfs-base-value or not $enable-rfs {
+          $val: $val + ' ' +  if($rfs-unit == rem, #{divide($value, $rfs-rem-value)}rem, #{$value}px);
         }
+        @else {
+          // Calculate the minimum value
+          $value-min: $rfs-base-value + divide(abs($value) - $rfs-base-value, $rfs-factor);
+
+          // Calculate difference between $value and the minimum value
+          $value-diff: abs($value) - $value-min;
+
+          // Base value formatting
+          $min-width: if($rfs-unit == rem, #{divide($value-min, $rfs-rem-value)}rem, #{$value-min}px);
+
+          // Use negative value if needed
+          $min-width: if($value < 0, -$min-width, $min-width);
+
+          // Use `vmin` if two-dimensional is enabled
+          $variable-unit: if($rfs-two-dimensional, vmin, vw);
+
+          // Calculate the variable width between 0 and $rfs-breakpoint
+          $variable-width: #{divide($value-diff * 100, $rfs-breakpoint)}#{$variable-unit};
+
+          // Return the calculated value
+          $val: $val + ' calc(' + $min-width + if($value < 0, ' - ', ' + ') + $variable-width + ')';
+        }
+      }
+    }
+  }
+
+  // Remove first space
+  @return unquote(str-slice($val, 2));
+}
+
+// RFS mixin
+@mixin rfs($values, $property: font-size) {
+  @if $values != null {
+    $val: rfs-value($values);
+    $fluidVal: rfs-fluid-value($values);
+
+    // Do not print the media query if responsive & non-responsive values are the same
+    @if $val == $fluidVal {
+      #{$property}: $val;
+    }
+    @else {
+      @include _rfs-rule {
+        #{$property}: if($rfs-mode == max-media-query, $val, $fluidVal);
 
         // Include safari iframe resize fix if needed
         min-width: if($rfs-safari-iframe-resize-bug-fix, (0 * 1vw), null);
       }
+
+      @include _rfs-media-query-rule {
+        #{$property}: if($rfs-mode == max-media-query, $fluidVal, $val);
+      }
     }
   }
 }
 
-// The font-size & responsive-font-size mixins use RFS to rescale the font size
-@mixin font-size($fs, $important: false) {
-  @include rfs($fs, $important);
+// Shorthand helper mixins
+@mixin font-size($value) {
+  @include rfs($value);
 }
 
-@mixin responsive-font-size($fs, $important: false) {
-  @include rfs($fs, $important);
+@mixin padding($value) {
+  @include rfs($value, padding);
+}
+
+@mixin padding-top($value) {
+  @include rfs($value, padding-top);
+}
+
+@mixin padding-right($value) {
+  @include rfs($value, padding-right);
+}
+
+@mixin padding-bottom($value) {
+  @include rfs($value, padding-bottom);
+}
+
+@mixin padding-left($value) {
+  @include rfs($value, padding-left);
+}
+
+@mixin margin($value) {
+  @include rfs($value, margin);
+}
+
+@mixin margin-top($value) {
+  @include rfs($value, margin-top);
+}
+
+@mixin margin-right($value) {
+  @include rfs($value, margin-right);
+}
+
+@mixin margin-bottom($value) {
+  @include rfs($value, margin-bottom);
+}
+
+@mixin margin-left($value) {
+  @include rfs($value, margin-left);
 }


### PR DESCRIPTION
Currently, we cannot run docsy as module with HEAD of repo. This PR fixes that by bumping `_rfs.scss` used by docsy dependencies to the latest bootstrap version 5.2.3.
This also affects #1217, I will update that PR accordingly. Were great if #1217 could be reviewed soon.

