### PR TITLE
User guide: fix warning about deprecated language config

### DIFF
--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -34,9 +34,10 @@ services:
 languages:
   en:
     title: Docsy
-    description: Docsy does docs
     languageName: English
     weight: 1
+    params:
+      description: Docsy does docs
 
 markup:
   goldmark:


### PR DESCRIPTION
When running the user guide with latest hugo version 0.112.0-DEV, a warning is printed out:

> WARN 2023/05/18 22:55:31 config: languages.en.description: custom params on the language top level is deprecated and will be removed in a future release. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

This PR provide a fix that eliminates this warning.