### PR TITLE
package.json: add license and homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "docsy",
   "version": "0.6.0",
+  "homepage": "https://docsy.dev",
+  "license": "Apache-2.0",
   "repository": "github:google/docsy",
   "scripts": {
     "_cd:docs": "cd userguide &&",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "docsy",
-  "version": "0.6.0",
-  "homepage": "https://docsy.dev",
-  "license": "Apache-2.0",
+  "version": "0.7.0-dev",
   "repository": "github:google/docsy",
+  "homepage": "https://www.docsy.dev",
+  "license": "Apache-2.0",
   "scripts": {
     "_cd:docs": "cd userguide &&",
     "build:preview": "npm run cd:docs build:preview",


### PR DESCRIPTION
This PR corrects an issue reported with #1421.

When running `npm view`, incorrect license information is printed: 

```
$ npm view deining/docsy

docsy@0.6.0 | Proprietary | deps: 2 | versions: 1

...
```