### PR TITLE
Blog list layout: no need for row/col-12 grid styling of content

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -5,40 +5,36 @@
   {{$.Scratch.Set "blog-pages" .Pages -}}
 {{ end -}}
 
-<div class="row">
-	<div class="col-12">
-		{{ if .Pages -}}
-		  {{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
-			{{ range $pag.PageGroups }}
-			<h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
-			<ul class="td-blog-posts-list">
-				{{ range .Pages }}
-				<li class="td-blog-posts-list__item">
-					<div class="td-blog-posts-list__body">
-						<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
-						<p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
-						<header class="article-meta">
-							{{ partial "taxonomy_terms_article_wrapper.html" . -}}
-							{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
-								{{ partial "reading-time.html" . -}}
-							{{ end -}}
-						</header>
-						{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
-						<p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
-						<p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
-					</div>
-				</li>
-				{{ end -}}
-			</ul>
-			{{ end -}}
-		{{ end }}
-	</div>
+<div class="td-blog-posts">
+  {{ if .Pages -}}
+    {{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
+    {{ range $pag.PageGroups }}
+    <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
+    <ul class="td-blog-posts-list">
+      {{ range .Pages }}
+      <li class="td-blog-posts-list__item">
+        <div class="td-blog-posts-list__body">
+          <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+          <p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+          <header class="article-meta">
+            {{ partial "taxonomy_terms_article_wrapper.html" . -}}
+            {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+              {{ partial "reading-time.html" . -}}
+            {{ end -}}
+          </header>
+          {{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
+          <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+          <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
+        </div>
+      </li>
+      {{ end -}}
+    </ul>
+    {{ end -}}
+  {{ end }}
 </div>
-<div class="row ps-2 pt-2">
-	<div class="col">
-		{{ if .Pages -}}
-			{{ template "_internal/pagination.html" . -}}
-		{{ end -}}
-	</div>
+<div class="td-blog-posts__pagination">
+  {{ if .Pages -}}
+    {{ template "_internal/pagination.html" . -}}
+  {{ end -}}
 </div>
 {{ end -}}


### PR DESCRIPTION
- Contributes to #470
- Closes #1571
- Drops the unnecessary use of row/col-12 combos. The main content doesn't need any grid styling.

---

It is a bit hard to see, but there are no content changes in the layout other than:

- Replacing `<div class="row"><div class="col-12">{{ if .Pages -}}...</div></div>` by
  `<div class="td-blog-posts">{{ if .Pages -}}...</div>`
- And similarly replacing the `div`s for the pagination
- Change from `<h2>` to `<div class="h2">` of the post-list header

Note that the class names `td-blog-posts*` currently have not styles associated with them.

In the before and after images, note the following fixes:

- The RSS button is flush-right and no longer takes up a column's worth of space
- ~Spacing above the **View page source** page-meta buttons~

### Before

> <img width="1290" alt="image" src="https://github.com/google/docsy/assets/4140793/2cf7b827-edc4-46b1-9357-f4f51a40e1ce">

### After

> <img width="1292" alt="image" src="https://github.com/google/docsy/assets/4140793/85b81fff-2ce2-48ec-93fa-bcb4ddf976bd">

Showing the pagination buttons:

> <img width="1291" alt="image" src="https://github.com/google/docsy/assets/4140793/aa851993-eaf7-4788-a4eb-a2d3f3789e3a">

