### PR TITLE
Tabpane: support persistence of all active tabs

### DIFF
--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -106,7 +106,6 @@
         {{ if $disabled }} disabled{{ end -}}"
           id="{{ $tabid }}" data-bs-toggle="tab" data-bs-target="#{{ $entryid }}" role="tab"
           {{ if and $persistTab $persistKey -}}
-            onclick="tdPersistActiveTab({{ $persistKey }});" {{/* */ -}}
             {{ printf "%s=%q " $tpPersistAttrName $persistKey | safeHTMLAttr -}}
           {{ end -}}
           aria-controls="{{- $entryid -}}" aria-selected="{{- cond ( and ( not $activeSet ) ( not $disabled ) ) "true" "false" -}}">

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -25,9 +25,9 @@
 
 {{ $_persist := .Get "persist" -}}
 {{ with $_persist -}}
-  {{ $matched := findRE "^(header|lang|none)$" . -}}
+  {{ $matched := findRE "^(header|lang|disabled)$" . -}}
   {{ if not $matched -}}
-    {{ errorf "Shortcode %q: parameter %q should be one of 'header', 'lang', or 'none'; but got %s. Error position: %s" $.Name "persist" $_persist $.Position  -}}
+    {{ errorf "Shortcode %q: parameter %q should be one of 'header', 'lang', or 'disabled'; but got %s. Error position: %s" $.Name "persist" $_persist $.Position  -}}
   {{ end -}}
 {{ end -}}
 
@@ -44,7 +44,7 @@
 {{ $langEqualsHeader := default false ($.Get "langEqualsHeader") -}}
 {{ $deprecatedPersistLang := $_persistLang | default true -}}
 {{ $persistKeyKind := $_persist | default (cond (eq $langPane "") "lang" "header") -}}
-{{ $persistTab := and $deprecatedPersistLang (ne $persistKeyKind "none") -}}
+{{ $persistTab := and $deprecatedPersistLang (ne $persistKeyKind "disabled") -}}
 {{ $rightPane := default false ($.Get "right") -}}
 {{ $activeSet := false -}}
 {{/* Scratchpad gets populated through call to .Inner */ -}}

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -1,9 +1,14 @@
 const td_persistStorageKeyName = 'td-tp-persist';
 const td_persistDataAttrName = `data-${td_persistStorageKeyName}`;
 
+// Helpers
+
 const tdPersistCssSelector = (attrValue) => attrValue
   ? `[${td_persistDataAttrName}="${attrValue}"]`
   : `[${td_persistDataAttrName}]`;
+const tdSupportsLocalStorage = () => typeof Storage !== 'undefined';
+
+// Main functions
 
 function tdActivateTabsWithKey(key) {
   if (!key) return;
@@ -25,10 +30,10 @@ function tdPersistActiveTab(activeTabKey) {
   }
 }
 
-const tdSupportsLocalStorage = () => typeof Storage !== 'undefined';
+// Register listeners
 
-// On page load, activate tabs
-if (tdSupportsLocalStorage()) {
+window.addEventListener('DOMContentLoaded', () => {
+  if (!tdSupportsLocalStorage()) return;
   const activeTabKey = localStorage.getItem(td_persistStorageKeyName);
   tdActivateTabsWithKey(activeTabKey);
-}
+});

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -63,13 +63,11 @@ function tdPersistActiveTab(activeTabKey) {
   tdActivateTabsWithKey(activeTabKey);
 }
 
