### PR TITLE
Make docsy theme point to latest version of dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 // indirect
-	github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e // indirect
+	github.com/google/docsy/dependencies v0.6.1-0.20230601182954-ff1818261e64 // indirect
 	github.com/twbs/bootstrap v5.2.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2 h1:Uv1z5E
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e h1:lfvr9ByCkuIz/ARoEDC/6gucVRjkooYTts5P+0yq5Qk=
 github.com/google/docsy/dependencies v0.6.1-0.20230125095517-798c2504905e/go.mod h1:qhtpynRkDn1FOmD1gj0a5n6ptDjDw0O4Zmb+6pfYUKU=
+github.com/google/docsy/dependencies v0.6.1-0.20230601182954-ff1818261e64 h1:ZBeOh/qGThEUn/r4vPXyfKXYKvMPmHgGS1BgQI8Xf2E=
+github.com/google/docsy/dependencies v0.6.1-0.20230601182954-ff1818261e64/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible h1:lOmsJx587qfF7/gE7Vv4FxEofegyJlEACeVV+Mt7cgc=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
- This PR is related to #1529. It ensures that we use and test docsy (module setup) with latest version of dependencies.
- Supersedes #1418