### PR TITLE
[BSv5] Adjusted offline search popover

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -7,17 +7,6 @@
         const $searchInput = $('.td-search input');
 
         //
-        // Options for popover
-        //
-
-        $searchInput.data('html', true);
-        $searchInput.data('placement', 'bottom');
-        $searchInput.data(
-            'template',
-            '<div class="td-offline-search-results popover" role="tooltip"><div class="popover-arrow"></div><h3 class="popover-header"></h3><div class="popover-body"></div></div>'
-        );
-
-        //
         // Register handler
         //
 
@@ -71,8 +60,18 @@
         );
 
         const render = ($targetSearchInput) => {
-            // Dispose the previous result
-            $targetSearchInput.popover('dispose');
+            //
+            // Dispose existing popover
+            //
+
+            {
+                let popover = bootstrap.Popover.getInstance(
+                    $targetSearchInput[0]
+                );
+                if (popover !== null) {
+                    popover.dispose();
+                }
+            }
 
             //
             // Search
@@ -130,8 +129,9 @@
                             .css({ fontWeight: 'bold' })
                     )
                     .append(
-                        $('<span>')
-                            .addClass('td-offline-search-results__close-button')
+                        $('<span>').addClass(
+                            'td-offline-search-results__close-button'
+                        )
                     )
             );
 
@@ -178,16 +178,23 @@
                 });
             }
 
-            $targetSearchInput.on('shown.bs.popover', () => {
-                $('.td-offline-search-results__close-button').on('click', () => {
-                    $targetSearchInput.val('');
-                    $targetSearchInput.trigger('change');
-                });
+            $targetSearchInput.one('shown.bs.popover', () => {
+                $('.td-offline-search-results__close-button').on(
+                    'click',
+                    () => {
+                        $targetSearchInput.val('');
+                        $targetSearchInput.trigger('change');
+                    }
+                );
             });
 
-            $targetSearchInput
-                .data('content', $html[0])
-                .popover('show');
+            const popover = new bootstrap.Popover($targetSearchInput, {
+                content: $html[0],
+                html: true,
+                customClass: 'td-offline-search-results',
+                placement: 'bottom',
+            });
+            popover.show();
         };
     });
 })(jQuery);


### PR DESCRIPTION
- Closes #1425
- Stop using `$targetSearchInput.popover`.
- Move popover options to `new bootstrap.Popover` constructor from `$searchInput.data`.
- Use `customClass` option to add `td-offline-search-results ` class instead of using template option.
- Fixed an issue that  `shown.bs.popover` is called more times than required when popover is shown multiple times.

<img width="1600" alt="Screenshot 2023-02-17 at 0 42 22" src="https://user-images.githubusercontent.com/659178/219415444-c6434b21-eb5a-4cb9-9ea5-35f57961a00b.png">
