### PR TITLE
User guide Print page: move tabs to separate pane to eliminate warning

### DIFF
--- a/userguide/content/en/docs/adding-content/print.md
+++ b/userguide/content/en/docs/adding-content/print.md
@@ -46,30 +46,33 @@ The site should then show a "Print entire section" link in the right hand naviga
 
 To disable showing the the table of contents in the printable view, set the `disable_toc` param to `true`, either in the page front matter, or in `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
-{{< tabpane >}}
+{{< tabpane langEqualsHeader=true >}}
 {{< tab header="Front matter:" disabled=true />}}
-{{< tab header="toml" lang="toml" >}}
+{{< tab toml >}}
 +++
 …
 disable_toc = true
 …
 +++
 {{< /tab >}}
-{{< tab header="yaml" lang="yaml" >}}
+{{< tab yaml >}}
 ---
 …
 disable_toc: true
 …
 ---
 {{< /tab >}}
-{{< tab header="json" lang="json" >}}
+{{< tab json >}}
 {
   …,
   "disable_toc": true,
   …
 }
 {{< /tab >}}
-{{< tab header="or config file:" disabled=true />}}
+{{< /tabpane >}}
+
+{{< tabpane >}}
+{{< tab header="Config file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 [params.print]
 disable_toc = true


### PR DESCRIPTION
- Splits a tabbed pane that hand two tabs with each language `yaml`, `toml`, and `json`; which was being reported as a warning:
  ```text
  WARN  Shortcode "tabpane": duplicate tab-persistence key "toml" detected, disabling persistance to avoid multiple tab display. Position: "/Users/chalin/git/lf/docsy/docsy/userguide/content/en/docs/adding-content/print.md:49:1"
  ```
- **Preview**: https://deploy-preview-1642--docsydocs.netlify.app/docs/adding-content/print/#disabling-the-toc

### Before

> <img width="573" alt="image" src="https://github.com/google/docsy/assets/4140793/4678749d-8aa3-4601-8073-6b50a88c9322">

### After

> <img width="582" alt="image" src="https://github.com/google/docsy/assets/4140793/784ab1ed-21a6-4808-9506-4ee9b585cfe9">

