### PR TITLE
User guide: do not enable mermaid and scripts globally

### DIFF
--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -119,10 +119,6 @@ params:
     disable_toc: false
   markmap:
     enable: true
-  mermaid:
-    theme: default
-    flowchart:
-      diagramPadding: 20
   drawio:
     enable: true
 


### PR DESCRIPTION
Currently, mermaid scripts are globally enabled in the user guide. This confuses users, as seen in #1588. This PR corrects this so that mermaid scripts are only inserted for pages that actually contain mermaid code blocks.

**Note:** Globally enabling mermaid scripts is due to legacy code (hugo < `v0.93.0`). We should do some cleanup here. I will open a separate issue for this.