### PR TITLE
User guide: reflect updates in example site

### DIFF
--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -376,7 +376,7 @@ weight: 20
 
 Docsy's `blog` layout also gives you a left nav menu (like the `docs` layout), and a list-type index page for your blog that's applied to `/blog/_index.md` and automatically displays snippets of all your recent posts in reverse chronological order.
 
-To create different blog categories to organize your posts, create subfolders in `blog/`. For instance, in our [example site](https://github.com/google/docsy-example/tree/master/content/en/blog) we have `news` and `releases`. Each category needs to have its own `_index.md` or `_index.html` landing page file specifying the category title for it to appear properly in the left nav and top-level blog landing page. Here's the index page for `releases`:
+To create different blog categories to organize your posts, create subfolders in `blog/`. For instance, in our [example site](https://github.com/google/docsy-example/tree/main/content/en/blog) we have `news` and `releases`. Each category needs to have its own `_index.md` or `_index.html` landing page file specifying the category title for it to appear properly in the left nav and top-level blog landing page. Here's the index page for `releases`:
 
 {{< tabpane persistLang=false >}}
 {{< tab header="Front matter:" disabled=true />}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -64,7 +64,7 @@ Note that the relevant shortcode parameters above will have sensible defaults, b
 | byline | Byline text on featured image. |
 
 
-To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/master/content/en), in the same directory.
+To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en), in the same directory.
 
 {{% alert title="Tip" %}}
 If you also include the word **featured** in the image name, e.g. `my-featured-background.jpg`, it will also be used as the Twitter Card image when shared.

--- a/userguide/content/en/docs/get-started/basic-configuration.md
+++ b/userguide/content/en/docs/get-started/basic-configuration.md
@@ -7,17 +7,17 @@ description: >
   Basic configuration for new Docsy sites.
 ---
 
-Site-wide configuration details and parameters are defined in your project's [configuration file] (`config.toml` or `hugo.toml`). These include your chosen Hugo theme (Docsy, of course!), project name, community links, Google Analytics configuration, and Markdown parser parameters. See the examples with comments in [`config.toml` in the example project](https://github.com/google/docsy-example/blob/master/config.toml) for how to add this information. **We recommend copying this config.toml and editing it even if you’re just using the theme and not copying the entire Docsy example site**, as it includes default values for many parameters that you need to set for your site to build correctly.
+Site-wide configuration details and parameters are defined in your project's [configuration file] (`hugo.toml` or `config.toml`). These include your chosen Hugo theme (Docsy, of course!), project name, community links, Google Analytics configuration, and Markdown parser parameters. See the examples with comments in [`hugo.toml` in the example project](https://github.com/google/docsy-example/blob/main/hugo.toml) for how to add this information. **We recommend copying this hugo.toml and editing it even if you’re just using the theme and not copying the entire Docsy example site**, as it includes default values for many parameters that you need to set for your site to build correctly.
 
-You may want to remove or customize some defaults of the copied `config.toml` file straight away:
+You may want to remove or customize some defaults of the copied `hugo.toml` file straight away:
 
 ## Internationalization
 
-The copied `config.toml` file defines content in English, Norwegian and Farsi. You can find out more about how Docsy supports multi-language content in [Multi-language support](/docs/language/).
+The copied `hugo.toml` file defines content in English, Norwegian and Farsi. You can find out more about how Docsy supports multi-language content in [Multi-language support](/docs/language/).
 
-If you don't intend to translate your site, you can remove the language switcher by removing the following lines from `config.toml`:
+If you don't intend to translate your site, you can remove the language switcher by removing the following lines from `hugo.toml`:
 
-```
+```toml
 [languages.no]
 title = "Docsy"
 description = "Docsy er operativsystem for skyen"


### PR DESCRIPTION
Recent changes in the doscy example site:

- default branch was renamed from `master` to `main`.
- the config file was renamed from `config.toml` to `config.yaml`.

With this PR applied these changes are reflected in the docsy user guide, too.

This PR also includes the change proposed with PR #1576.