### PR TITLE
UG landing page rework of CTA and subtitle

### DIFF
--- a/assets/scss/_colors.scss
+++ b/assets/scss/_colors.scss
@@ -12,7 +12,7 @@
 
   // Make links in paragraphs stand out more.
   @include link-variant(
-    ".-bg-#{$color-name} p > a",
+    ".-bg-#{$color-name} p:not(.p-initial) > a",
     $link-color,
     $link-hover-color,
     false

--- a/userguide/content/en/_index.md
+++ b/userguide/content/en/_index.md
@@ -1,17 +1,15 @@
 ---
 title: Docsy
+description: A Hugo theme for creating great technical documentation sites
 ---
 
 {{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" %}}
-<a class="btn btn-lg btn-primary me-3 mb-4" href="{{% relref "/about" %}}">
-  Learn More <i class="fa-solid fa-circle-right ms-2"></i>
-</a>
-<a class="btn btn-lg btn-secondary me-3 mb-4" href="{{% relref "/get-started" %}}">
-  Get started &nbsp;<i class="fa-solid fa-play "></i>
-</a>
+{{% param description %}}
+{.display-6}
 
-A Hugo theme for creating great technical documentation sites
-{.lead .mt-5}
+<a class="btn btn-lg btn-primary me-3" href="about/">Learn More</a>
+<a class="btn btn-lg btn-secondary" href="docs/get-started/">Get started</a>
+{.p-initial .my-5}
 
 {{% blocks/link-down color="info" %}}
 {{% /blocks/cover %}}


### PR DESCRIPTION
- Drops icons from CTA buttons, as discussed during the last PSC meeting
- Moves page subtitle into `description` field, so that it can populate the `description` meta elements, and be used in the page too.
- Changes page element order to: title, subtitle, CTA buttons
- **Preview**: https://deploy-preview-1581--docsydocs.netlify.app

| Before | After |
|--------|--------|
| <img width="375" alt="image" src="https://github.com/google/docsy/assets/4140793/657bc7c2-0a6a-44c1-b19e-cfcc293b2aa0"> | <img width="377" alt="image" src="https://github.com/google/docsy/assets/4140793/71f3a086-cbf2-4fd5-8881-3f78e6494a43"> | 