### PR TITLE
Correct required hugo version (#1546)

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -18,7 +18,7 @@ outputFormats:
 module:
   hugoVersion:
     extended: true
-    min: 0.73.0
+    min: 0.110.0
   mounts:
     - source: assets
       target: assets

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
-min_version = 0.53
+min_version = 0.110.0
 
 [author]
   name = "The Docsy Authors"

--- a/userguide/content/en/docs/Deployment/_index.md
+++ b/userguide/content/en/docs/Deployment/_index.md
@@ -45,7 +45,7 @@ Then follow the instructions in [Host on Netlify](https://gohugo.io/hosting-and-
       * If you are using Docsy as a [Hugo module](/docs/get-started/docsy-as-module/) or NPM package, you can just specify `hugo`.   
    3. Click **Show advanced**.
    4. In the **Advanced build settings** section, click **New variable**.
-   5. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its **Value** to the latest version of Hugo (minimum recommended version: `0.73`).
+   5. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its **Value** to the latest version of Hugo (minimum required version: `0.110.0`).
    6. In the **Advanced build settings** section, click **New variable** again.
    7. Specify `GO_VERSION` as the **Key** for the new variable, and set its **Value** to the latest version of Go (minimum recommended version: `1.18`).
 
@@ -69,7 +69,7 @@ For example, if you want to use a version of `postcss-cli` later than version 8.
 
 Alternatively, you can follow the same instructions but specify your **Deploy settings** in a [`netlify.toml` file](https://docs.netlify.com/configure-builds/file-based-configuration/) in your repo rather than in the **Deploy settings** page. You can see an example of this in the [Docsy theme repo](https://github.com/google/docsy/blob/main/netlify.toml) (though note that the build command here is a little unusual because the Docsy user guide is *inside* the theme repo).
 
-If you have an existing deployment you can view and update the relevant information by selecting the site from your list of sites in Netlify, then clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Xenial 16.04** is selected in the **Build image selection** section - if you're creating a new deployment this is used by default. You need to use this image to run the extended version of Hugo.
+If you have an existing deployment you can view and update the relevant information by selecting the site from your list of sites in Netlify, then clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Focal 20.04** is selected in the **Build image selection** section - if you're creating a new deployment this is used by default. You need to use this image to run the extended version of Hugo.
 
 ## Deployment with Amazon S3 + Amazon CloudFront
 

--- a/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -70,7 +70,7 @@ Hugo's commands for module management require that the Go programming language i
 
 ```console
 $ go version
-go version go1.19.2 windows/amd64
+go version go1.20.5
 ```
 
 Ensure that you are using version 1.12 or higher.
@@ -84,7 +84,7 @@ Hugo's commands for module management require that the `git` client is installed
 
 ```console
 $ git version
-git version 2.39.1
+git version 2.40.1
 ```
 
 If no `git` client is installed on your system yet, go to the [Git website](https://git-scm.com/), download the installer for your system architecture and execute it. Afterwards, check for a successful installation.


### PR DESCRIPTION
This PR follows up on #1546 and #856. It corrects required hugo version in a few places.
It also updates the build image settings for Netlify builds to the latest version.
This PR closes #856.