### PR TITLE
Module setup: bump FontAwesome to latest version 6.3.0

### DIFF
--- a/dependencies/go.mod
+++ b/dependencies/go.mod
@@ -3,6 +3,6 @@ module github.com/google/docsy/dependencies
 go 1.12
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815 // indirect
 	github.com/twbs/bootstrap v5.2.3+incompatible // indirect
 )

--- a/dependencies/go.sum
+++ b/dependencies/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 h1:xfr9SidRCMEh4A8fdkLhFPcHAVbrdv3Ua0Jp/nSmhhQ=
-github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815 h1:IgbtROhk8s9GkcNxrqFKAzR5rmDwV/QQ4Y31pb6crM8=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/google/docsy
 go 1.12
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815 // indirect
 	github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e // indirect
 	github.com/twbs/bootstrap v5.2.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4 h1:xfr9SidRCMEh4A8fdkLhFPcHAVbrdv3Ua0Jp/nSmhhQ=
-github.com/FortAwesome/Font-Awesome v0.0.0-20221115183454-96cafbd73ec4/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815 h1:IgbtROhk8s9GkcNxrqFKAzR5rmDwV/QQ4Y31pb6crM8=
+github.com/FortAwesome/Font-Awesome v0.0.0-20230207192303-d02961b01815/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e h1:lfvr9ByCkuIz/ARoEDC/6gucVRjkooYTts5P+0yq5Qk=
 github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e/go.mod h1:qhtpynRkDn1FOmD1gj0a5n6ptDjDw0O4Zmb+6pfYUKU=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=

--- a/userguide/content/en/docs/Updating/Convert-site-to-module.md
+++ b/userguide/content/en/docs/Updating/Convert-site-to-module.md
@@ -187,8 +187,8 @@ hugo mod graph
 hugo: collected modules in 1092 ms
 github.com/me/my-existing-site github.com/google/docsy@v{{% param "version" %}}
 github.com/me/my-existing-site github.com/google/docsy/dependencies@v{{% param "version" %}}
-github.com/google/docsy/dependencies@v{{% param "version" %}} github.com/twbs/bootstrap@v4.6.1+incompatible
-github.com/google/docsy/dependencies@v{{% param "version" %}} github.com/FortAwesome/Font-Awesome@v0.0.0-20210804190922-7d3d774145ac
+github.com/google/docsy/dependencies@v{{% param "version" %}} github.com/twbs/bootstrap@v5.2.3+incompatible
+github.com/google/docsy/dependencies@v{{% param "version" %}} github.com/FortAwesome/Font-Awesome@v0.0.0-20230207192303-d02961b01815
 ```
 
 Make sure that three lines with dependencies `docsy`, `bootstrap` and `Font-Awesome` are listed. If not, please double check your config settings.


### PR DESCRIPTION
Following up on #1403, this PR bumps FontAwesome to latest version for module setup, too.