### PR TITLE
Fix community section colors

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -50,7 +50,7 @@ $td-sidebar-border-color: $border-color !default;
 // Background colors for the sections on home page etc. It is a paint by number system, starting at 0, where the number is taken from the shortcode's ordinal
 // if not provided by the user.
 // These colors are all part of the theme palette, but the mix is fairly random to create variation. This can be overridden by the project if needed.
-$td-box-colors: $dark, $primary, $secondary, $info, $gray-600, $success, $warning, $dark, $danger, $primary, $secondary, $info !default;
+$td-box-colors: $dark, $primary, $secondary, $info, $white, $gray-600, $success, $warning, $dark, $danger, $primary, $secondary, $info !default;
 
 $link-color: adjust-color($blue, $lightness: -15%) !default;
 $link-decoration: none !default;

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,7 +1,7 @@
-{{ define "main" }}
+{{ define "main" -}}
 
 <a class="td-offset-anchor"></a>
-<section class="row td-box td-box--1 position-relative td-box--gradient td-box--height-auto">
+<section class="row td-box td-box--primary position-relative td-box--gradient td-box--height-auto">
     <div class="container text-center td-arrow-down">
         <span class="h4 mb-0">
             <h1>{{ T "community_join" . }}</h1>
@@ -10,10 +10,12 @@
     </div>
 </section>
 
-{{ partial "community_links.html" . }}
+{{ partial "community_links.html" . -}}
 
+{{ with .Content -}}
 <div class="td-content">
-    {{ .Content }}
+{{ . }}
 </div>
+{{- end -}}
 
 {{ end }}

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -1,30 +1,33 @@
-{{ $links := .Site.Params.links }}
+{{ $links := .Site.Params.links -}}
 
-<section class="row td-box td-box--4 td-box--gradient td-box--height-auto linkbox">
-    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-        <h2>{{ T "community_learn" }}</h2>
-        <p>{{ T "community_using" . }}</p>
-        {{ with index $links "user"}}
-        {{ template "community-links-list" . }}
-        {{ end }}
-    </div>
-    <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
-        <h2>{{ T "community_develop" }}</h2>
-        <p>{{ T "community_contribute" . }}</p>
-        {{ with index $links "developer"}}
-        {{ template "community-links-list" . }}
-        {{ end }}
-        <p>{{ T "community_how_to" . }} <a href="/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>
-    </div>
+<section class="row td-box td-box--white td-box--gradient td-box--height-auto linkbox">
+  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+    <h2>{{ T "community_learn" }}</h2>
+    <p>{{ T "community_using" . }}</p>
+    {{ with index $links "user" -}}
+      {{ template "community-links-list" . -}}
+    {{ end }}
+  </div>
+  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+    <h2>{{ T "community_develop" }}</h2>
+    <p>{{ T "community_contribute" . }}</p>
+    {{ with index $links "developer" -}}
+      {{ template "community-links-list" . -}}
+    {{ end }}
+    <p>
+      {{ T "community_how_to" . }}
+      <a href="/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>
+    </p>
+  </div>
 </section>
 
-{{ define "community-links-list" }}
+{{ define "community-links-list" -}}
 <ul>
-    {{ range . }}
-    <li title="{{ .name }}">
-        <a target="_blank" rel="noopener" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ .name }}:</a>
-        {{ .desc }}
-    </li>
-    {{ end }}
-</ul>
+{{ range . -}}
+  <li title="{{ .name }}">
+    <a target="_blank" rel="noopener" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ .name }}</a>:
+    {{ .desc }}
+  </li>
 {{ end }}
+</ul>
+{{- end }}

--- a/userguide/content/en/community/_index.md
+++ b/userguide/content/en/community/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Community
 menu: {main: {weight: 40}}
+# Content below, if any, will be added to the community page.
 ---
-
-<!--add blocks of content here to add more sections to the community page -->


### PR DESCRIPTION
- Closes #1406
- Uses `td-box` color names instead of numbers in the community layouts
- Although not necessary to fix #1406, this PR recovers the intent of `$td-box-colors` by adding `$white` in replacement for `$primary-light`, which was dropped via #1384. This way we won't break Docsy's "painting by colors" feature (a feature which I think we should drop, but that's another story).

**Preview**: https://deploy-preview-1437--docsydocs.netlify.app/community/