### PR TITLE
Fix warning: '.File.UniqueID on zero object' (#1007)

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,31 +1,33 @@
 <div class="section-index">
-    {{ $parent := .Page }}
-    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
+    {{ $parent := .Page -}}
+    {{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
     {{ $pages = (where $pages "Type" "!=" "search") }}
-    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
-    {{ $pages = (where $pages ".Parent" "!=" nil) }}
-    {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
-    {{ if or $parent.Params.no_list (eq (len $pages) 0) }}
+    {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
+    {{ $pages = (where $pages ".Parent" "!=" nil) -}}
+    {{ if .Parent.File -}}
+        {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
+    {{ end -}}
+    {{ if or $parent.Params.no_list (eq (len $pages) 0) -}}
     {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}
-    {{ else if $parent.Params.simple_list }}
+    {{ else if $parent.Params.simple_list -}}
     {{/* If simple_list is true we show a bulleted list of subpages */}}
         <ul>
-            {{ range $pages }}
+            {{ range $pages -}}
                 {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
                 <li><a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a></li>
-            {{ end }}
+            {{ end -}}
         </ul>
-    {{ else }}
+    {{ else -}}
     {{/* Otherwise we show a nice formatted list of subpages with page descriptions */}}
     <hr class="panel-line">
-        {{ range $pages }}
-            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) }}
+        {{ range $pages -}}
+            {{ $manualLink := cond (isset .Params "manuallink") .Params.manualLink ( cond (isset .Params "manuallinkrelref") (relref . .Params.manualLinkRelref) .RelPermalink) -}}
             <div class="entry">
                 <h5>
                     <a href="{{ $manualLink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
                 </h5>
-                <p>{{ .Description | markdownify }}</p>
+                <p>{{ .Description | markdownify -}}</p>
             </div>
-        {{ end }}
-    {{ end }}
+        {{ end -}}
+    {{ end -}}
 </div>


### PR DESCRIPTION
This PR closes #1007 (see my analysis there). The fix is quite easy, all we have to do here is to put a `{{ with }}` statement around the offending code line 8:

```
7  {{ with .Parent.File -}}
8     {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
9  {{ end -}}
```

 Also I did some code cleanup in order to prevent superfluous whitespace and lines.
I did a `diff` of the published user guide, and there are no changes caused by this PR other than white space cleanup.
