### PR TITLE
[BSv5] Drop display SASS variables that no longer exist

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -91,17 +91,6 @@ $h4-font-size: $font-size-base * 1.35 !default;
 $h5-font-size: $font-size-base * 1.15 !default;
 $h6-font-size: $font-size-base !default;
 
-// Display styles
-
-$display1-weight: $font-weight-bold !default;
-$display2-weight: $font-weight-bold !default;
-$display3-weight: $font-weight-bold !default;
-$display4-weight: $font-weight-bold !default;
-$display1-size: 3rem !default;
-$display2-size: 2.5rem !default;
-$display3-size: 2rem !default;
-$display4-size: 1.75rem !default;
-
 // Space
 
 $spacer: 1rem;


### PR DESCRIPTION
- Contributes to #470
- Drops `$display<n>-*` variables since they no longer exist under BSv5