### PR TITLE
tabpane width fix

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -8,6 +8,7 @@
 
 .tab-content {
   .tab-pane {
+    @extend .td-max-width-on-larger-screens;
     .highlight {
       margin: 0rem 0 0rem 0;
       border: none;
@@ -15,7 +16,6 @@
     }
     margin-top: 0rem;
     margin-bottom: 1.5rem;
-    max-width: 80%;
     border-left: 1px solid rgba(0, 0, 0, 0.125);
     border-right: 1px solid rgba(0, 0, 0, 0.125);
     border-bottom: 1px solid rgba(0, 0, 0, 0.125);


### PR DESCRIPTION
- Closes #1162
- **Preview**: https://deploy-preview-1639--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes

### Before

> <img width="695" alt="image" src="https://user-images.githubusercontent.com/4140793/184600793-f787a8cd-a804-4e75-8895-993be2a7b860.png">

### After

> <img width="649" alt="image" src="https://github.com/google/docsy/assets/4140793/2fbde18d-729c-4ab3-8234-b5c9847b05e0">
