### PR TITLE
[BSv5] blocks/cover row/col fix

### DIFF
--- a/assets/scss/blocks/_cover.scss
+++ b/assets/scss/blocks/_cover.scss
@@ -17,6 +17,7 @@
   }
 
   & > .byline {
+    @extend .small;
     position: absolute;
     bottom: 2px;
     right: 4px;

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -1,50 +1,50 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
-{{ $blockID := printf "td-cover-block-%d" .Ordinal }}
-{{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**background*" }}
-{{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" }}
-{{ $col_id := .Get "color" | default "dark" }}
-{{ $image_anchor := .Get "image_anchor" | default "smart" }}
-{{ $logo_anchor := .Get "logo_anchor" | default "smart" }}
-{{/* Height can be one of: auto, min, med, max, full. */}}
-{{ $height := .Get "height" | default "max" }}
-{{ $byline := .Get "byline" | default "" }}
-{{ with $promo_image }}
-{{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) }}
-{{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) }}
+{{ $_hugo_config := `{ "version": 1 }` -}}
+{{ $blockID := printf "td-cover-block-%d" .Ordinal -}}
+{{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**background*" -}}
+{{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" -}}
+{{ $col_id := .Get "color" | default "dark" -}}
+{{ $image_anchor := .Get "image_anchor" | default "smart" -}}
+{{ $logo_anchor := .Get "logo_anchor" | default "smart" -}}
+{{/* Height can be one of: auto, min, med, max, full. */ -}}
+{{ $height := .Get "height" | default "max" -}}
+
+{{ with $promo_image -}}
+{{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) -}}
+{{ $promo_image_small := (.Fill (printf "960x540 %s" $image_anchor)) -}}
 <link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
 <link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
 <style>
 #{{ $blockID }} {
-    background-image: url({{ $promo_image_small.RelPermalink }}); 
+  background-image: url({{ $promo_image_small.RelPermalink }});
 }
 @media only screen and (min-width: 1200px) {
-    #{{ $blockID }} {
-        background-image: url({{ $promo_image_big.RelPermalink }}); 
-    }
+  #{{ $blockID }} {
+    background-image: url({{ $promo_image_big.RelPermalink }});
+  }
 }
 </style>
-{{ end }}
-<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }}{{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover{{ end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
-  <div class="container td-overlay__inner">
-    <div class="row">
-      <div class="col-12">
-        <div class="text-center">
-          {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
-          {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
-          <div class="pt-3 lead">
-            {{ if eq .Page.File.Ext "md" }}
-                {{ .Inner | markdownify }}
-            {{ else }}
-                {{ .Inner | htmlUnescape | safeHTML }}
-            {{ end }}
-          </div>
+{{ end -}}
+
+<section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
+  {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
+  {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
+  <div class="col-12 p-0">
+    <div class="container td-overlay__inner">
+      <div class="text-center">
+        {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
+        {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
+        <div class="pt-3 lead">
+          {{ if eq .Page.File.Ext "md" }}
+              {{ .Inner | markdownify }}
+          {{ else }}
+              {{ .Inner | htmlUnescape | safeHTML }}
+          {{ end }}
         </div>
       </div>
     </div>
   </div>
-  {{ if $byline }}
-  <div class="byline">
-    <small>{{ $byline }}</small>
-  </div>
-  {{ end }}
+  {{ with .Get "byline" | default "" -}}
+    <div class="byline">{{ . }}</div>
+  {{- end }}
 </section>
+{{/**/ -}}

--- a/userguide/content/en/_index.html
+++ b/userguide/content/en/_index.html
@@ -2,7 +2,7 @@
 title: Docsy
 ---
 
-{{< blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" color="orange" >}}
+{{< blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" >}}
 <div class="mx-auto">
 	<a class="btn btn-lg btn-primary me-3 mb-4" href="{{< relref "/about" >}}">
 		Learn More <i class="fa-solid fa-circle-right ms-2"></i>

--- a/userguide/content/en/docs/adding-content/iconsimages.md
+++ b/userguide/content/en/docs/adding-content/iconsimages.md
@@ -57,7 +57,7 @@ Docsy's [`blocks/cover` shortcode](/docs/adding-content/shortcodes/#blockscover)
 You specify the preferred display height of a cover block container (and hence its image) using the block's `height` parameter.  For a full viewport height, use `full`:
 
 ```html
-{{</* blocks/cover title="Welcome to the Docsy Example Project!" image_anchor="top" height="full" color="orange" */>}}
+{{</* blocks/cover title="Welcome to the Docsy Example Project!" image_anchor="top" height="full" */>}}
 ...
 {{</* /blocks/cover */>}}
 ```


### PR DESCRIPTION
- Contributes to #1466
- Fixes the width/max-width of `blocks/cover`s
- Makes the child of `section.row` a column (`col-12`), and drops inner `.row` & `.col` wrappers
- Whitespace cleanup
- Byline cleanup

**Preview**:

- https://deploy-preview-1467--docsydocs.netlify.app
- https://deploy-preview-1467--docsydocs.netlify.app/about

---

### Screenshots

Screenshots of the homepage cover. You can also compare the About page covers.

Originally (under BSv4):

> <img width="900" alt="image" src="https://user-images.githubusercontent.com/4140793/223712970-a11abd71-2682-429e-9a20-f55e0c0a9a64.png">


Before this PR:

> <img width="900" alt="image" src="https://user-images.githubusercontent.com/4140793/223713035-b022cb56-bfc4-4c5d-bf15-9a5b2fcfc0b0.png">

With this PR's fix:

> <img width="900" alt="image" src="https://user-images.githubusercontent.com/4140793/223713159-5f175aa5-7c82-46f1-b898-77c34f52eef5.png">
