### PR TITLE
[BSv5]: make docsy point to latest version of dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 // indirect
-	github.com/google/docsy/dependencies v0.6.0 // indirect
+	github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e // indirect
 	github.com/twbs/bootstrap v5.2.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/google/docsy/dependencies v0.4.1-0.20220905171817-ae8b8117ed16/go.mod
 github.com/google/docsy/dependencies v0.5.1-0.20221014161617-be5da07ecff1 h1:DH0NbaXJjODFImfRJGCSXDhnRO/IaD2VTGVlRjULUtc=
 github.com/google/docsy/dependencies v0.5.1-0.20221014161617-be5da07ecff1/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/google/docsy/dependencies v0.5.1/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e h1:lfvr9ByCkuIz/ARoEDC/6gucVRjkooYTts5P+0yq5Qk=
+github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e/go.mod h1:qhtpynRkDn1FOmD1gj0a5n6ptDjDw0O4Zmb+6pfYUKU=
 github.com/twbs/bootstrap v4.6.2+incompatible h1:TDa+R51BTiy1wEHSYjmqDb8LxNl/zaEjAOpRE9Hwh/o=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=


### PR DESCRIPTION
This PR is related to #1372. It ensures that users can run docsy as module from HEAD of repo again.