### PR TITLE
[BSv5] Footer: drop flex-shrink tweak + other adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,17 +29,19 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
   - Dropped support for pre-Hugo-0.54.x behavior of `{{% %}}`. ([#939])
   - `blocks/section`: **default** and accepted values of the `type` argument
     have changed! For details see [blocks/section] ([#1472]).
-
-- **[Adaptation of shortcodes for diplay of cards (#1376)][1376]:
-  - shortcode `cardpane`: renamed CSS class `td-card-deck` to `td-card-group`.
-  - shortcode `card`, `card-code`: markup of inner content (html/markdown)
-    now depends on the syntax of the calling shortcode, not on extension
-    of page file any more [#906][906].
-  - shortcode `card-code` is now deprecated, use shortcode `card` with named
-    parameter `code=true` instead.
+  - **Card shortcodes** ([#1376])]:
+    - Renamed CSS class `td-card-deck` to `td-card-group`.
+    - `card`, `card-code`: markup of inner content (HTML/markdown) now depends
+      on the syntax of the calling shortcode, not on extension of page file any
+      more [#906].
+    - `card-code` is deprecated; use `card` with named parameter `code=true`
+      instead.
 
 **Other changes**:
 
+- `$list-inline-padding` is increased in support of footer icons ([#1523]). If
+  this global adjustment is a problem for your project, let us know and we can
+  contextualize the adjustment to the footer.
 - Non-breaking changes that result from the Bootstrap v5 upgrade:
   - Draw.io diagram edit button: replaced custom colors by BS's outline primary.
 
@@ -47,8 +49,10 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 [#906]: https://github.com/google/docsy/issues/906
 [#939]: https://github.com/google/docsy/issues/939
 [#1369]: https://github.com/google/docsy/issues/1369
+[#1376]: https://github.com/google/docsy/issues/1369
 [#1442]: https://github.com/google/docsy/issues/1442
 [#1472]: https://github.com/google/docsy/issues/1472
+[#1523]: https://github.com/google/docsy/pull/1523
 [blocks/section]:
   https://www.docsy.dev/docs/adding-content/shortcodes/#blockssection
 [bsv5mig]: https://getbootstrap.com/docs/5.2/migration/

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -87,3 +87,7 @@ $pagination-disabled-color: $gray-300 !default; // TODO: consider using BS defau
 
 $navbar-dark-color: rgba($white, 0.75) !default;      // TODO: consider moving into UG SCSS
 $navbar-dark-hover-color: rgba($white, 0.5) !default; // TODO: consider moving into UG SCSS
+
+// Footer
+
+$list-inline-padding: $spacer;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 {{ $links := .Site.Params.links -}}
-<footer class="bg-dark py-5 row d-print-none">
-  <div class="container-fluid flex-shrink-1 mx-sm-5">
-    <div class="row">
+<footer class="bg-dark pt-5 row d-print-none">
+  <div class="container-fluid">
+    <div class="row mx-md-2">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
         {{ with $links }}
         {{ with index . "user" }}
@@ -30,7 +30,7 @@
 {{- define "footer-links-block" }}
 <ul class="list-inline mb-0">
   {{ range . }}
-  <li class="list-inline-item mx-2 h3" data-bs-toggle="tooltip" title="{{ .name }}" aria-label="{{ .name }}">
+  <li class="list-inline-item h3" data-bs-toggle="tooltip" title="{{ .name }}" aria-label="{{ .name }}">
     <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
       <i class="{{ .icon }}"></i>
     </a>


### PR DESCRIPTION
- (Re-)Closes #1466
- Followup to #1373: reverts `flex-shrink` tweak. This is possible by moving the margin adjustment from the footer container to the row element.
- Adjusts margin breakpoint (from `sm`) to match main page content breakpoint (`md`) in `mx-md-*`
- Removes excessive margins (`mx-2`) around list inline elements, since the base inline list style provides sufficient margins appropriately tuned for list items.
- Other minor style adjustements
- These adjustments bring the footer appearance to very closely match the pre-BSv5 migration as you can see from: https://deploy-preview-1356--docsydocs.netlify.app

**Preview**: https://deploy-preview-1523--docsydocs.netlify.app

---

### Screenshots

Showing breakpoint mismatch between page content and footer layout.

Before:

> <img width="500" alt="Screen Shot 2023-05-26 at 11 13 38" src="https://github.com/google/docsy/assets/4140793/7d5f6653-c484-4f2b-9c6d-f793fabb7f1b">


After:

> <img width="500" alt="Screen Shot 2023-05-26 at 11 13 08" src="https://github.com/google/docsy/assets/4140793/89371b4f-4635-4225-937a-51a293b92303">
