### PR TITLE
User guide, shortcodes, print preview: fix broken links

### DIFF
--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -412,15 +412,15 @@ This code translates to the right aligned tabbed pane below, showing a `Welcome!
 {{< tabpane text=true right=true >}}
   {{% tab header="**Languages**:" disabled=true /%}}
   {{% tab header="English" lang="en" %}}
-  ![Flag United Kingdom](flags/uk.png)
+  ![Flag United Kingdom](/docs/adding-content/shortcodes/flags/uk.png)
   **Welcome!**
   {{% /tab %}}
   {{< tab header="German" lang="de" >}}
     <b>Herzlich willkommen!</b>
-    <img src="flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
+    <img src="/docs/adding-content/shortcodes/flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
   {{< /tab >}}
   {{% tab header="Swahili" lang="sw" %}}
-  ![Flag Tanzania](flags/tz.png)
+  ![Flag Tanzania](/docs/adding-content/shortcodes/flags/tz.png)
   **Karibu sana!**
   {{% /tab %}}
 {{< /tabpane >}}


### PR DESCRIPTION
User guide, page `Shortcodes`, **regular** view:

![grafik](https://user-images.githubusercontent.com/18169566/221892975-22f86f50-7b2f-4d17-97cf-368c01401766.png)

User guide, page `Shortcodes`, **print** view:

![grafik](https://user-images.githubusercontent.com/18169566/221893565-cc65bc7b-6293-4373-b712-5bfe33179e51.png)

The link to the flag is broken in the print view. This PR address this issue and fixes it by using absolute image links.

