### PR TITLE
Revert update of Hugo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "5.2.3"
   },
   "devDependencies": {
-    "hugo-extended": "0.112.3"
+    "hugo-extended": "0.110.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
- For context, see https://github.com/google/docsy/pull/1529/files#r1214544184
- Under 0.112.3, we lose `og:site_name`, and it isn't clear why. I'll investigate this separately, but only once 0.7.0 has been released.

/cc @deining @geriom 