### PR TITLE
[BSv5] Factor out Docy's table style and set max-width

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -82,9 +82,7 @@
     padding-right: 5vw;
   }
   table {
-    @extend .table;
-    @extend .table-striped;
-    @extend .table-responsive;
+    @extend .td-table;
   }
 }
 

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -41,11 +41,7 @@
   }
 
   table {
-    @extend .table-striped;
-
-    @extend .table-responsive;
-
-    @extend .table;
+    @extend .td-table;
   }
 
   blockquote {
@@ -64,18 +60,19 @@
     font-weight: $font-weight-bold;
   }
 
-  > pre,
+  .footnotes,
+  > .alert,
   > .highlight,
   > .lead,
-  > h1,
-  > h2,
-  > ul,
-  > ol,
-  > p,
+  > .td-table,
   > blockquote,
   > dl dd,
-  .footnotes,
-  > .alert {
+  > h1,
+  > h2,
+  > ol,
+  > p,
+  > pre,
+  > ul {
     @extend .td-max-width-on-larger-screens;
   }
 

--- a/assets/scss/_table.scss
+++ b/assets/scss/_table.scss
@@ -1,0 +1,5 @@
+.td-table {
+  @extend .table;
+  @extend .table-responsive;
+  @extend .table-striped;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -19,6 +19,7 @@ $display1-size: null !default;
 
 @import "support/utilities";
 @import "colors";
+@import "table";
 @import "boxes";
 @import "blog";
 @import "code";


### PR DESCRIPTION
- Closes #1473
- Factors out Docsy's table styling into `.td-table`
- Uses `.td-table` in the boxes and content styles
- Applies `.td-max-width-on-larger-screens` to `.td-tables`, as suggested in #1473
- Might contribute to #1431

---

### Screenshots

Before:

> <img width="933" alt="image" src="https://user-images.githubusercontent.com/4140793/224101684-eb122e42-0f78-4a7e-8332-a11eb1d6c52c.png">

After:

> <img width="931" alt="image" src="https://user-images.githubusercontent.com/4140793/224101759-5bbf7160-dbc4-465e-9e78-be3c4631c220.png">

