### PR TITLE
[BS5] Breadcrumbs active-breadcrumb fix

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -13,7 +13,7 @@
           {{ if not .Site.Params.ui.taxonomy_breadcrumb_disable -}}
             {{/* Use breadcrumb partial, but remove attributes that are invalid or inappropriate in this page-summary context. */ -}}
             {{ partial "breadcrumb.html" .
-              | replaceRE ` aria-\w+=\".*?\"|(breadcrumb-item) active|(btn-link) disabled` "$1" | safeHTML
+              | replaceRE ` aria-\w+=\".*?\"|(breadcrumb-item) active` "$1" | safeHTML
             -}}
           {{ end -}}
           <p>{{ .Description | markdownify }}</p>

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -20,10 +20,10 @@
   {{ $isActive :=  eq .p1 .p2 }}
   <li class="breadcrumb-item{{ if $isActive }} active{{ end }}"
       {{- if $isActive }} aria-current="page"{{ end }}>
-    <a href="{{ .p1.Permalink }}"
-      {{- if $isActive }} aria-disabled="true" class="btn-link disabled"{{ end -}}
-    >
-      {{- .p1.LinkTitle -}}
-    </a>
+    {{ if $isActive -}}
+      {{ .p1.LinkTitle -}}
+    {{ else -}}
+      <a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
+    {{- end -}}
   </li>
 {{- end -}}


### PR DESCRIPTION
- Contributes to #470
- Implements Bootstrap-5-based breadcrumbs.
- According to the following sources, the active breadcrumb is no longer represented as a disabled link, but rather plain text:
  - https://getbootstrap.com/docs/5.3/components/breadcrumb
  - https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
 
For ARIA details, see the following link, though the page (as of the time of writing) encodes the active breadcrumb the "old way" (as a link):

- https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb