### PR TITLE
go.sum: clear unused entries, and tabpane cleanup

### DIFF
--- a/dependencies/go.sum
+++ b/dependencies/go.sum
@@ -1,6 +1,4 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 h1:xfr9SidRCMEh4A8fdkLhFPcHAVbrdv3Ua0Jp/nSmhhQ=
 github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e h1:lfvr9ByCkuIz/ARoEDC/6gucVRjkooYTts5P+0yq5Qk=
-github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e/go.mod h1:qhtpynRkDn1FOmD1gj0a5n6ptDjDw0O4Zmb+6pfYUKU=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -59,7 +59,7 @@
       {{ $lang = $element.header -}}
     {{ end -}}
     {{ with $element.language -}}
-      {{ $lang = $element.language -}}
+      {{ $lang = . -}}
     {{ end -}}
 
     {{/* Check for duplicate languages */ -}}
@@ -116,7 +116,7 @@
       {{ $lang = $element.header -}}
     {{ end -}}
     {{ with $element.language -}}
-      {{ $lang = $element.language -}}
+      {{ $lang = . -}}
     {{ end -}}
 
     {{ $disabled := false -}}
@@ -126,7 +126,7 @@
 
     {{ $hloptions := $hloptionsPane -}}
     {{ with $element.highlight -}}
-      {{ $hloptions = $element.highlight -}}
+      {{ $hloptions = . -}}
     {{ end -}}
 
     {{ $text := $textPane -}}


### PR DESCRIPTION
```
@deining - is the content of this file meant to be (generally) cumulative?
Eg., why are there still entries for older versions of the Docsy dependencies and BS v4?
```

_Originally posted by @chalin in https://github.com/google/docsy/pull/1374#discussion_r1092526849_

The entries for older versions of the Docsy dependencies and BS v4 can be safely removed. That's what this PR is about.
The PR also performs minor code cleanup within the shortcode 'tabpane'.