### PR TITLE
[BSv5] Drop invalid and unnecessary tooltip attribute

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -30,7 +30,7 @@
 {{- define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-bs-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+  <li class="list-inline-item mx-2 h3" data-bs-toggle="tooltip" title="{{ .name }}" aria-label="{{ .name }}">
     <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>


### PR DESCRIPTION
- Cleanup following #1382
- Removes `data-placement`, which should have been renamed to `data-bs-placement`, because "top" is the default value.