### PR TITLE
NPM package version: add suffix -dev.0-unreleased

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.7.1",
+  "version": "0.7.2-dev.0-unreleased",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
We might not have a 0.7.2 release, and instead go directly to 0.8.0, but we at least want all work until then to be identified as "unreleased".