### PR TITLE
Footer, copyright notice: allow customization of year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ For the full list of changes, see the [0.9.0] release notes.
   renamed to `td-footer__center`. For details concerning all foot changes, see
   [#1818].
 
+- **Footer, copyright notice**:
+  - display of year can now be customized via .Site.Params.copyright.year
+  - title displayed after year must now be given via
+    .Site.Params.copyright.title
+
 **Other changes**:
 
 - The latest release of [Mermaid] resources are fetched at build time ([#1410]).

--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,3 +1,5 @@
 {{ with .Site.Params.copyright -}}
-  <span class="td_footer__copyright">&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
+  <span class="td_footer__copyright">&copy; {{ with .year -}}{{- . -}}{{- else -}}{{- now.Year -}}{{- end }} {{ with .title -}}{{- . -}}{{- end }} {{ T "footer_all_rights_reserved" }}</span>
+  {{- else }}
+    {{ with .Site.Copyright }}{{ . | safeHTML }}{{ end }}
 {{- end -}}

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -50,7 +50,9 @@ markup:
     style: tango
 
 params:
-  copyright: The Docsy Authors
+  copyright:
+    title: The Docsy Authors
+    year: 2024
   privacy_policy: https://policies.google.com/privacy
   version_menu: Releases
   archived_version: false


### PR DESCRIPTION
Following up on #1592, this PR allows to customize the year displayed in the footer's copyright notice. This is done via specifying `.Site.Params.copyright.year` in your config file.

This PR closes #1592

Closes #2