### PR TITLE
Delete duplicate mixin definitions

### DIFF
--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -1,4 +1,4 @@
-// Some simple mixins.
+// Mixins
 
 @mixin link-variant($parent, $color, $hover-color, $underline: false) {
   #{$parent} {

--- a/assets/scss/support/_utilities.scss
+++ b/assets/scss/support/_utilities.scss
@@ -1,30 +1,4 @@
-// Mixins
-
-@mixin optional-at-root($sel) {
-  @at-root #{if(not &, $sel, selector-append(&, $sel))} {
-    @content;
-  }
-}
-
-@mixin placeholder {
-  @include optional-at-root("::-webkit-input-placeholder") {
-    @content;
-  }
-
-  @include optional-at-root(":-moz-placeholder") {
-    @content;
-  }
-
-  @include optional-at-root("::-moz-placeholder") {
-    @content;
-  }
-
-  @include optional-at-root(":-ms-input-placeholder") {
-    @content;
-  }
-}
-
-// Common util classes.
+// Common utility classes
 
 .td-border-top {
   border: none;


### PR DESCRIPTION
- Cleanup done as part of #470
- Deletes mixins from `assets/scss/support/_utilities.scss` that appear in `assets/scss/support/_mixins.scss` with the exact same definitions.