### PR TITLE
Documents the body_class parameter

### DIFF
--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -546,7 +546,7 @@ To add the classes `myclass` and `anotherclass`, add the following line to the
 front matter of the page:
 
 <!-- prettier-ignore -->
-{{< tabpane persistLang=false >}}
+{{< tabpane >}}
 {{< tab header="Front matter :" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 body_class = "myclass anotherclass"

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -545,7 +545,7 @@ To add the classes `myclass` and `anotherclass`, add the following line to the f
 body_class = "myclass anotherclass"
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
-body_class : "myclass anotherclass"
+body_class : myclass anotherclass
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 "body_class" : "myclass anotherclass"

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -545,19 +545,9 @@ be added to the class attribute of your page's body element.
 To add the classes `myclass` and `anotherclass`, add the following line to the
 front matter of the page:
 
-<!-- prettier-ignore -->
-{{< tabpane >}}
-{{< tab header="Front matter :" disabled=true />}}
-{{< tab header="hugo.toml" lang="toml" >}}
-body_class = "myclass anotherclass"
-{{< /tab >}}
-{{< tab header="hugo.yaml" lang="yaml" >}}
-body_class : myclass anotherclass
-{{< /tab >}}
-{{< tab header="hugo.json" lang="json" >}}
-"body_class" : "myclass anotherclass"
-{{< /tab >}}
-{{< /tabpane >}}
+```yaml
+body_class: myclass anotherclass
+```
 
 The page's opening body tag will look like this (assuming it is a section page):
 

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -529,18 +529,33 @@ which is used by all the other page templates:
 
 ## Adding custom class to the body element
 
-Sometimes it's useful to assign custom classes to a page, or to an entire section, for example, to apply custom styling. Docsy automatically adds the value of the `body_class` parameter of the frontmatter to the `class` attribute of the `body` element of the page.
-
 By default, Docsy adds the `td-{{ .Kind }}` class, where the kind is the kind of the page, like section, blog, and so on. For example:
 
 ```html
 <body class="td-section">
 ```
 
+Sometimes it's useful to assign custom classes to a page, or to an entire section, for example, to apply custom styling. To do so, add the `body_class` parameter to the frontmatter of your page. The value of the parameter will be then added to the class attribute of your page's body element.
+
 To add the classes `myclass` and `anotherclass`, add the following line to the frontmatter of the page:
 
-```toml
-body_class: "myclass anotherclass"
+{{< tabpane persistLang=false >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="hugo.toml" lang="toml" >}}
+body_class = "myclass anotherclass"
+{{< /tab >}}
+{{< tab header="hugo.yaml" lang="yaml" >}}
+body_class : "myclass anotherclass"
+{{< /tab >}}
+{{< tab header="hugo.json" lang="json" >}}
+"body_class" = "myclass anotherclass"
+{{< /tab >}}
+{{< /tabpane >}}
+
+The output will look like:
+
+```html
+<body class="td-section myclass anotherclass">
 ```
 
 To apply the custom class to every page of a section or a directory, use the [Front Matter Cascade](https://gohugo.io/content-management/front-matter/#front-matter-cascade) feature of Hugo in your configuration file, or in the frontmatter of the highest-level page you want to modify.

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -3,7 +3,7 @@ title: Look and Feel
 date: 2017-01-05
 weight: 2
 description: Customize colors, fonts, code highlighting, and more for your site.
-spelling: cSpell:ignore wordmark docsy
+spelling: cSpell:ignore wordmark docsy myclass anotherclass
 ---
 
 By default, a site using Docsy has the theme's default fonts, colors, and
@@ -539,15 +539,15 @@ the page, like section, blog, and so on. For example:
 
 Sometimes it's useful to assign custom classes to a page, or to an entire
 section, for example, to apply custom styling. To do so, add the `body_class`
-parameter to the frontmatter of your page. The value of the parameter will then
+parameter to the front matter of your page. The value of the parameter will then
 be added to the class attribute of your page's body element.
 
 To add the classes `myclass` and `anotherclass`, add the following line to the
-frontmatter of the page:
+front matter of the page:
 
 <!-- prettier-ignore -->
 {{< tabpane persistLang=false >}}
-{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="Front matter :" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 body_class = "myclass anotherclass"
 {{< /tab >}}
@@ -568,7 +568,7 @@ The page's opening body tag will look like this (assuming it is a section page):
 
 To apply the custom class to every page of a section or a directory, use the
 [Front Matter Cascade](https://gohugo.io/content-management/front-matter/#front-matter-cascade)
-feature of Hugo in your configuration file, or in the frontmatter of the
+feature of Hugo in your configuration file, or in the front matter of the
 highest-level page you want to modify.
 
 [bs-docs]: https://getbootstrap.com/docs/

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -527,4 +527,22 @@ which is used by all the other page templates:
 </html>
 ```
 
+## Adding custom class to the body element
+
+Sometimes it's useful to assign custom classes to a page, or to an entire section, for example, to apply custom styling. Docsy automatically adds the value of the `body_class` parameter of the frontmatter to the `class` attribute of the `body` element of the page.
+
+By default, Docsy adds the `td-section` class, like this:
+
+```html
+<body class="td-section">
+```
+
+To add the classes `myclass` and `anotherclass`, add the following line to the frontmatter of the page:
+
+```toml
+body_class: "myclass anotherclass"
+```
+
+To apply the custom class to every page of a section or a directory, use the [Front Matter Cascade](https://gohugo.io/content-management/front-matter/#front-matter-cascade) feature of Hugo in your configuration file, or in the frontmatter of the highest-level page you want to modify.
+
 [bs-docs]: https://getbootstrap.com/docs/

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -552,7 +552,7 @@ body_class : myclass anotherclass
 {{< /tab >}}
 {{< /tabpane >}}
 
-The output will look like:
+The page's opening body tag will look like this (assuming it is a section page):
 
 ```html
 <body class="td-section myclass anotherclass">

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -548,7 +548,7 @@ body_class = "myclass anotherclass"
 body_class : "myclass anotherclass"
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
-"body_class" = "myclass anotherclass"
+"body_class" : "myclass anotherclass"
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -529,16 +529,23 @@ which is used by all the other page templates:
 
 ## Adding custom class to the body element
 
-By default, Docsy adds the `td-{{ .Kind }}` class, where the kind is the kind of the page, like section, blog, and so on. For example:
+By default, Docsy adds the `td-{{ .Kind }}` class, where the kind is the kind of
+the page, like section, blog, and so on. For example:
 
+<!-- prettier-ignore -->
 ```html
 <body class="td-section">
 ```
 
-Sometimes it's useful to assign custom classes to a page, or to an entire section, for example, to apply custom styling. To do so, add the `body_class` parameter to the frontmatter of your page. The value of the parameter will be then added to the class attribute of your page's body element.
+Sometimes it's useful to assign custom classes to a page, or to an entire
+section, for example, to apply custom styling. To do so, add the `body_class`
+parameter to the frontmatter of your page. The value of the parameter will then
+be added to the class attribute of your page's body element.
 
-To add the classes `myclass` and `anotherclass`, add the following line to the frontmatter of the page:
+To add the classes `myclass` and `anotherclass`, add the following line to the
+frontmatter of the page:
 
+<!-- prettier-ignore -->
 {{< tabpane persistLang=false >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -554,10 +561,14 @@ body_class : myclass anotherclass
 
 The page's opening body tag will look like this (assuming it is a section page):
 
+<!-- prettier-ignore -->
 ```html
 <body class="td-section myclass anotherclass">
 ```
 
-To apply the custom class to every page of a section or a directory, use the [Front Matter Cascade](https://gohugo.io/content-management/front-matter/#front-matter-cascade) feature of Hugo in your configuration file, or in the frontmatter of the highest-level page you want to modify.
+To apply the custom class to every page of a section or a directory, use the
+[Front Matter Cascade](https://gohugo.io/content-management/front-matter/#front-matter-cascade)
+feature of Hugo in your configuration file, or in the frontmatter of the
+highest-level page you want to modify.
 
 [bs-docs]: https://getbootstrap.com/docs/

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -531,7 +531,7 @@ which is used by all the other page templates:
 
 Sometimes it's useful to assign custom classes to a page, or to an entire section, for example, to apply custom styling. Docsy automatically adds the value of the `body_class` parameter of the frontmatter to the `class` attribute of the `body` element of the page.
 
-By default, Docsy adds the `td-section` class, like this:
+By default, Docsy adds the `td-{{ .Kind }}` class, where the kind is the kind of the page, like section, blog, and so on. For example:
 
 ```html
 <body class="td-section">


### PR DESCRIPTION
Just ran into that while looking for a way to add custom attributes to the body tag (which doesn't seem to be possible, so I'll open a separate PR for that).

Anyway, this PR documents https://github.com/google/docsy/pull/774 and fixes https://github.com/google/docsy/issues/778

@chalin 

**Preview**: https://deploy-preview-1541--docsydocs.netlify.app/docs/adding-content/lookandfeel/#adding-custom-class-to-the-body-element