### PR TITLE
[BSv5] fix horizontal scrollbar issues

### DIFF
--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -4,7 +4,7 @@
 <section
   class="row td-box td-box--primary position-relative td-box--height-auto"
 >
-  <div class="col-12 px-0">
+  <div class="col-12">
     <div class="container text-center td-arrow-down">
       <span class="h4 mb-0">
         <h1>{{ T "community_join" . }}</h1>

--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -28,7 +28,7 @@
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
   {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
   {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
-  <div class="col-12 px-0">
+  <div class="col-12">
     <div class="container td-overlay__inner">
       <div class="text-center">
         {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}

--- a/layouts/shortcodes/blocks/lead.html
+++ b/layouts/shortcodes/blocks/lead.html
@@ -8,7 +8,7 @@
 
 <div><a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a></div>
 <section class="row td-box td-box--{{ $col_id }} position-relative td-box--height-{{ $height }}">
-<div class="col-12 px-0">
+<div class="col-12">
 <div class="container text-center td-arrow-down">
 <div class="h4 mb-0">
 {{/* Do NOT remove this comment! It ends the HTML block above. See https://spec.commonmark.org/0.30/#html-blocks, 7. */}}

--- a/layouts/shortcodes/blocks/section.html
+++ b/layouts/shortcodes/blocks/section.html
@@ -4,7 +4,7 @@
 
 <div><a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a></div>
 <section class="row td-box td-box--{{ $col_id }} td-box--height-{{ $height }}">
-<div class="col px-0">
+<div class="col">
 <div class="{{ $type }}">
 {{/* Do NOT remove this comment! It ends the HTML block above. See https://spec.commonmark.org/0.30/#html-blocks, 7. */}}
 {{ .Inner -}}


### PR DESCRIPTION
IIUC, Bootstrap row has negative left and right margins to counteract col padding (https://getbootstrap.com/docs/5.3/layout/grid/#how-it-works). Setting col padding to 0 can lead to issues where a pointless horizontal scrollbar is added to the browser window.

Before:
![Capture d’écran du 2023-04-21 19-39-00](https://user-images.githubusercontent.com/8511577/233700414-135d53da-99e5-4cb3-9d88-25e13d466904.png)

After:
![Capture d’écran du 2023-04-21 19-39-13](https://user-images.githubusercontent.com/8511577/233700435-45996126-afdd-4139-9b55-d41fee00667f.png)