### PR TITLE
tabpane: fix duplicate-key detection

### DIFF
--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -82,7 +82,7 @@
 
     {{/* Check for duplicate tab-persistence keys */ -}}
     {{ if and $persistTab $persistKey -}}
-      {{ if in $persistKey $persistKeyList -}}
+      {{ if in $persistKeyList $persistKey -}}
         {{ $duplicate = true -}}
         {{ $duplicateKey = $persistKey -}}
         {{ $persistTab = false -}}


### PR DESCRIPTION
- Closes #1634
- The source of the problem was the wrong order of arguments to `in` (sigh)