### PR TITLE
Typo continuar in spanish

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -7,7 +7,7 @@ other = "Previo"
 other = "Siguiente"
 
 [ui_read_more]
-other = "Contiuar leyendo"
+other = "Continuar leyendo"
 
 [ui_search]
 other = "Buscar"


### PR DESCRIPTION
The right word is "continuar" in spanish