### PR TITLE
User guide: replace config.[toml|yaml] with hugo.[toml|yaml]

### DIFF
--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -91,7 +91,7 @@ When you use `.-bg-<color>`, the text colors will be adjusted to get proper cont
 
 ## Code highlighting with Chroma
 
-With Hugo version 0.60 and higher, you can choose from a range of code block highlight and colour styles using [Chroma](https://github.com/alecthomas/chroma) that are applied to your fenced code blocks by default. If you copied a recent `config.toml` your site uses Tango (like this site), otherwise the Hugo default is Monokai. You can switch to any of the [available Chroma styles](https://xyproto.github.io/splash/docs/all.html) (including our Docsy default Tango) using your `hugo.toml`/`hugo.yaml`/`hugo.json`:
+With Hugo version 0.60 and higher, you can choose from a range of code block highlight and colour styles using [Chroma](https://github.com/alecthomas/chroma) that are applied to your fenced code blocks by default. If you copied a recent `hugo.toml` your site uses Tango (like this site), otherwise the Hugo default is Monokai. You can switch to any of the [available Chroma styles](https://xyproto.github.io/splash/docs/all.html) (including our Docsy default Tango) using your `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane persistLang=false >}}
 {{< tab header="Configuration file:" disabled=true />}}

--- a/userguide/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -63,8 +63,8 @@ As the Docsy example site repo is a [template repository](https://github.blog/20
     ```
 
 {{% alert title="Note" color="primary" %}}
-Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/1c7f7e300c90cd690ca5be66b43fe58713bb21c9/config.toml#L221-L228) inside your `config.toml` slightly, for example by adding a proxy to use when downloading remote modules.
-You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level). 
+Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227) inside your `hugo.toml` slightly, for example by adding a proxy to use when downloading remote modules.
+You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 {{% /alert %}}
 
 Now you can make local edits and test your copied site locally with Hugo.

--- a/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -84,7 +84,7 @@ Hugo's commands for module management require that the `git` client is installed
 
 ```console
 $ git version
-git version 2.40.1
+git version 2.41.0
 ```
 
 If no `git` client is installed on your system yet, go to the [Git website](https://git-scm.com/), download the installer for your system architecture and execute it. Afterwards, check for a successful installation.

--- a/userguide/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -22,7 +22,7 @@ hugo new site my-new-site
 cd  my-new-site
 hugo mod init github.com/me/my-new-site
 hugo mod get github.com/google/docsy@v{{% param "version" %}}
-cat >> config.toml <<EOL
+cat >> hugo.toml <<EOL
 [module]
 proxy = "direct"
 [[module.imports]]
@@ -47,7 +47,7 @@ path = "github.com/google/docsy"^
 
 [[module.imports]]^
 
-path = "github.com/google/docsy/dependencies")>>config.toml
+path = "github.com/google/docsy/dependencies")>>hugo.toml
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
@@ -68,7 +68,7 @@ hugo new site my-new-site
 cd  my-new-site
 ```
 
-This will create a minimal site structure, containing the folders `archetypes`, `content`, `data`, `layouts`, `static`, and `themes` and a configuration file (default: `config.toml`).
+This will create a minimal site structure, containing the folders `archetypes`, `content`, `data`, `layouts`, `static`, and `themes` and a configuration file (default: `hugo.toml`).
 
 {{% alert title="Tip" %}}
 In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
@@ -95,7 +95,7 @@ This command adds the `docsy` theme module to your definition file `go.mod`.
 
 ### Add theme module configuration settings
 
-Add the settings in the following snippet at the end of your site's [configuration file] (default: `config.toml`) and save the file.
+Add the settings in the following snippet at the end of your site's [configuration file] (default: `hugo.toml`) and save the file.
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -176,7 +176,7 @@ your project's root directory:
 2.  Add Docsy as a theme, for example:
 
     ```sh
-    echo 'theme = "docsy"' >> config.toml
+    echo 'theme = "docsy"' >> hugo.toml
     ```
 
     {{% alert title="Tip" %}}
@@ -253,7 +253,7 @@ You can use Docsy as an NPM module as follows:
     ```sh
     hugo new site myproject
     cd myproject
-    echo 'theme = "docsy"' >> config.toml
+    echo 'theme = "docsy"' >> hugo.toml
     ```
 
 2.  Install Docsy, and postCSS (as [instructed earlier](#install-postcss)):
@@ -276,7 +276,7 @@ You can use Docsy as an NPM module as follows:
     your site's configuration file:
 
     ```sh
-    echo 'themesDir = "node_modules"' >> config.toml
+    echo 'themesDir = "node_modules"' >> hugo.toml
     ```
 
 As an alternative to specifying a `themesDir`, on some platforms, you can

--- a/userguide/content/en/docs/updating/convert-site-to-module.md
+++ b/userguide/content/en/docs/updating/convert-site-to-module.md
@@ -17,7 +17,8 @@ cd /path/to/my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
 hugo mod get github.com/google/docsy@v{{% param "version" %}}
 sed -i '/theme = \["docsy"\]/d' config.toml
-cat >> config.toml <<EOL
+mv config.toml hugo.toml
+cat >> hugo.toml <<EOL
 [module]
 proxy = "direct"
 [[module.imports]]
@@ -31,8 +32,7 @@ hugo server
 cd  my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
 hugo mod get github.com/google/docsy@v{{% param "version" %}}
-findstr /v /c:"theme = [\"docsy\"]" config.toml > config.toml.temp
-move /Y config.toml.temp config.toml
+findstr /v /c:"theme = [\"docsy\"]" config.toml > hugo.toml
 (echo [module]^
 
 proxy = "direct"^
@@ -43,7 +43,7 @@ path = "github.com/google/docsy"^
 
 [[module.imports]]^
 
-path = "github.com/google/docsy/dependencies")>>config.toml
+path = "github.com/google/docsy/dependencies")>>hugo.toml
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
@@ -77,11 +77,11 @@ This command adds the `docsy` theme module to your definition file `go.mod`.
 
 ### Update your config file
 
-In your `config.toml`/`config.yaml`/`config.json` file, update the theme setting to use Hugo Modules. Find the following line:
+In your `hugo.toml`/`hugo.yaml`/`hugo.json` file, update the theme setting to use Hugo Modules. Find the following line:
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
-{{< tab header="config.toml" lang="toml" >}}
+{{< tab header="hugo.toml" lang="toml" >}}
 theme = ["docsy"]
 {{< /tab >}}
 {{< tab header="config.yaml" lang="yaml" >}}
@@ -96,7 +96,7 @@ Change this line to:
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
-{{< tab header="config.toml" lang="toml" >}}
+{{< tab header="hugo.toml" lang="toml" >}}
 theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 {{< /tab >}}
 {{< tab header="config.yaml" lang="yaml" >}}
@@ -104,7 +104,7 @@ theme:
   - github.com/google/docsy
   - github.com/google/docsy/dependencies
 {{< /tab >}}
-{{< tab header="config.json" lang="json" >}}
+{{< tab header="hugo.json" lang="json" >}}
 "theme": [
   "github.com/google/docsy",
   "github.com/google/docsy/dependencies"
@@ -116,7 +116,7 @@ Alternatively, you can omit this line altogether and replace it with the setting
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
-{{< tab header="config.toml" lang="toml" >}}
+{{< tab header="hugo.toml" lang="toml" >}}
 [module]
   proxy = "direct"
   # uncomment line below for temporary local development of module
@@ -131,7 +131,7 @@ Alternatively, you can omit this line altogether and replace it with the setting
     path = "github.com/google/docsy/dependencies"
     disable = false
 {{< /tab >}}
-{{< tab header="config.yaml" lang="yaml" >}}
+{{< tab header="hugo.yaml" lang="yaml" >}}
 module:
   proxy: direct
   hugoVersion:
@@ -143,7 +143,7 @@ module:
     - path: github.com/google/docsy/dependencies
       disable: false
 {{< /tab >}}
-{{< tab header="config.json" lang="json" >}}
+{{< tab header="hugo.json" lang="json" >}}
 {
   "module": {
     "proxy": "direct",
@@ -171,11 +171,11 @@ Depending on your environment you may need to tweak them slightly, for example b
 
 {{% alert title="Tip" %}}
 In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
-If you are using hugo 0.110 or above, consider renaming your `config.toml` to `hugo.toml`!
+If you are using hugo 0.110 or above, we recommend renaming your `config.toml` to `hugo.toml`!
 {{% /alert %}}
 
 {{% alert title="Attention" color="warning" %}}
-If you have a multi language installation, please make sure that the section `[languages]` inside your `config.toml` is declared before the section `[module]` with the module imports. Otherwise you will run into trouble!
+If you have a multi language installation, please make sure that the section `[languages]` inside your `hugo.toml` is declared before the section `[module]` with the module imports. Otherwise you will run into trouble!
 {{% /alert %}}
 
 ### Check validity of your configuration settings


### PR DESCRIPTION
As of hugo version `0.113.0`, the command `hugo new site` now creates `hugo.toml` inside the newly created site directory, while with older versions, `config.toml` was used. This PR reflects this change throughout the whole user guide.