### PR TITLE
[BSv5] fix main container height

### DIFF
--- a/assets/scss/_main-container.scss
+++ b/assets/scss/_main-container.scss
@@ -2,7 +2,7 @@
 .td-outer {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 // The outer page container for the default base template.


### PR DESCRIPTION
Setting a minimum height instead of a fixed height fixes footer overflow issues.

Before:
![Capture d’écran du 2023-04-21 19-28-30](https://user-images.githubusercontent.com/8511577/233698730-da183e1c-16a2-4aa5-b7eb-f7675d08bbc6.png)

After:
![Capture d’écran du 2023-04-21 19-28-52](https://user-images.githubusercontent.com/8511577/233698763-42204f59-18c1-481b-bc6a-7df770f71efa.png)