### PR TITLE
User guide, deployment page: add section 'Deployment on GitHub Pages'

### DIFF
--- a/userguide/content/en/docs/deployment/_index.md
+++ b/userguide/content/en/docs/deployment/_index.md
@@ -86,41 +86,41 @@ Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '
 {{% /alert %}}
 
 1. With GitHub Pages, a site is published to the branch `gh-pages` and served from there by default. You must create this branch first, either in the GitHub web interface or via command line (at the root of your local repo clone):
-    
+
     ```console
     $ git checkout -b gh-pages
     Switched to a new branch 'gh-pages'
     ```
-    
+
 1. Push this local branch to your repo:
-    
+
     ```console
     $ git push --set-upstream origin gh-pages
      details omitted …
      * [new branch]      new -> new
     branch 'gh-pages' set up to track 'origin/gh-pages'.
     ```
-    
+
 1. Switch back to the `main` (or `work`) branch of your repo:
-    
+
     ```console
     $ git checkout main
     Switched to branch 'main'
-    
+
     ```
-    
+
 1. Check if you already have the workflow file `.github/workflows/deploy-github-pages.yml` in your repo. If this file doesn't exist, do the following:
 
     1. Create a new empty workflow file from the root of your repo, as follows:
-    
+
        ```console
        $ mkdir -p .github/workflows
        $ touch .github/workflows/deploy-github-pages.yml
        ```
 
-    
+
     1. Open the file in an editor of your choice, paste in the code below, and save the file:
-    
+
        ```yaml
        name: Deployment to GitHub Pages
 
@@ -144,46 +144,46 @@ Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '
              - uses: actions/checkout@v3
                with:
                  fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
-    
+
              - name: Setup Hugo
                uses: peaceiris/actions-hugo@v2
                with:
-                 hugo-version: '0.110.0'
+                 hugo-version: '0.120.4'
                  extended: true
-    
+
              - name: Setup Node
-               uses: actions/setup-node@v3
+               uses: actions/setup-node@v4
                with:
-                 node-version: '18'
+                 node-version: '20'
                  cache: 'npm'
                  cache-dependency-path: '**/package-lock.json'
-    
+
              - run: npm ci
              - run: hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME} --minify
-    
+
              - name: Deploy
                uses: peaceiris/actions-gh-pages@v3
                if: ${{ github.ref == 'refs/heads/main' }} # <-- specify same branch as above here
                with:
                  github_token: ${{ secrets.GITHUB_TOKEN }}
        ```
-    
+
    1. Add the file to the staging area, commit your change and push the change to your remote GitHub repo:
-    
+
        ```console
        $ git add .github/workflows/deploy-github-pages.yml
        $ git commit -m "Adding workflow file for site deployment"
-       $ git push origin 
+       $ git push origin
        ```
-    
+
 1. In your browser, make sure you are logged into your GitHub account. In your repo  **Settings**, select **Pages**.
-    
+
     1. Under **Build and deployment**, select **Deploy from a branch** in the **source** dropdown.
-    
+
     2. From the **branch** dropdown, select **gh-page** as branch where the site is built from.
-    
+
     3. From the **folder** dropdown, select **/(root)** as root directory.
-    
+
 That's it! Your deployment workflow for your site is configured.
 
 Any future push to the branch specified in your workflow file will now trigger the action workflow defined in the workflow file. Additionally, you can trigger the deployment manually by using GitHub web UI.
@@ -194,7 +194,7 @@ Once you push to your repo, you can see the progress of the triggered workflow i
 URL 'Repo actions': https://github.com/<username>/<repository_name>/actions
 ```
 
-After the first successful deployment, a new environment `github-pages` is added to your repo. This is shown at the right of your repo main view (below **Releases** and **Packages**). When you click on this environment, a list of deployments is displayed:  
+After the first successful deployment, a new environment `github-pages` is added to your repo. This is shown at the right of your repo main view (below **Releases** and **Packages**). When you click on this environment, a list of deployments is displayed:
 
 ```
 URL 'Repo deployments': https://github.com/<username>/<repository_name>/deployments/

--- a/userguide/content/en/docs/deployment/_index.md
+++ b/userguide/content/en/docs/deployment/_index.md
@@ -45,11 +45,11 @@ Then follow the instructions in [Host on Netlify](https://gohugo.io/hosting-and-
       * If you are using Docsy as a [Hugo module](/docs/get-started/docsy-as-module/) or NPM package, you can just specify `hugo`.
    3. Click **Show advanced**.
    4. In the **Advanced build settings** section, click **New variable**.
-   5. Specify `NODE_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest LTS version](https://nodejs.org/en/download/) of node.js (minimum recommended version: `v18.x`).
+   5. Specify `NODE_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest LTS version](https://nodejs.org/en/download/) of node.js (minimum recommended version: `v20.x`).
    6. In the **Advanced build settings** section, click **New variable**.
-   7. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://github.com/gohugoio/hugo/releases) of Hugo (minimum recommended version: `0.110.0`).
+   7. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://github.com/gohugoio/hugo/releases) of Hugo (minimum recommended version: `0.125.4`).
    8. In the **Advanced build settings** section, click **New variable** again.
-   9. Specify `GO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://go.dev/dl/) of Go (minimum recommended version: `1.18`).
+   9. Specify `GO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://go.dev/dl/) of Go (minimum recommended version: `1.21`).
 
    If you don't want your site to be indexed by search engines, you can add an environment flag to your build command to specify a non-`production` environment, as described in [Build environments and indexing](#build-environments-and-indexing).
 1. Click **Deploy site**.
@@ -61,9 +61,9 @@ For example, if you want to use a version of `postcss-cli` later than version 8.
 
 ```
   "devDependencies": {
-    "autoprefixer": "^10.4.14",
-    "postcss-cli": "^10.1.0",
-    "postcss": "^8.4.24"
+    "autoprefixer": "^10.4.19",
+    "postcss-cli": "^11.0.0",
+    "postcss": "^8.4.38"
   }
 ```
 
@@ -141,14 +141,14 @@ Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '
            concurrency:
              group: ${{ github.workflow }}-${{ github.ref }}
            steps:
-             - uses: actions/checkout@v3
+             - uses: actions/checkout@v4
                with:
                  fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
 
              - name: Setup Hugo
-               uses: peaceiris/actions-hugo@v2
+               uses: peaceiris/actions-hugo@v3
                with:
-                 hugo-version: '0.120.4'
+                 hugo-version: '0.125.5'
                  extended: true
 
              - name: Setup Node
@@ -162,7 +162,7 @@ Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '
              - run: hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME} --minify
 
              - name: Deploy
-               uses: peaceiris/actions-gh-pages@v3
+               uses: peaceiris/actions-gh-pages@v4
                if: ${{ github.ref == 'refs/heads/main' }} # <-- specify same branch as above here
                with:
                  github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new section `Deployment on GitHub Pages` to the deployment page of the user guide.

You may have a look at the section preview at Netlify [here](https://deploy-preview-1435--docsydocs.netlify.app/docs/deployment/#deployment-on-github-pages).

The newly added section also refers to the deployment workfile, to be added to the example site via this [PR](https://github.com/google/docsy-example/pull/198). Both PRs are closely related and should be reviewed in parallel.

Thir PR also brings some minor corrections and amendments to the section `Deployment with Netlify`.