### PR TITLE
Fix link text and hover color contrast for all bgs

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -4,7 +4,11 @@
 @mixin box-variant($parent, $color-name, $color-value) {
   $text-color: color-contrast($color-value);
   $link-color: mix($blue, $text-color, lightness($color-value));
-  $link-hover-color: shade-color($text-color, $link-shade-percentage);
+  $link-hover-color: if(
+    color-contrast($link-color) == $color-contrast-light,
+    shade-color($link-color, $link-shade-percentage),
+    tint-color($link-color, $link-shade-percentage)
+  );
 
   #{$parent} {
     &--#{$color-name} {

--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -4,7 +4,7 @@
 @mixin box-variant($parent, $color-name, $color-value) {
   $text-color: color-contrast($color-value);
   $link-color: mix($blue, $text-color, lightness($color-value));
-  $link-hover-color: rgba($link-color, 0.5) !default;
+  $link-hover-color: shade-color($text-color, $link-shade-percentage);
 
   #{$parent} {
     &--#{$color-name} {
@@ -31,7 +31,7 @@
 
   // Improve contrast for the links in paragraphs.
   @include link-variant(
-    "#{$parent}--#{$color-name} p > a",
+    "#{$parent}--#{$color-name} p > a, #{$parent}--#{$color-name} span > a",
     $link-color,
     $link-hover-color,
     false

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -43,11 +43,21 @@ $display1-size: null !default;
   @import url($web-font-path);
 }
 
-footer {
+.td-footer {
+  @extend .td-box--dark;
+
   min-height: 150px;
+  padding-top: map-get($spacers, 5);
 
   @include media-breakpoint-down(lg) {
     min-height: 200px;
+  }
+
+  &__copyright-etc {
+    @extend .small;
+  }
+  &__about {
+    font-size: initial;
   }
 }
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 {{ $links := .Site.Params.links -}}
-<footer class="bg-dark pt-5 row d-print-none">
+<footer class="td-footer row d-print-none">
   <div class="container-fluid">
     <div class="row mx-md-2">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
@@ -16,11 +16,17 @@
         {{ end }}
         {{ end }}
       </div>
-      <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-        {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}
-        {{ with .Site.Params.privacy_policy }}<small class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+      <div class="td-footer__copyright-etc col-12 col-sm-4 text-center py-2 order-sm-2">
+        {{ with .Site.Params.copyright -}}
+          <span>&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
+        {{- end }}
+        {{ with .Site.Params.privacy_policy -}}
+          <span class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></span>
+        {{- end }}
         {{ if not .Site.Params.ui.footer_about_disable -}}
-          {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+          {{ with .Site.GetPage "about" -}}
+            <p class="td-footer__about mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>
+          {{- end -}}
         {{ end }}
       </div>
     </div>


### PR DESCRIPTION
- Closes #1482
- Closes #1483
- As was mentioned in the two previous issues, these problems existed before the migration to BSv5. I would have normally deferred resolution of non-BSv5 problems until after the BSv5 release of Docsy, but I had the work done already 🤷🏼‍♂️
- Contributes to #783 for the Docsy footer (partial work)
- Switches from `.bg-dark` to Docsy's custom style `.td-box--dark` for the footer, since that style has link and hover colors appropriately set in the latter
- For each `.td-box--*`, the hover color is determined in a way that is similar to what Bootstrap does, in particular, using `$link-shade-percentage`

**Preview**: https://deploy-preview-1525--docsydocs.netlify.app/about

---

### Screenshots

These images show the fix in a block and the footer. The link [contribution guidelines](https://deploy-preview-1525--docsydocs.netlify.app/docs/contribution-guidelines/) (roughly in the middle of the page) is in a hover state.

Before:

> <img width="700" alt="image" src="https://github.com/google/docsy/assets/4140793/3bcd57c4-1425-4154-bac7-7912fdfaaa04">


After:

> <img width="700" alt="image" src="https://github.com/google/docsy/assets/4140793/f7081500-47bf-425e-89ea-78a4f2bfd428">

<!-- was
> <img width="700" alt="image" src="https://github.com/google/docsy/assets/4140793/6033b8dd-4944-49f2-a895-5cb1824b3ebd">
-->