### PR TITLE
Fix whitespace cleanup syntax issue

### DIFF
--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -5,7 +5,7 @@
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}
 		{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
-			{{ partial "reading-time.html" .- }}
+			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
 	{{ .Content }}


### PR DESCRIPTION
I believe this was introduced in bf65c18d2845055b4a3f1b922d5b6761f0671448.