### PR TITLE
Upgrade FontAwesome to 6.3.0 and tweak update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
     "serve": "npm run cd:docs serve",
     "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest",
-    "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@6 bootstrap@5"
+    "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest"
   },
   "cspell": "cSpell:ignore docsy userguide fortawesome fontawesome ",
   "prettier": {
     "proseWrap": "always"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.2.1",
+    "@fortawesome/fontawesome-free": "6.3.0",
     "bootstrap": "5.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This upgrade does not affect generated page content, only resources:

```console
$ (cd public && git diff -bw --ignore-blank-lines) | grep ^diff 
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
diff --git a/webfonts/fa-brands-400.ttf b/webfonts/fa-brands-400.ttf
diff --git a/webfonts/fa-brands-400.woff2 b/webfonts/fa-brands-400.woff2
diff --git a/webfonts/fa-regular-400.ttf b/webfonts/fa-regular-400.ttf
diff --git a/webfonts/fa-regular-400.woff2 b/webfonts/fa-regular-400.woff2
diff --git a/webfonts/fa-solid-900.ttf b/webfonts/fa-solid-900.ttf
diff --git a/webfonts/fa-solid-900.woff2 b/webfonts/fa-solid-900.woff2
diff --git a/webfonts/fa-v4compatibility.ttf b/webfonts/fa-v4compatibility.ttf
diff --git a/webfonts/fa-v4compatibility.woff2 b/webfonts/fa-v4compatibility.woff2
```