### PR TITLE
Tabbed pane, fix: do not print blank first line

### DIFF
--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -141,7 +141,7 @@
         {{ if $text -}}
           {{ index . "content" -}}
         {{ else -}}
-          {{ highlight (trim (index . "content") "\n") $lang $hloptions -}}
+          {{ highlight (trim (index . "content") "\r\n") $lang $hloptions -}}
         {{ end }}
     </div>
 

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -331,7 +331,7 @@ in the response headers." you __CAN__ embed it, but when the test says "Great! X
 Sometimes it's very useful to have tabbed panes when authoring content. One common use-case is to show multiple syntax highlighted code blocks that showcase the same problem, and how to solve it in different programming languages. As an example, the tabbed pane below shows the language-specific variants of the famous `Hello world!` program one usually writes first when learning a new programming language:
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab "C" >}}
+{{< tab "C" >}}
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
If the line encoding of the page file with a tabbed pane is CRLF (windows line endings), a blank first line is added in each tab of the tabpane. This PR fixes this issue. This PR also corrects an indentation on the way.