### PR TITLE
[BS5] Adjust HTML of dropdowns for version and lang

### DIFF
--- a/layouts/partials/navbar-lang-selector.html
+++ b/layouts/partials/navbar-lang-selector.html
@@ -1,10 +1,12 @@
-{{/* Link directly to documentation etc., if possible. */}}
-{{ $langPage := cond (gt (len .Translations) 0) . .Site.Home }}
-<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	{{ $langPage.Language.LanguageName }}
-</a>
-<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-	{{ range $langPage.Translations }}
-	<a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
-	{{ end }}
+{{/* Link directly to documentation etc., if possible. */ -}}
+{{ $langPage := cond (gt (len .Translations) 0) . .Site.Home -}}
+<div class="dropdown">
+  <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    {{- $langPage.Language.LanguageName -}}
+  </a>
+  <ul class="dropdown-menu">
+    {{ range $langPage.Translations -}}
+    <li><a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
+    {{ end -}}
+  </ul>
 </div>

--- a/layouts/partials/navbar-version-selector.html
+++ b/layouts/partials/navbar-version-selector.html
@@ -1,12 +1,14 @@
-<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-	{{ .Site.Params.version_menu }}
-</a>
-<div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-	{{ $path := "" }}
-	{{ if .Site.Params.version_menu_pagelinks }}
-		{{ $path = .Page.RelPermalink }}
-	{{ end }}
-	{{ range .Site.Params.versions }}
-	<a class="dropdown-item" href="{{ .url }}{{ $path }}">{{ .version }}</a>
-	{{ end }}
+<div class="dropdown">
+  <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    {{- .Site.Params.version_menu -}}
+  </a>
+  <ul class="dropdown-menu">
+    {{ $path := "" -}}
+    {{ if .Site.Params.version_menu_pagelinks -}}
+      {{ $path = .Page.RelPermalink -}}
+    {{ end -}}
+    {{ range .Site.Params.versions -}}
+    <li><a class="dropdown-item" href="{{ .url }}{{ $path }}">{{ .version }}</a></li>
+    {{ end -}}
+  </ul>
 </div>


### PR DESCRIPTION
- Contributes to #470
- Updates the HTML generated for the nav versions and languages dropdown. The updates were made according to ttps://getbootstrap.com/docs/5.3/components/dropdowns/

### Screenshot (with a versions menu added)

> <img width="1019" alt="image" src="https://user-images.githubusercontent.com/4140793/218599478-3a7cc422-2e09-45f4-b6f0-f55ae6b45616.png">
