### PR TITLE
module: ignore Bootstrap config

### DIFF
--- a/dependencies/config.toml
+++ b/dependencies/config.toml
@@ -25,6 +25,7 @@ _merge = "deep"
 [[module.imports]]
   path = "github.com/twbs/bootstrap"
   disable = false
+  ignoreConfig = true
 [[module.imports.mounts]]
   source = "scss"
   target = "assets/vendor/bootstrap/scss"


### PR DESCRIPTION
This PR ignores the config https://github.com/twbs/bootstrap/blob/main/config.yml from Bootstrap, since it will be merged into user's configuration and override some Hugo module's configuration which cause build fails.