### PR TITLE
Resolves the breaks in github's preview tab

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,41 +1,52 @@
-{{ if .File }}
-{{ $pathFormatted := replace .File.Path "\\" "/" -}}
-{{ $gh_repo := ($.Param "github_repo") -}}
-{{ $gh_url := ($.Param "github_url") -}}
-{{ $gh_subdir := ($.Param "github_subdir") -}}
-{{ $gh_project_repo := ($.Param "github_project_repo") -}}
-{{ $gh_branch := (default "main" ($.Param "github_branch")) -}}
-<div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
-{{ if $gh_url -}}
-  {{ warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
-  <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-{{ else if $gh_repo -}}
-  {{ $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
-  {{ if and ($gh_subdir) (.Site.Language.Lang) -}}
-    {{ $gh_repo_path = printf "%s/%s/content/%s/%s" $gh_branch $gh_subdir ($.Site.Language.Lang) $pathFormatted -}}
-  {{ else if .Site.Language.Lang -}}
-    {{ $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
-  {{ else if $gh_subdir -}}
-    {{ $gh_repo_path = printf "%s/%s/content/%s" $gh_branch $gh_subdir $pathFormatted -}}
-  {{ end -}}
+{{- if .Path -}}
+  {{- $pathFormatted := replace .File.Path "\\" "/" -}}
+  {{- $dirFormatted := replace .Path "\\" "/" | path.Dir -}}
+  {{- $gh_repo := ($.Param "github_repo") -}}
+  {{- $gh_url := ($.Param "github_url") -}}
+  {{- $gh_subdir := ($.Param "github_subdir") -}}
+  {{- $gh_project_repo := ($.Param "github_project_repo") -}}
+  {{- $gh_branch := (default "main" ($.Param "github_branch")) -}}
 
-  {{/* Adjust $gh_repo_path based on path_base_for_github_subdir */ -}}
-  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
-  {{ $ghs_rename := "" -}}
-  {{ if reflect.IsMap $ghs_base -}}
-    {{ $ghs_rename = $ghs_base.to -}}
-    {{ $ghs_base = $ghs_base.from -}}
-  {{ end -}}
-  {{ with $ghs_base -}}
-    {{ $gh_repo_path = replaceRE . $ghs_rename $gh_repo_path -}}
-  {{ end -}}
+  <div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
+    {{- with $gh_url -}}
+      {{- warnf "Warning: use of `github_url` is deprecated. For details see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
+      <a href="{{- . -}}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+    {{- else -}}
+      {{- $gh_repo_path := printf "%s/content/%s" $gh_branch $pathFormatted -}}
+      {{- $gh_repo_dir := printf "%s/content/%s" $gh_branch $dirFormatted -}}
+
+      {{- if $gh_subdir -}}
+        {{- $gh_repo_path = printf "%s/%s/content" $gh_branch $gh_subdir -}}
+        {{- $gh_repo_dir = printf "%s/%s/content" $gh_branch $gh_subdir -}}
+        {{- if .Site.Language.Lang -}}
+          {{- $gh_repo_path = printf "%s/%s/%s" $gh_repo_path ($.Site.Language.Lang) $pathFormatted -}}
+          {{- $gh_repo_dir = printf "%s/%s/%s" $gh_repo_dir ($.Site.Language.Lang) $dirFormatted -}}
+        {{- else -}}
+          {{- $gh_repo_path = printf "%s/%s" $gh_repo_path $pathFormatted -}}
+          {{- $gh_repo_dir = printf "%s/%s" $gh_repo_dir $dirFormatted -}}
+        {{- end -}}
+      {{- else if .Site.Language.Lang -}}
+        {{- $gh_repo_path = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $pathFormatted -}}
+        {{- $gh_repo_dir = printf "%s/content/%s/%s" $gh_branch ($.Site.Language.Lang) $dirFormatted -}}
+      {{- else -}}
+        {{- $gh_repo_path = printf "%s/content/%s" $gh_branch $pathFormatted -}}
+        {{- $gh_repo_dir = printf "%s/content/%s" $gh_branch $dirFormatted -}}
+      {{- end -}}
+
+      {{- with $.Param "path_base_for_github_subdir" -}}
+        {{- if reflect.IsMap . -}}
+          {{- .from | replaceRE .to $gh_repo_path -}}
+        {{- else -}}
+          {{- replaceRE . "" $gh_repo_path -}}
+        {{- end -}}
+      {{- end -}}
 
   {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
   {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
   {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
   {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
   {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
-  {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS -}}
+  {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_dir $newPageQS }}
 
   <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
   <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>


### PR DESCRIPTION
issue #668
The proposed changes is the enhancement of code to remove the parent filename in the GH repo path.
Preview tab is also now works as expected.