### PR TITLE
Pin Docsy version in other installation options

### DIFF
--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -161,6 +161,15 @@ your project's root directory:
 1.  Install Docsy as a Git submodule:
 
     ```sh
+    git submodule add https://github.com/google/docsy.git themes/docsy
+    cd themes/docsy
+    git checkout v{{% param version %}}
+    ```
+
+    To work from the development version of Docsy (not recommended),
+    run the following command instead:
+
+    ```sh
     git submodule add --depth 1 https://github.com/google/docsy.git themes/docsy
     ```
 
@@ -215,17 +224,21 @@ maintain your own copy of the theme directly, or your deployment choice requires
 you to include a copy of the theme in your repository), you can clone the theme
 into your project's `themes` subdirectory.
 
-To clone Docsy into your project's `theme` folder, run the following commands
-from your project's root directory:
+To clone Docsy at v{{% param version %}} into your project's `theme` folder, run
+the following commands from your project's root directory:
 
 ```sh
 cd themes
-git clone https://github.com/google/docsy
+git clone -b v{{% param version %}} https://github.com/google/docsy
 cd docsy
 npm install
 ```
 
-Consider setting up an NPM [prepare][] script, as documented in Option 1.
+To work from the development version of Docsy (not recommended unless, for
+example, you plan to upstream changes to Docsy), omit the `-b v{{% param version
+%}}` argument from the clone command above.
+
+Then consider setting up an NPM [prepare][] script, as documented in Option 1.
 
 For more information, see
 [Theme Components](https://gohugo.io/hugo-modules/theme-components/) on the
@@ -245,8 +258,8 @@ You can use Docsy as an NPM module as follows:
 
 2.  Install Docsy, and postCSS (as [instructed earlier](#install-postcss)):
 
-    ```sh
-    npm install --save-dev google/docsy autoprefixer postcss-cli postcss
+    ```console
+    npm install --save-dev google/docsy#semver:{{% param version %}} autoprefixer postcss-cli postcss
     ```
 
 3.  Build or serve your new site using the usual Hugo commands, specifying the


### PR DESCRIPTION
- Updates instructions for "other installation options" so that the version of Docsy is pinned to the latest official release (as we've done for the main installation option).
- This is in response to #1421

**Preview**: e.g., see https://deploy-preview-1439--docsydocs.netlify.app/docs/get-started/other-options/#option-3-docsy-as-an-npm-package

/cc @NatasaKralj