### PR TITLE
[BSv5] Drop import of rtl/main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
   - Clean up of unused, or rarely used, variables and functions:
     - Dropped `$primary-light`.
     - Dropped `color-diff()`.
+  - BSv4 RTL support, being incompatible with BSv5, has been removed. For
+    progress in RTL support, see [#1442][1442].
+
+[1442]: https://github.com/google/docsy/issues/1442
 
 **Other changes**:
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -33,39 +33,36 @@
 @import "shortcodes";
 
 @if $td-enable-google-fonts {
-    @import url($web-font-path);
+  @import url($web-font-path);
 }
 
 footer {
-    min-height: 150px;
+  min-height: 150px;
 
-    @include media-breakpoint-down(lg) {
-        min-height: 200px;
-    }
+  @include media-breakpoint-down(lg) {
+    min-height: 200px;
+  }
 }
 
 // Adjust anchors vs the fixed menu.
 @include media-breakpoint-up(md) {
-    .td-offset-anchor:target {
-        display: block;
-        position: relative;
-        top: -4rem;
-        visibility: hidden;
-    }
+  .td-offset-anchor:target {
+    display: block;
+    position: relative;
+    top: -4rem;
+    visibility: hidden;
+  }
 
-    h2[id]:before,
-    h3[id]:before,
-    h4[id]:before,
-    h5[id]:before {
-        display: block;
-        content: " ";
-        margin-top: -5rem;
-        height: 5rem;
-        visibility: hidden;
-    }
+  h2[id]:before,
+  h3[id]:before,
+  h4[id]:before,
+  h5[id]:before {
+    display: block;
+    content: " ";
+    margin-top: -5rem;
+    height: 5rem;
+    visibility: hidden;
+  }
 }
 
-
-
-@import "rtl/main";
 @import "styles_project";


### PR DESCRIPTION
- As is mentioned in the changelog, this drops the BSv5-incompatible RTL support we had before. We drop the `rtl/main` import from the main SCSS file, but keep the `rtl` style files for now.
- Contributes to #1442, which we'll use to track progress of RTL-support reintroduction
- View diff by ignoring whitespace changes