### PR TITLE
Fix page-meta for single language sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 - Non-breaking changes that result from the Bootstrap v5 upgrade:
   - Draw.io diagram edit button: replaced custom colors by BS's outline primary.
+- Fix page meta links for single language pages ([#138])
 
+[#138]: https://github.com/google/docsy/issues/138
 [#470]: https://github.com/google/docsy/issues/470
 [#906]: https://github.com/google/docsy/issues/906
 [#939]: https://github.com/google/docsy/issues/939

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -10,13 +10,9 @@
   {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
   <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
 {{ else if $gh_repo -}}
-  {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
-  {{ if and (.Site.IsMultiLingual) ($gh_subdir) (.Site.Language.Lang) -}}
-    {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted -}}
-  {{ else if and (.Site.IsMultiLingual) (.Site.Language.Lang) -}}
-    {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
-  {{ else if $gh_subdir -}}
-    {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted -}}
+  {{ $gh_repo_path := printf "%s/content/%s" $gh_branch ( relLangURL $pathFormatted ) -}}
+  {{ if $gh_subdir -}}
+    {{ $gh_repo_path = printf "%s/%s/content%s" $gh_branch $gh_subdir ( relLangURL $pathFormatted ) -}}
   {{ end -}}
 
   {{/* Adjust $gh_repo_path based on path_base_for_github_subdir */ -}}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -11,9 +11,9 @@
   <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
 {{ else if $gh_repo -}}
   {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
-  {{ if and ($gh_subdir) (.Site.Language.Lang) -}}
+  {{ if and (.Site.IsMultiLingual) ($gh_subdir) (.Site.Language.Lang) -}}
     {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted -}}
-  {{ else if .Site.Language.Lang -}}
+  {{ else if and (.Site.IsMultiLingual) (.Site.Language.Lang) -}}
     {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
   {{ else if $gh_subdir -}}
     {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted -}}


### PR DESCRIPTION
Fixes #981
Fixes #138

## Summary

The "edit", "view source" and similar links in the page-meta area (on the right) are broken for single-language Hugo sites (HTTP 404).

Those sites *may* store their source documents without language specific path segment depending on the `.Site.IsMultiLingual` property.
 
This PR changes the page-meta partial template to take that property into account.