### PR TITLE
Upgrade Hugo to 0.115.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bootstrap": "5.2.3"
   },
   "devDependencies": {
-    "hugo-extended": "0.113.0"
+    "hugo-extended": "0.115.1"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
There are no changes to the generated user-guide pages:

```console
$ npm run test
...
$ (cd userguide/public && git diff -bw -I "Hugo 0.11" ) # no diff other than Hugo version
$
```