### PR TITLE
[BSv5] Fix RSS button style

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -1,8 +1,8 @@
 .td-blog {
   .td-rss-button {
     @extend .btn;
+    @extend .btn-info;
     @extend .btn-lg;
-    @extend .-bg-orange;
 
     float: right;
 


### PR DESCRIPTION
- Switches to use of one of the standard button classes for the RSS button, namely the "info" class. In that way, hovering is handled automatically, just like for all other BS buttons.
- Closes #1481
- Contributes to #470
- **Preview**: https://deploy-preview-1521--docsydocs.netlify.app/blog/

### Screenshots

Before:

> <img width="996" alt="image" src="https://github.com/google/docsy/assets/4140793/d6530db1-6bae-432a-9268-72b1e441f545">

After:

> <img width="996" alt="image" src="https://github.com/google/docsy/assets/4140793/5246d18e-7b3c-4a42-8e13-971ebe5bf4f7">
