### PR TITLE
Click-to-copy: remove vertical space from button div

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -12,7 +12,6 @@
     .click-to-copy {
       display: block;
       text-align: right;
-      height: 1ex;
     }
 
     pre {


### PR DESCRIPTION
- Closes #1548
- Contributes to #470
- **Preview**: https://deploy-preview-1549--docsydocs.netlify.app/docs/adding-content/lookandfeel/#site-colors

### Screenshots

Before:

> <img width="618" alt="image" src="https://github.com/google/docsy/assets/4140793/c8e64798-468c-4447-a969-bfa1f0a0f385">

After:

> <img width="639" alt="image" src="https://github.com/google/docsy/assets/4140793/7f33a06c-6188-42f3-8a30-2d8358e1fa88">
