### PR TITLE
Search resource cleanup and style tweak

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -1,200 +1,183 @@
 // Adapted from code by Matt Walters https://www.mattwalters.net/posts/2018-03-28-hugo-and-lunr/
 
 (function ($) {
-    'use strict';
+  'use strict';
 
-    $(document).ready(function () {
-        const $searchInput = $('.td-search input');
+  $(document).ready(function () {
+    const $searchInput = $('.td-search input');
 
-        //
-        // Register handler
-        //
+    //
+    // Register handler
+    //
 
-        $searchInput.on('change', (event) => {
-            render($(event.target));
+    $searchInput.on('change', (event) => {
+      render($(event.target));
 
-            // Hide keyboard on mobile browser
-            $searchInput.blur();
-        });
-
-        // Prevent reloading page by enter key on sidebar search.
-        $searchInput.closest('form').on('submit', () => {
-            return false;
-        });
-
-        //
-        // Lunr
-        //
-
-        let idx = null; // Lunr index
-        const resultDetails = new Map(); // Will hold the data for the search results (titles and summaries)
-
-        // Set up for an Ajax call to request the JSON data file that is created by Hugo's build process
-        $.ajax($searchInput.data('offline-search-index-json-src')).then(
-            (data) => {
-                idx = lunr(function () {
-                    this.ref('ref');
-
-                    // If you added more searchable fields to the search index, list them here.
-                    // Here you can specify searchable fields to the search index - e.g. individual toxonomies for you project
-                    // With "boost" you can add weighting for specific (default weighting without boost: 1)
-                    this.field('title', { boost: 5 });
-                    this.field('categories', { boost: 3 });
-                    this.field('tags', { boost: 3 });
-                    // this.field('projects', { boost: 3 }); // example for an individual toxonomy called projects
-                    this.field('description', { boost: 2 });
-                    this.field('body');
-
-                    data.forEach((doc) => {
-                        this.add(doc);
-
-                        resultDetails.set(doc.ref, {
-                            title: doc.title,
-                            excerpt: doc.excerpt,
-                        });
-                    });
-                });
-
-                $searchInput.trigger('change');
-            }
-        );
-
-        const render = ($targetSearchInput) => {
-            //
-            // Dispose existing popover
-            //
-
-            {
-                let popover = bootstrap.Popover.getInstance(
-                    $targetSearchInput[0]
-                );
-                if (popover !== null) {
-                    popover.dispose();
-                }
-            }
-
-            //
-            // Search
-            //
-
-            if (idx === null) {
-                return;
-            }
-
-            const searchQuery = $targetSearchInput.val();
-            if (searchQuery === '') {
-                return;
-            }
-
-            const results = idx
-                .query((q) => {
-                    const tokens = lunr.tokenizer(searchQuery.toLowerCase());
-                    tokens.forEach((token) => {
-                        const queryString = token.toString();
-                        q.term(queryString, {
-                            boost: 100,
-                        });
-                        q.term(queryString, {
-                            wildcard:
-                                lunr.Query.wildcard.LEADING |
-                                lunr.Query.wildcard.TRAILING,
-                            boost: 10,
-                        });
-                        q.term(queryString, {
-                            editDistance: 2,
-                        });
-                    });
-                })
-                .slice(
-                    0,
-                    $targetSearchInput.data('offline-search-max-results')
-                );
-
-            //
-            // Make result html
-            //
-
-            const $html = $('<div>');
-
-            $html.append(
-                $('<div>')
-                    .css({
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        marginBottom: '1em',
-                    })
-                    .append(
-                        $('<span>')
-                            .text('Search results')
-                            .css({ fontWeight: 'bold' })
-                    )
-                    .append(
-                        $('<span>').addClass(
-                            'td-offline-search-results__close-button'
-                        )
-                    )
-            );
-
-            const $searchResultBody = $('<div>').css({
-                maxHeight: `calc(100vh - ${
-                    $targetSearchInput.offset().top -
-                    $(window).scrollTop() +
-                    180
-                }px)`,
-                overflowY: 'auto',
-            });
-            $html.append($searchResultBody);
-
-            if (results.length === 0) {
-                $searchResultBody.append(
-                    $('<p>').text(`No results found for query "${searchQuery}"`)
-                );
-            } else {
-                results.forEach((r) => {
-                    const doc = resultDetails.get(r.ref);
-                    const href =
-                        $searchInput.data('offline-search-base-href') +
-                        r.ref.replace(/^\//, '');
-
-                    const $entry = $('<div>').addClass('mt-4');
-
-                    $entry.append(
-                        $('<small>').addClass('d-block text-muted').text(r.ref)
-                    );
-
-                    $entry.append(
-                        $('<a>')
-                            .addClass('d-block')
-                            .css({
-                                fontSize: '1.2rem',
-                            })
-                            .attr('href', href)
-                            .text(doc.title)
-                    );
-
-                    $entry.append($('<p>').text(doc.excerpt));
-
-                    $searchResultBody.append($entry);
-                });
-            }
-
-            $targetSearchInput.one('shown.bs.popover', () => {
-                $('.td-offline-search-results__close-button').on(
-                    'click',
-                    () => {
-                        $targetSearchInput.val('');
-                        $targetSearchInput.trigger('change');
-                    }
-                );
-            });
-
-            const popover = new bootstrap.Popover($targetSearchInput, {
-                content: $html[0],
-                html: true,
-                customClass: 'td-offline-search-results',
-                placement: 'bottom',
-            });
-            popover.show();
-        };
+      // Hide keyboard on mobile browser
+      $searchInput.blur();
     });
+
+    // Prevent reloading page by enter key on sidebar search.
+    $searchInput.closest('form').on('submit', () => {
+      return false;
+    });
+
+    //
+    // Lunr
+    //
+
+    let idx = null; // Lunr index
+    const resultDetails = new Map(); // Will hold the data for the search results (titles and summaries)
+
+    // Set up for an Ajax call to request the JSON data file that is created by Hugo's build process
+    $.ajax($searchInput.data('offline-search-index-json-src')).then((data) => {
+      idx = lunr(function () {
+        this.ref('ref');
+
+        // If you added more searchable fields to the search index, list them here.
+        // Here you can specify searchable fields to the search index - e.g. individual toxonomies for you project
+        // With "boost" you can add weighting for specific (default weighting without boost: 1)
+        this.field('title', { boost: 5 });
+        this.field('categories', { boost: 3 });
+        this.field('tags', { boost: 3 });
+        // this.field('projects', { boost: 3 }); // example for an individual toxonomy called projects
+        this.field('description', { boost: 2 });
+        this.field('body');
+
+        data.forEach((doc) => {
+          this.add(doc);
+
+          resultDetails.set(doc.ref, {
+            title: doc.title,
+            excerpt: doc.excerpt,
+          });
+        });
+      });
+
+      $searchInput.trigger('change');
+    });
+
+    const render = ($targetSearchInput) => {
+      //
+      // Dispose existing popover
+      //
+
+      {
+        let popover = bootstrap.Popover.getInstance($targetSearchInput[0]);
+        if (popover !== null) {
+          popover.dispose();
+        }
+      }
+
+      //
+      // Search
+      //
+
+      if (idx === null) {
+        return;
+      }
+
+      const searchQuery = $targetSearchInput.val();
+      if (searchQuery === '') {
+        return;
+      }
+
+      const results = idx
+        .query((q) => {
+          const tokens = lunr.tokenizer(searchQuery.toLowerCase());
+          tokens.forEach((token) => {
+            const queryString = token.toString();
+            q.term(queryString, {
+              boost: 100,
+            });
+            q.term(queryString, {
+              wildcard:
+                lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING,
+              boost: 10,
+            });
+            q.term(queryString, {
+              editDistance: 2,
+            });
+          });
+        })
+        .slice(0, $targetSearchInput.data('offline-search-max-results'));
+
+      //
+      // Make result html
+      //
+
+      const $html = $('<div>');
+
+      $html.append(
+        $('<div>')
+          .css({
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: '1em',
+          })
+          .append(
+            $('<span>').text('Search results').css({ fontWeight: 'bold' })
+          )
+          .append(
+            $('<span>').addClass('td-offline-search-results__close-button')
+          )
+      );
+
+      const $searchResultBody = $('<div>').css({
+        maxHeight: `calc(100vh - ${
+          $targetSearchInput.offset().top - $(window).scrollTop() + 180
+        }px)`,
+        overflowY: 'auto',
+      });
+      $html.append($searchResultBody);
+
+      if (results.length === 0) {
+        $searchResultBody.append(
+          $('<p>').text(`No results found for query "${searchQuery}"`)
+        );
+      } else {
+        results.forEach((r) => {
+          const doc = resultDetails.get(r.ref);
+          const href =
+            $searchInput.data('offline-search-base-href') +
+            r.ref.replace(/^\//, '');
+
+          const $entry = $('<div>').addClass('mt-4');
+
+          $entry.append(
+            $('<small>').addClass('d-block text-muted').text(r.ref)
+          );
+
+          $entry.append(
+            $('<a>')
+              .addClass('d-block')
+              .css({
+                fontSize: '1.2rem',
+              })
+              .attr('href', href)
+              .text(doc.title)
+          );
+
+          $entry.append($('<p>').text(doc.excerpt));
+
+          $searchResultBody.append($entry);
+        });
+      }
+
+      $targetSearchInput.one('shown.bs.popover', () => {
+        $('.td-offline-search-results__close-button').on('click', () => {
+          $targetSearchInput.val('');
+          $targetSearchInput.trigger('change');
+        });
+      });
+
+      const popover = new bootstrap.Popover($targetSearchInput, {
+        content: $html[0],
+        html: true,
+        customClass: 'td-offline-search-results',
+        placement: 'bottom',
+      });
+      popover.show();
+    };
+  });
 })(jQuery);

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -14,30 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-(function($) {
+(function ($) {
+  'use strict';
 
-    'use strict';
+  var Search = {
+    init: function () {
+      $(document).ready(function () {
+        $(document).on('keypress', '.td-search input', function (e) {
+          if (e.keyCode !== 13) {
+            return;
+          }
 
-    var Search = {
-        init: function() {
-            $(document).ready(function() {
-               $(document).on('keypress', '.td-search input', function(e) {
-                    if (e.keyCode !== 13) {
-                        return
-                    }
+          var query = $(this).val();
+          var searchPage = '{{ "search/" | absURL }}?q=' + query;
+          document.location = searchPage;
 
-                    var query = $(this).val();
-                    var searchPage = "{{ "search/" | absURL }}?q=" + query;
-                    document.location = searchPage;
+          return false;
+        });
+      });
+    },
+  };
 
-                    return false;
-                });
-
-            });
-        },
-    };
-
-    Search.init();
-
-
-}(jQuery));
+  Search.init();
+})(jQuery);

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -3,7 +3,7 @@
 .td-search {
     background: transparent;
     position: relative;
-    width: 90%;
+    width: 100%;
 
     // Search icon
     &__icon {


### PR DESCRIPTION
- Followup to #1429
- Runs Prettier over `js/*search.js` assets
  - Diff best viewed by ignoring whitespace changes
- Makes search input field 100% wide -- we need as wide as we can get it to be. 

## Screenshots

### Before

> <img width="1051" alt="image" src="https://user-images.githubusercontent.com/4140793/220787611-3c8159c1-9833-4084-a5f9-98b048601621.png">

### After

> <img width="1051" alt="image" src="https://user-images.githubusercontent.com/4140793/220787738-9d2f22ff-07bb-4672-a622-d178b9c19e6b.png">

> <img width="667" alt="image" src="https://user-images.githubusercontent.com/4140793/220787850-abc0bd64-915f-4e90-8f86-0e14b07b7e67.png">

