### PR TITLE
Shortcodes: Update readfile to throw compile error when file not found

### DIFF
--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -24,8 +24,8 @@ path */}}
 {{ end }}
 
 
-{{/* If the file exists, read it and highlight it if it's code. Throw an error
-if the file is not found */}}
+{{/* If the file exists, read it and highlight it if it's code.
+Throw a compile error or print an error on the page if the file is not found */}}
 
 {{ if fileExists ($.Scratch.Get "filepath") }}
   {{ if eq (.Get "code") "true" }}
@@ -34,4 +34,8 @@ if the file is not found */}}
   {{ else }}
     {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
   {{ end }}
-{{ else }}{{- errorf "File not found: %s %s" ($.Scratch.Get "filepath") .Position -}}{{ end }}
+{{ else if eq (.Get "draft") "true" }}
+
+  <p style="color: #D74848"><b><i>The file <code>{{ $.Scratch.Get "filepath" }}</code> was not found.</i></b></p> 
+
+{{ else }}{{- errorf "Shortcode %q: file %q not found at %s" .Name ($.Scratch.Get "filepath") .Position -}}{{ end }}

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -34,8 +34,4 @@ if the file is not found */}}
   {{ else }}
     {{- $.Scratch.Get "filepath" | os.ReadFile | .Page.RenderString | safeHTML -}}
   {{ end }}
-{{ else }}
-
-<p style="color: #D74848"><b><i>The file <code>{{ $.Scratch.Get "filepath" }}</code> was not found.</i></b></p>
-
-{{ end }}
+{{ else }}{{- errorf "File not found: %s %s" ($.Scratch.Get "filepath") .Position -}}{{ end }}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -679,13 +679,27 @@ under the parent file's working directory are supported.
 For files outside the current working directory you can use an absolute path
 starting with `/`. The root directory is the `/content` folder.
 
-
-
 | Parameter        | Default    | Description  |
 | ---------------- |------------| ------------|
 | file | | Path of external file|
 | code | false | Boolean value. If `true` the contents is treated as code|
 | lang | plain text | Programming language |
+
+### Error reporting
+
+If the shortcode can't find the specified file, the shortcode throws a compile error.
+
+In the following example, Hugo throws a compile error if it can't find `includes/deploy.yml`:
+
+```go-html-template
+{{</* readfile file="includes/deploy.yaml" code="true" lang="yaml" */>}}
+```
+
+Alternately, Hugo you can display a message on the rendered page instead of throwing a compile error. Add `draft="true"` as a parameter. For example:
+
+```go-html-template
+{{</* readfile file="includes/deploy.yaml" code="true" lang="yaml" draft="true" */>}}
+```
 
 ## Conditional text
 


### PR DESCRIPTION
* Update the `readfile` shortcode to throw a compile error when the file is not found. 
* Update userguide

Currently the shortcode prints a message on the UI, which presents a problem when refactoring a docs site. A UI message requires visual conformation and is easy to miss when moving or renaming directories. Throwing a compile error ensures the tech writer knows there is a problem.

With this modification, the default behavior is to throw a compile error:

<img width="1424" alt="readfile-compile-error" src="https://user-images.githubusercontent.com/26799583/232868051-daa8853f-015e-43a2-b4a7-5442202a79f1.png">

Alternately, the user can display a message on the page instead of having Hugo throw a compile error (this implements deining's suggestion)

![readfile-ui-msg](https://user-images.githubusercontent.com/26799583/232868353-d12f04d8-7b08-432f-b8d6-ef2f94849a4b.png)