-function tdGetAndActivatePersistedTabsInThisPage() {
+function tdGetAndActivatePersistedTabs(tabs) {
   // Get unique persistence keys of tabs in this page
   var keyOfTabsInThisPage = [
     ...new Set(
-      Array.from(document.querySelectorAll(_tdPersistCssSelector())).map((el) =>
-        el.getAttribute(td_persistDataAttrName)
-      )
+      Array.from(tabs).map((el) => el.getAttribute(td_persistDataAttrName))
     ),
   ];
 
@@ -93,10 +91,7 @@ function tdGetAndActivatePersistedTabsInThisPage() {
   return key_ageList;
 }
 
-function tdRegisterTabClickHandlers() {
-  // Tabs in this page
-  var tabs = document.querySelectorAll(_tdPersistCssSelector());
-
+function tdRegisterTabClickHandler(tabs) {
   tabs.forEach((tab) => {
     tab.addEventListener('click', () => {
       const activeTabKey = tab.getAttribute(td_persistDataAttrName);
@@ -105,10 +100,12 @@ function tdRegisterTabClickHandlers() {
   });
 }
 
-// Register listeners
+// Register listeners and activate tabs
 
 window.addEventListener('DOMContentLoaded', () => {
   if (!_tdSupportsLocalStorage()) return;
-  tdGetAndActivatePersistedTabsInThisPage();
-  tdRegisterTabClickHandlers();
+
+  var allTabsInThisPage = document.querySelectorAll(_tdPersistCssSelector());
+  tdRegisterTabClickHandler(allTabsInThisPage);
+  tdGetAndActivatePersistedTabs(allTabsInThisPage);
 });

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -64,7 +64,7 @@ function tdPersistActiveTab(activeTabKey) {
 }
 
 function tdGetAndActivatePersistedTabsInThisPage() {
-  // Get keys of tabs in this page
+  // Get unique persistence keys of tabs in this page
   var keyOfTabsInThisPage = [
     ...new Set(
       Array.from(document.querySelectorAll(_tdPersistCssSelector())).map((el) =>
@@ -93,10 +93,22 @@ function tdGetAndActivatePersistedTabsInThisPage() {
   return key_ageList;
 }
 
+function tdRegisterTabClickHandlers() {
+  // Tabs in this page
+  var tabs = document.querySelectorAll(_tdPersistCssSelector());
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const activeTabKey = tab.getAttribute(td_persistDataAttrName);
+      tdPersistActiveTab(activeTabKey);
+    });
+  });
+}
+
 // Register listeners
 
 window.addEventListener('DOMContentLoaded', () => {
   if (!_tdSupportsLocalStorage()) return;
   tdGetAndActivatePersistedTabsInThisPage();
-  // TODO: ... tabElement.addEventListener('click', f);
+  tdRegisterTabClickHandlers();
 });

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -1,10 +1,14 @@
-// Storage key name also used as a data-* attribute suffix:
-const storageKeyName = 'td-tp-persist';
+const td_persistStorageKeyName = 'td-tp-persist';
+const td_persistDataAttrName = `data-${td_persistStorageKeyName}`;
+
+const tdPersistCssSelector = (attrValue) => attrValue
+  ? `[${td_persistDataAttrName}="${attrValue}"]`
+  : `[${td_persistDataAttrName}]`;
 
 function tdActivateTabsWithKey(key) {
   if (!key) return;
   document
-    .querySelectorAll(`[data-${storageKeyName}="${key}"]`)
+    .querySelectorAll(tdPersistCssSelector(key))
     .forEach((element) => {
       new bootstrap.Tab(element).show();
     });
@@ -14,7 +18,7 @@ function tdPersistActiveTab(activeTabKey) {
   if (!tdSupportsLocalStorage()) return;
 
   try {
-    localStorage.setItem(storageKeyName, activeTabKey);
+    localStorage.setItem(td_persistStorageKeyName, activeTabKey);
     tdActivateTabsWithKey(activeTabKey);
   } catch (error) {
     console.error(`Unable to save active tab '${activeTabKey}' to localStorage:`, error);
@@ -25,6 +29,6 @@ const tdSupportsLocalStorage = () => typeof Storage !== 'undefined';
 
 // On page load, activate tabs
 if (tdSupportsLocalStorage()) {
-  const activeTabKey = localStorage.getItem(storageKeyName);
+  const activeTabKey = localStorage.getItem(td_persistStorageKeyName);
   tdActivateTabsWithKey(activeTabKey);
 }

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -5,9 +5,10 @@ const td_persistDataAttrName = `data-${td_persistStorageKeyNameBase}`;
 
 // Utilities
 
-const _tdPersistCssSelector = (attrValue) => attrValue
-  ? `[${td_persistDataAttrName}="${attrValue}"]`
-  : `[${td_persistDataAttrName}]`;
+const _tdPersistCssSelector = (attrValue) =>
+  attrValue
+    ? `[${td_persistDataAttrName}="${attrValue}"]`
+    : `[${td_persistDataAttrName}]`;
 
 const _tdStoragePersistKey = (tabKey) =>
   td_persistStorageKeyNameBase + ':' + (tabKey || '');
@@ -27,7 +28,10 @@ function tdPersistKey(key, value) {
     }
   } catch (error) {
     const action = value ? 'add' : 'remove';
-    console.error(`Docsy tabpane: unable to ${action} localStorage key '${key}': `, error);
+    console.error(
+      `Docsy tabpane: unable to ${action} localStorage key '${key}': `,
+      error
+    );
   }
 }
 
@@ -47,11 +51,9 @@ function tdGetTabSelectEventCount() {
 function tdActivateTabsWithKey(key) {
   if (!key) return;
 
-  document
-    .querySelectorAll(_tdPersistCssSelector(key))
-    .forEach((element) => {
-      new bootstrap.Tab(element).show();
-    });
+  document.querySelectorAll(_tdPersistCssSelector(key)).forEach((element) => {
+    new bootstrap.Tab(element).show();
+  });
 }
 
 function tdPersistActiveTab(activeTabKey) {
@@ -63,17 +65,20 @@ function tdPersistActiveTab(activeTabKey) {
 
 function tdGetAndActivatePersistedTabsInThisPage() {
   // Get keys of tabs in this page
-  var keyOfTabsInThisPage = [...new Set(
-    Array.from(document.querySelectorAll(_tdPersistCssSelector()))
-      .map(el => el.getAttribute(td_persistDataAttrName))
-  )];
+  var keyOfTabsInThisPage = [
+    ...new Set(
+      Array.from(document.querySelectorAll(_tdPersistCssSelector())).map((el) =>
+        el.getAttribute(td_persistDataAttrName)
+      )
+    ),
+  ];
 
   // Create a list of active tabs with their age:
   let key_ageList = keyOfTabsInThisPage
     // Map to [tab-key, last-activated-age]
-    .map(k => [
+    .map((k) => [
       k,
-      parseInt(localStorage.getItem(_tdStoragePersistKey(k))) || 0
+      parseInt(localStorage.getItem(_tdStoragePersistKey(k))) || 0,
     ])
     // Exclude tabs that have never been activated
     .filter(([k, v]) => v)

--- a/static/js/tabpane-persist.js
+++ b/static/js/tabpane-persist.js
@@ -36,7 +36,7 @@ function tdPersistKey(key, value) {
 }
 
 // Retrieve, increment, and store tab-select event count, then returns it.
-function tdGetTabSelectEventCount() {
+function tdGetTabSelectEventCountAndInc() {
   // @requires: tdSupportsLocalStorage();
 
   const storedCount = localStorage.getItem(td_persistCounterStorageKeyName);
@@ -59,9 +59,14 @@ function tdActivateTabsWithKey(key) {
 function tdPersistActiveTab(activeTabKey) {
   if (!_tdSupportsLocalStorage()) return;
 
-  tdPersistKey(_tdStoragePersistKey(activeTabKey), tdGetTabSelectEventCount());
+  tdPersistKey(
+    _tdStoragePersistKey(activeTabKey),
+    tdGetTabSelectEventCountAndInc()
+  );
   tdActivateTabsWithKey(activeTabKey);
 }
+
+// Handlers
 
 function tdGetAndActivatePersistedTabs(tabs) {
   // Get unique persistence keys of tabs in this page


### PR DESCRIPTION
- Updates option value to disable persistence: now use `persist=disabled` (instead of `off`)
- Enhances tabpane to support the persistence of the active tab selection for **all tabpanes** (excluding those with `persist=disabled`),  rather than just the last activated tab
- Restores all persisted activated tabs on page load
- Persists in localStorage a count of the tab-activated events
- Persists each activated tab in localStorage using the tab's persistence key. The value associated with the key is the tab-activated-event count plus one (also saved to localStorage). This supports typical use cases, in addition to the one explained below.
- Drops `button.onclick` in favor of `click` event handlers.

### Handling of non-uniform shared tabs

Assume that a page contains three tabpanes with the following distribution of tabs A, B, C, D -- where these letters represent the tab-persistence keys:

1. A, B
2. B, D
3. A, B, C

If you activate tab B from any tabpane, it will become active in all three tabs and the selection will be persisted. If you then select C, then tab C will become active in tabpane 3, but tab panes 1 and 2 will remain active at B -- and these settings are persisted. If you then select A, then: tabpanes 1  and 3 become active at A, but tabpane 2 remains unchanged.

IMHO, this applies the principle of least surprise.

### Preview and tests

- https://deploy-preview-1611--docsydocs.netlify.app/docs/adding-content/content/#custom-sections -- select `yaml` and refresh the page. You'll see that the choice of language persists in this page and is active in other pages with the same tab-persistence key
- https://deploy-preview-1611--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes -- select, say, German, and Scala, then refresh to see the persistence in action. Return to the previous page to see that the `yaml` persistence is still active.

### Other

- FYI, I've successfully tested this on the OTel website.
- Updates to the changelog and docs will be made in a followup PR.