### PR TITLE
[BSv5] Footer fixes

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,17 +1,17 @@
-{{ $links := .Site.Params.links }}
+{{ $links := .Site.Params.links -}}
 <footer class="bg-dark py-5 row d-print-none">
-  <div class="container-fluid mx-sm-5">
+  <div class="container-fluid flex-shrink-1 mx-sm-5">
     <div class="row">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
         {{ with $links }}
-        {{ with index . "user"}}
+        {{ with index . "user" }}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3">
+      <div class="col-6 col-sm-4 text-end text-xs-center order-sm-3">
         {{ with $links }}
-        {{ with index . "developer"}}
+        {{ with index . "developer" }}
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
@@ -19,14 +19,15 @@
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
         {{ with .Site.Params.privacy_policy }}<small class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
-	{{ if not .Site.Params.ui.footer_about_disable }}
-		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
-	{{ end }}
+        {{ if not .Site.Params.ui.footer_about_disable -}}
+          {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+        {{ end }}
       </div>
     </div>
   </div>
 </footer>
-{{ define "footer-links-block" }}
+
+{{- define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
@@ -36,4 +37,4 @@
   </li>
   {{ end }}
 </ul>
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
- Contributes to #470
- Closes #1364
- `text-right` becomes `text-end`
- Resets the `flex-shrink` to the default of 1 in the footer container. Otherwise the margin settings cause the footer container to overflow. I've inquired as to why the `flex-shrink` value was changed to 0 for all columns: 
  https://github.com/twbs/bootstrap/discussions/37951
- Cleans up indentation and removes some excessive whitespace

Note that icons are a bit smaller, so the footer "links block" will be a bit narrower.