### PR TITLE
[BSv5] community/list row-col hierarchy fix

### DIFF
--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,15 +1,18 @@
 {{ define "main" -}}
 
 <a class="td-offset-anchor"></a>
-<section class="row td-box td-box--primary position-relative td-box--height-auto">
+<section
+  class="row td-box td-box--primary position-relative td-box--height-auto"
+>
+  <div class="col-12 px-0">
     <div class="container text-center td-arrow-down">
-        <span class="h4 mb-0">
-            <h1>{{ T "community_join" . }}</h1>
-            <p>{{ T "community_introduce" . }}</p>
-        </span>
+      <span class="h4 mb-0">
+        <h1>{{ T "community_join" . }}</h1>
+        <p>{{ T "community_introduce" . }}</p>
+      </span>
     </div>
+  </div>
 </section>
-
 {{ partial "community_links.html" . -}}
 
 {{ with .Content -}}

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -28,7 +28,7 @@
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
   {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
   {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
-  <div class="col-12 p-0">
+  <div class="col-12 px-0">
     <div class="container td-overlay__inner">
       <div class="text-center">
         {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}


### PR DESCRIPTION
- Contributes to #1466
- Fixes the width/max-width of `community/list.html`
- Makes the child of `section.row` a column (`col-12`)
- Makes padding style more precise in `layouts/shortcodes/blocks/cover.html`

**Preview**: https://deploy-preview-1471--docsydocs.netlify.app/community/