### PR TITLE
Avoid warning 'calling IsSet with unsupported type "invalid" (<nil>)'

### DIFF
--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,8 +1,5 @@
 {{/* We cache this partial for bigger sites and set the active class client side. */ -}}
-{{ $sidebarCacheLimit := 2000 -}}
-{{ with .Site.Params.ui.sidebar_cache_limit -}}
-    {{ $sidebarCacheLimit = . -}}
-{{ end -}}
+{{ $sidebarCacheLimit := .Site.Params.ui.sidebar_cache_limit | default 2000 -}}
 {{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
@@ -29,14 +26,8 @@
     {{ end -}}
     {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
     {{ $ulNr := 0 -}}
-    {{ $ulShow := 1 -}}
-    {{ with .Site.Params.ui.ul_show -}}
-        {{ $ulShow = . -}}
-    {{ end -}}
-    {{ $sidebarMenuTruncate := 50 -}}
-    {{ with .Site.Params.ui.sidebar_menu_truncate -}}
-        {{ $sidebarMenuTruncate = . -}}
-    {{ end -}}
+    {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
+    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 50 -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
       {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -1,5 +1,8 @@
-{{/* We cache this partial for bigger sites and set the active class client side. */}}
-{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
+{{/* We cache this partial for bigger sites and set the active class client side. */ -}}
+{{ $sidebarCacheLimit := 2000 -}}
+{{ with .Site.Params.ui.sidebar_cache_limit -}}
+    {{ $sidebarCacheLimit = . -}}
+{{ end -}}
 {{ $shouldDelayActive := ge (len .Site.Pages) $sidebarCacheLimit -}}
 <div id="td-sidebar-menu" class="td-sidebar__inner{{ if $shouldDelayActive }} d-none{{ end }}">
   {{ if not .Site.Params.ui.sidebar_search_disable -}}
@@ -26,8 +29,14 @@
     {{ end -}}
     {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
     {{ $ulNr := 0 -}}
-    {{ $ulShow := cond (isset .Site.Params.ui "ul_show") .Site.Params.ui.ul_show 1 -}}
-    {{ $sidebarMenuTruncate := cond (isset .Site.Params.ui "sidebar_menu_truncate") .Site.Params.ui.sidebar_menu_truncate 50 -}}
+    {{ $ulShow := 1 -}}
+    {{ with .Site.Params.ui.ul_show -}}
+        {{ $ulShow = . -}}
+    {{ end -}}
+    {{ $sidebarMenuTruncate := 50 -}}
+    {{ with .Site.Params.ui.sidebar_menu_truncate -}}
+        {{ $sidebarMenuTruncate = . -}}
+    {{ end -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
       {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,13 +1,7 @@
 {{/* The "active" toggle here may delay rendering, so we only cache this side bar menu for bigger sites. */ -}}
-{{ $sidebarCacheLimit := 2000 -}}
-{{ with .Site.Params.ui.sidebar_cache_limit -}}
-    {{ $sidebarCacheLimit = . -}}
-{{ end -}}
+{{ $sidebarCacheLimit := .Site.Params.ui.sidebar_cache_limit | default 2000 -}}
 {{ $shouldCache := ge (len .Site.Pages) $sidebarCacheLimit -}}
-{{ $sidebarCacheTypeRoot := false -}}
-{{ with .Site.Params.ui.sidebar_cache_type_root -}}
-    {{ $sidebarCacheTypeRoot = . -}}
-{{ end -}}
+{{ $sidebarCacheTypeRoot := .Site.Params.ui.sidebar_cache_type_root | default false -}}
 {{ if $shouldCache -}}
   {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
   <script>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,7 +1,13 @@
-{{/* The "active" toggle here may delay rendering, so we only cache this side bar menu for bigger sites.
-*/}}{{ $sidebarCacheLimit := cond (isset .Site.Params.ui "sidebar_cache_limit") .Site.Params.ui.sidebar_cache_limit 2000 -}}
+{{/* The "active" toggle here may delay rendering, so we only cache this side bar menu for bigger sites. */ -}}
+{{ $sidebarCacheLimit := 2000 -}}
+{{ with .Site.Params.ui.sidebar_cache_limit -}}
+    {{ $sidebarCacheLimit = . -}}
+{{ end -}}
 {{ $shouldCache := ge (len .Site.Pages) $sidebarCacheLimit -}}
-{{ $sidebarCacheTypeRoot := cond (isset .Site.Params.ui "sidebar_cache_type_root") .Site.Params.ui.sidebar_cache_type_root false -}}
+{{ $sidebarCacheTypeRoot := false -}}
+{{ with .Site.Params.ui.sidebar_cache_type_root -}}
+    {{ $sidebarCacheTypeRoot = . -}}
+{{ end -}}
 {{ if $shouldCache -}}
   {{ $mid := printf "m-%s" (.RelPermalink | anchorize) }}
   <script>

--- a/layouts/partials/taxonomy_terms_article_wrapper.html
+++ b/layouts/partials/taxonomy_terms_article_wrapper.html
@@ -1,6 +1,6 @@
 {{ $context := . }}
-{{ if isset .Site.Params "taxonomy" }}
-  {{ if isset .Site.Params.Taxonomy "taxonomypageheader" }}
+{{ if .Site.Params.Taxonomy }}
+  {{ if .Site.Params.Taxonomy.taxonomyPageHeader }}
     {{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyPageHeader }}
       {{ partial "taxonomy_terms_article.html" (dict "context" $context "taxo" $taxo) }}
     {{ end }}

--- a/layouts/partials/taxonomy_terms_clouds.html
+++ b/layouts/partials/taxonomy_terms_clouds.html
@@ -1,8 +1,8 @@
 {{ $context := . }}
-{{ if isset .Site.Params "taxonomy" }}
-	{{ if isset .Site.Params.Taxonomy "taxonomycloud" }}
+{{ if .Site.Params.taxonomy }}
+	{{ if .Site.Params.Taxonomy.taxonomyCloud }}
 		{{ range $index, $taxo := .Site.Params.Taxonomy.taxonomyCloud }}
-			{{ if isset $.Site.Params.Taxonomy "taxonomycloudtitle" }}
+			{{ if $.Site.Params.Taxonomy.taxonomyCloudTitle }}
 				{{ $.Scratch.Set "title" (index $.Site.Params.Taxonomy.taxonomyCloudTitle $index) }}
 			{{ else }}
 				{{ $.Scratch.Set "title" (humanize $taxo) }}


### PR DESCRIPTION
This PR addresses #1464.

As pointed out in #608 already, the root cause of the warning is the wrong use of `isset`.
This PR replaces `isset` and uses `with` clauses instead, thus avoiding the confusing warn messages.

This PR closes #1464.