### PR TITLE
Use <pre> tag for mermaid code blocks

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,5 +1,5 @@
 {{ .Page.Store.Set "hasmermaid" true -}}
 
-<div class="mermaid">
-  {{- .Inner | safeHTML }}
-</div>
+<pre class="mermaid">
+  {{- .Inner }}
+</pre>


### PR DESCRIPTION
Right now a mermaid code block is enclosed in `<div>` tags. With this PR applied we now use `<pre>` tags instead, as suggested and discussed in #1450. 

**Note**: We are using `<pre>`tag for mermaid code blocks already here, so this PR makes behaviour consistent in all places.

https://github.com/google/docsy/blob/26d4d117a863fb55be71b624256cfd37f501c27f/assets/js/mermaid.js#L9-L12

This PR closes #1450.

---

**Preview**: https://deploy-preview-1451--docsydocs.netlify.app/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid