### PR TITLE
[BSv5] Drop redundant setting of BS `$enable-rounded` variable

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -1,17 +1,7 @@
-/*
+// Bootstrap options
 
-Bootstrap variables overrides for theme.
-See https://github.com/twbs/bootstrap/pull/23260
-*/
-
-// Bootstrap flags. For more, see https://getbootstrap.com/docs/4.0/getting-started/theming/
 $enable-gradients: true !default;
-$enable-rounded: true !default;
 $enable-shadows: true !default;
-
-// Theme flags.
-
-$td-enable-google-fonts: true !default;
 
 // Theme colors
 
@@ -58,6 +48,8 @@ $link-hover-color: shade-color($link-color, 30%) !default;
 $link-hover-decoration: none !default;
 
 // Fonts
+
+$td-enable-google-fonts: true !default;
 
 $google_font_name: "Open Sans" !default;
 $google_font_family: "Open+Sans:300,300i,400,400i,700,700i" !default;

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -30,9 +30,9 @@ PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in s
 
 ## Site colors
 
-To easily customize your site's colors, add SCSS variable overrides to
-`assets/scss/_variables_project.scss`. A simple example changing the primary and
-secondary color to two shades of purple:
+To customize your site's colors, add SCSS variable overrides to
+`assets/scss/_variables_project.scss`. For example, you can set the primary and
+secondary site colors as follows:
 
 ```scss
 $primary: #390040;
@@ -43,7 +43,6 @@ The theme has features such as rounded corners and gradient backgrounds enabled 
 
 ```scss
 $enable-gradients: true;
-$enable-rounded: true;
 $enable-shadows: true;
 ```
 


### PR DESCRIPTION
- Contributes to #470 (badges)
- Drops the redundant setting of `$enable-rounded` since we're using the BS default value, see https://getbootstrap.com/docs/5.3/customize/options/.