### PR TITLE
NPM package config: set Node version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   },
   "devDependencies": {
     "hugo-extended": "0.110.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
This formally encode the Docsy project constraint that we officially support only the active LTS version of Node: https://github.com/google/docsy/blob/6f796f91dfabfbc26e3cfc1587a501a43503c686/.nvmrc#L1

