### PR TITLE
[BSv5] Fix SCSS functions import issue, and replace darken()

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -38,7 +38,7 @@ $gray-800: #333 !default;
 $gray-900: #222 !default;
 $black: #000 !default;
 
-$code-color: darken($secondary, 20%) !default;
+$code-color: shade-color($secondary, 40%) !default;
 
 // UI element colors
 
@@ -52,9 +52,9 @@ $td-sidebar-border-color: $border-color !default;
 // These colors are all part of the theme palette, but the mix is fairly random to create variation. This can be overridden by the project if needed.
 $td-box-colors: $dark, $primary, $secondary, $info, $gray-600, $success, $warning, $dark, $danger, $primary, $secondary, $info !default;
 
-$link-color: darken($blue, 15%) !default;
+$link-color: adjust-color($blue, $lightness: -15%) !default;
 $link-decoration: none !default;
-$link-hover-color: darken($link-color, 15%) !default;
+$link-hover-color: shade-color($link-color, 30%) !default;
 $link-hover-decoration: none !default;
 
 // Fonts
@@ -116,7 +116,7 @@ $td-block-space-bottom-base: 4 * $spacer !default;
 
 $pagination-color: $gray-600 !default;
 $pagination-border-color: rgba($black, 0.1) !default;
-$pagination-active-border-color: darken($primary, 5%) !default;
+$pagination-active-border-color: adjust-color($primary, $lightness: -5%) !default;
 $pagination-disabled-color: $gray-300 !default;
 
 // Navbar

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,3 +1,5 @@
+@import "../vendor/bootstrap/scss/functions";
+
 @import "support/functions";
 @import "variables_project";
 @import "variables";


### PR DESCRIPTION
⚠️ See below for an **IMPORTANT DESIGN NOTE**!

This PR:

- Contributes to #470
- Imports Bootstrap's `functions` first! For details, see the design note below.
- Replaces `darken()` by other functions, getting some guidance from:
  - [Bootstrap did it][bs-color-sys] ([#30622])
  - [Sass `darken()` documentation][sass-darken] , which describes suitable replacements

Followup:

- #1387

---

## ⚠️ Design note regarding `functions` import fix

### Is this fix really necessary?

Without the import fix included in this PR, use of Bootstrap `functions` can result in bogus errors like the following:

> argument `$color` of `<some-bs-function>(...)` must be a color

when in fact the argument _is_ a color.

### Learn more

For details concerning the need to import `functions.scss` first, see the Bootstrap migration guide under [New _maps.scss][bs-new-maps]

### Design choice: double import vs. inlining many imports

In this PR, I'm proposing to `@import "functions"` before our variable overrides, and then import the full Bootstrap suite of SCSS. This will result in the "functions" file being loaded twice, but according to the [Sass `@import` documentation](https://sass-lang.com/documentation/at-rules/import):

> If the same stylesheet is imported more than once, it will be evaluated again each time. If it just defines functions and mixins, this usually isn’t a big deal, but if it contains style rules they’ll be compiled to CSS more than once.

The [_functions.scss](https://github.com/twbs/bootstrap/blob/main/scss/_functions.scss) file doesn't contain any style rules, so we should be ok. The alternative would be to inline all of the 40+ imports in https://github.com/twbs/bootstrap/blob/main/scss/bootstrap.scss, which would be a significant maintenance overhead, one that I think that we can avoid (until proven otherwise).

[#30622]: https://github.com/twbs/bootstrap/pull/30622
[bs-color-sys]: https://getbootstrap.com/docs/5.3/migration/#color-system
[bs-new-maps]: https://getbootstrap.com/docs/5.3/migration/#new-_mapsscss
[sass-darken]: https://sass-lang.com/documentation/modules/color#darken