### PR TITLE
Fix: correct min_version in theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
-min_version = 0.110
+min_version = "0.110.0"
 
 [author]
   name = "The Docsy Authors"

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
-min_version = 0.110.0
+min_version = 0.110
 
 [author]
   name = "The Docsy Authors"


### PR DESCRIPTION
This PR corrects a warning introduced with #1546.

```
WARN 2023/06/07 22:46:37 Failed to read module config for "github.com/google/docsy"
in "/tmp/hugo_cache/modules/filecache/modules/pkg/mod/github.com/google/docsy@v0.6.1-0.20230607204327-bae56a339ea1/theme.toml": "_stream.toml:8:20":
unmarshal failed: toml: float can have at most one decimal point

```