### PR TITLE
Make automatic detection of draw.io diagrams an opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 **Breaking changes:**
 
 - **Upgraded Bootstrap ([#470])** to v5.2. For a list of Bootstrap's breaking
-  changes, see the [Bootstrap migration page][bsv5mig]. Other, Docsy-specific
-  changes are listed below:
+  changes, see the [Bootstrap migration page][bsv5mig]. Docsy-specific changes:
   - Clean up of unused, or rarely used, variables, functions, and mixins:
     - Dropped `$primary-light`
     - Dropped `color-diff()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 **Breaking changes:**
 
-- **Upgraded Bootstrap ([#470])** to v5.2. For a list of Bootstrap breaking
-  changes, see the [Bootstrap migration guide][bsv5mig]. Other, Docsy-specific
+- **Upgraded Bootstrap ([#470])** to v5.2. For a list of Bootstrap's breaking
+  changes, see the [Bootstrap migration page][bsv5mig]. Other, Docsy-specific
   changes are listed below:
   - Clean up of unused, or rarely used, variables, functions, and mixins:
     - Dropped `$primary-light`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 **Breaking changes:**
 
-- **[Upgraded Bootstrap ([#470][])** to v5.2. For a list of Bootstrap breaking
+- **Upgraded Bootstrap ([#470])** to v5.2. For a list of Bootstrap breaking
   changes, see the [Bootstrap migration guide][bsv5mig]. Other, Docsy-specific
   changes are listed below:
   - Clean up of unused, or rarely used, variables, functions, and mixins:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 **Breaking changes:**
 
-- **Upgraded Bootstrap ([#470])** to v5.2. For a list of Bootstrap's breaking
-  changes, see the [Bootstrap migration guide][bsv5mig]. Other Docsy-specific
+- **Detection of draw.io diagrams** is now **disabled** by default [#1185][]
+
+- **[Upgraded Bootstrap ([#470][])** to v5.2. For a list of Bootstrap breaking
+  changes, see the [Bootstrap migration guide][bsv5mig]. Other, Docsy-specific
   changes are listed below:
   - Clean up of unused, or rarely used, variables, functions, and mixins:
     - Dropped `$primary-light`
@@ -52,6 +54,7 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
   - Draw.io diagram edit button: replaced custom colors by BS's outline primary.
 
 [#470]: https://github.com/google/docsy/issues/470
+[#1185]: https://github.com/google/docsy/issues/1185
 [#906]: https://github.com/google/docsy/issues/906
 [#939]: https://github.com/google/docsy/issues/939
 [#1369]: https://github.com/google/docsy/issues/1369

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 **Breaking changes:**
 
-- **Detection of draw.io diagrams** is now **disabled** by default [#1185][]
-
 - **[Upgraded Bootstrap ([#470][])** to v5.2. For a list of Bootstrap breaking
   changes, see the [Bootstrap migration guide][bsv5mig]. Other, Docsy-specific
   changes are listed below:
@@ -45,6 +43,8 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 [chroma-docsy]: https://www.docsy.dev/docs/adding-content/lookandfeel/#code-highlighting-with-chroma
 
+- **Detection of draw.io diagrams** is now **disabled** by default [#1185][]
+
 **Other changes**:
 
 - `$list-inline-padding` is increased in support of footer icons ([#1523]). If
@@ -54,9 +54,9 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
   - Draw.io diagram edit button: replaced custom colors by BS's outline primary.
 
 [#470]: https://github.com/google/docsy/issues/470
-[#1185]: https://github.com/google/docsy/issues/1185
 [#906]: https://github.com/google/docsy/issues/906
 [#939]: https://github.com/google/docsy/issues/939
+[#1185]: https://github.com/google/docsy/issues/1185
 [#1369]: https://github.com/google/docsy/issues/1369
 [#1376]: https://github.com/google/docsy/issues/1369
 [#1442]: https://github.com/google/docsy/issues/1442

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,8 +6,6 @@ params:
   time_format_blog: Monday, January 02, 2006
   time_format_default: January 2, 2006
   rss_sections: [blog]
-  drawio:
-    enable: true
 
 outputFormats:
   PRINT:

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Diagrams and Formulae"
-linkTitle: "Diagrams and Formulae"
+title: Diagrams and Formulae
+linkTitle: Diagrams and Formulae
 weight: 11
 description: Add generated diagrams and scientific formulae to your site.
 math: true
@@ -634,39 +634,39 @@ params:
 
 ## Diagrams with Diagrams.net
 
-[Diagrams.net](https://diagrams.net/) (aka draw.io) provides a free and open source diagram editor that can generate a wider range of diagrams than Mermaid or PlantUML using a web or desktop editor.
+[Diagrams.net](https://diagrams.net/) (aka `draw.io`) provides a free and open source diagram editor that can generate a wider range of diagrams than Mermaid or PlantUML using a web or desktop editor.
 
-SVG and PNG files exported with the tool contain the source code of the original diagram by default, which allows the diagrams.net site to import those images again for edit in the future.  Docsy can detect this and automatically add an "edit" button over any image that can be edited using the online site.
+SVG and PNG files exported with the tool contain the source code of the original diagram by default, which allows the diagrams.net site to import those images again for edit in the future. With `draw.io` enabled, Docsy will detect this and automatically add an `Edit` button over any image that can be edited using the online site.
 
-Hover over the image below and click edit to instantly start working with it.  Clicking the "Save" button will cause the edited diagram to be exported using the same filename and filetype, and downloaded to your browser.
+Hover over the image below and click edit to instantly start working with it.  Clicking the `Save` button will cause the edited diagram to be exported using the same filename and filetype, and downloaded to your browser.
 
 {{%alert title="Note"  color="primary" %}}
-If you're creating a new diagram, be sure to File -> Export in either svg or png format (svg is usually the best choice) and ensure the "Include a copy of my diagram" is selected so it can be edited again later.
+If you're creating a new diagram, be sure to `File -> Export` in either `svg` or `png` format (`svg` is usually the best choice) and ensure the `Include a copy of my diagram` is selected so it can be edited again later.
 {{%/alert%}}
 
 As the diagram data is transported via the browser, the diagrams.net server does not need to access the content on your Docsy server directly at all.
 
 
-{{< figure src="docsy-diagrams.svg" caption="Mouse over the above image and click the edit button!">}}
+{{< figure src="docsy-diagrams.svg" caption="Mouse over the above image and click the `Edit` button!">}}
 
-To disable detection of diagrams, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
+To enable detection of diagrams, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane persistLang=false >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 [params.drawio]
-enable = false
+enable = true
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
 params:
   drawio:
-    enable: false
+    enable: true
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
   "params": {
     "drawio": {
-      "enable": false
+      "enable": true
     }
   }
 }

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -1,6 +1,5 @@
 ---
 title: Diagrams and Formulae
-linkTitle: Diagrams and Formulae
 weight: 11
 description: Add generated diagrams and scientific formulae to your site.
 math: true

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -123,6 +123,9 @@ params:
     theme: default
     flowchart:
       diagramPadding: 20
+  drawio:
+    enable: true
+
 
 taxonomies:
   tag: tags

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -126,7 +126,6 @@ params:
   drawio:
     enable: true
 
-
 taxonomies:
   tag: tags
   category: categories


### PR DESCRIPTION
This PR addresses #1185. It makes automatic detection of draw.io diagrams an opt-in. It also reflects these breaking change in the user guide and in the change log.

This PR closes #1185.

---

Preview: https://deploy-preview-1470--docsydocs.netlify.app/docs/adding-content/diagrams-and-formulae/#diagrams-with-diagramsnet