### PR TITLE
Improve compile-time detection of Bootstrap version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 Useful links: Docsy [releases][] & [tags][]. Jump to the [latest][] release.
 
-For a list of issues targeted for the next release, see the [23Q1][] milestone.
+For a list of issues targeted for the next release, see the [23Q2][] milestone.
 
 ## [0.8.0][releases] - next major release (unpublished yet)
 
 **New**:
+
 **Breaking changes**:
+
 **Other changes**:
 
 ## [0.7.1][releases] - next planned release (unpublished yet)
@@ -20,11 +22,15 @@ For a list of issues targeted for the next release, see the [23Q1][] milestone.
 
 **Other changes**:
 
-- Followup changes to **Bootstrap (BS) 5.2 upgrade** ([#470]):
-  - `td-blog-posts-list__item` and `td-blog-posts-list__body` replace
-    the `.media` and `.media-body` classes, dropped by BS 5 [#1560].
+Followup changes to **Bootstrap (BS) 5.2 upgrade** ([#470]):
+
+- `td-blog-posts-list__item` and `td-blog-posts-list__body` replace the `.media`
+  and `.media-body` classes, dropped by BS 5 [#1560].
+- Docsy test for Bootstrap version has been made more robust, and can be
+  disabled. For details, see [#1578].
 
 [#1560]: https://github.com/google/docsy/issues/1560
+[#1578]: https://github.com/google/docsy/issues/1578
 
 ## [0.7.0][]
 
@@ -268,7 +274,7 @@ For a full list of the changes to this release, see the [release notes][0.x.y].
 [0.3.0]: https://github.com/google/docsy/releases/v0.3.0
 [0.2.0]: https://github.com/google/docsy/releases/v0.2.0
 [0.x.y]: #
-[23q1]: https://github.com/google/docsy/milestone/6
+[23q2]: https://github.com/google/docsy/milestone/7
 [hugo modules]: https://gohugo.io/hugo-modules/
 [latest]: https://github.com/google/docsy/releases/latest
 [releases]: https://github.com/google/docsy/releases

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -7,11 +7,7 @@
 @import "support/mixins";
 
 @import "../vendor/bootstrap/scss/bootstrap";
-
-$display1-size: null !default;
-@if $display1-size {
-  @error "Docsy requires Bootstrap v5, but v4 was detected. Did you forget to update Docsy dependencies?";
-}
+@import "support/bootstrap_vers_test";
 
 @import "../vendor/Font-Awesome/scss/fontawesome.scss";
 @import "../vendor/Font-Awesome/scss/solid.scss";

--- a/assets/scss/support/_bootstrap_vers_test.scss
+++ b/assets/scss/support/_bootstrap_vers_test.scss
@@ -1,0 +1,8 @@
+$enable-important-utilities: null !default;
+@if $enable-important-utilities == null {
+  @error "
+  Docsy requires Bootstrap v5, but the v5 variable
+  $enable-important-utilities isn't defined.
+  Did you forget to update Docsy dependencies?
+  ";
+}


### PR DESCRIPTION
- Closes #1574
- Places BS version test in a separate SCSS file named `assets/scss/support/_bootstrap_vers_test.scss`. 
  To **disable** the test, all a project has to do is create an empty file of the same name.
- The new test is intended to result in, at worst, a false negative (fail to detect BSv4) rather than a false positive (incorrectly think BS is at v4) -- as was reported in https://github.com/google/docsy/discussions/1555#discussioncomment-6188819

/cc @jmichelgarcia