### PR TITLE
Tabpane: improve key-kind default setting

### DIFF
--- a/layouts/shortcodes/tab.html
+++ b/layouts/shortcodes/tab.html
@@ -19,34 +19,34 @@
 {{/* store all tab info in dict tab */ -}}
 {{ $tab := dict "header" $header -}}
 {{ with $.Get "lang" -}}
-  {{ $tab = merge $tab (dict "language" ($.Get "lang")) -}}
+  {{ $tab = merge $tab (dict "language" .) -}}
 {{ end -}}
 {{ with $.Get "highlight" -}}
-  {{ $tab = merge $tab (dict "highlight" ($.Get "highlight")) -}}
+  {{ $tab = merge $tab (dict "highlight" .) -}}
 {{ end -}}
 {{ with $.Get "text" -}}
   {{ if ne ( printf "%T" . ) "bool" -}}
     {{ errorf "Shortcode %q: boolean value expected for parameter %q, but got %s. Error position: %s" $.Name "text" (printf "%T" .) $.Position  -}}
   {{ end -}}
-  {{ $tab = merge $tab (dict "text" ($.Get "text")) -}}
+  {{ $tab = merge $tab (dict "text" .) -}}
 {{ end -}}
 {{ with $.Get "right" -}}
   {{ if ne ( printf "%T" . ) "bool" -}}
     {{ errorf "Shortcode %q: boolean value expected for parameter %q, but got %s. Error position: %s" $.Name "right" (printf "%T" .) $.Position  -}}
   {{ end -}}
-  {{ $tab = merge $tab (dict "rightpush" ($.Get "right")) -}}
+  {{ $tab = merge $tab (dict "rightpush" .) -}}
 {{ end -}}
 {{ with $.Get "disabled" -}}
   {{ if ne ( printf "%T" . ) "bool" -}}
     {{ errorf "Shortcode %q: boolean value expected for parameter %q, but got %s. Error position: %s" $.Name "disabled" (printf "%T" .) $.Position  -}}
   {{ end -}}
-  {{ $tab = merge $tab (dict "disabled" ($.Get "disabled")) -}}
+  {{ $tab = merge $tab (dict "disabled" .) -}}
 {{ end -}}
 
 {{ with $.Inner -}}
   {{/* Trim any leading and trailing newlines from .Inner, this avoids
        spurious lines during syntax highlighting */ -}}
-  {{ $tab = merge $tab (dict "content" $.Inner) -}}
+  {{ $tab = merge $tab (dict "content" .) -}}
 {{ end -}}
 
 {{/* add dict tab to parent's scratchpad */ -}}

--- a/layouts/shortcodes/tabpane.html
+++ b/layouts/shortcodes/tabpane.html
@@ -43,8 +43,9 @@
 {{ $textPane := default false ($.Get "text") -}}
 {{ $langEqualsHeader := default false ($.Get "langEqualsHeader") -}}
 {{ $deprecatedPersistLang := $_persistLang | default true -}}
-{{ $persistKeyKind := $_persist | default (cond (eq $langPane "") "lang" "header") -}}
-{{ $persistTab := and $deprecatedPersistLang (ne $persistKeyKind "disabled") -}}
+{{ $persistKeyKind := $_persist
+    | default (cond (or $textPane (ne "" $langPane)) "header" "lang") -}}
+{{ $persistTabpane := and $deprecatedPersistLang (ne $persistKeyKind "disabled") -}}
 {{ $rightPane := default false ($.Get "right") -}}
 {{ $activeSet := false -}}
 {{/* Scratchpad gets populated through call to .Inner */ -}}
@@ -59,10 +60,7 @@
 <ul class="nav nav-tabs{{ if $rightPane }} justify-content-end{{ end }}" id="tabs-{{- $tabPaneOrdinal -}}" role="tablist">
   {{ range $index, $element := $.Scratch.Get "tabs" -}}
 
-    {{ $disabled := false -}}
-    {{ with $element.disabled -}}
-      {{ $disabled = . -}}
-    {{ end -}}
+    {{ $enabled := not $element.disabled -}}
 
     {{ $lang := $langPane -}}
     {{ if $langEqualsHeader -}}
@@ -74,14 +72,21 @@
 
     {{ $persistKey := "" -}}
     {{ if eq $persistKeyKind "lang" -}}
-      {{ $persistKey = $lang -}}
+      {{ with $lang -}}
+        {{ $persistKey = . -}}
+      {{ else -}}
+        {{ with findRE "```(\\S+)" $element.content 1 -}}
+          {{ $persistKey = index . 1 -}}
+        {{ end -}}
+      {{ end -}}
     {{ else if eq $persistKeyKind "header" -}}
       {{ $persistKey = $element.header -}}
     {{ end -}}
     {{ $persistKey = $persistKey | lower -}}
+    {{ $persistTab := and $persistTabpane $persistKey $enabled -}}
 
     {{/* Check for duplicate tab-persistence keys */ -}}
-    {{ if and $persistTab $persistKey -}}
+    {{ if $persistTab -}}
       {{ if in $persistKeyList $persistKey -}}
         {{ $duplicate = true -}}
         {{ $duplicateKey = $persistKey -}}
@@ -101,23 +106,23 @@
       {{ $tabid := printf "tabs-%02v-%v-tab" $tabPaneOrdinal $index | anchorize -}}
       {{ $entryid := printf "tabs-%02v-%v" $tabPaneOrdinal $index | anchorize -}}
 
+      {{ $isActive := and $enabled (not $activeSet) -}}
+
       <button class="nav-link
-        {{- if and ( not $activeSet ) ( not $disabled ) }} active{{ end -}}
-        {{ if $disabled }} disabled{{ end -}}"
+        {{- if $isActive -}}
+          {{ $activeSet = true }} active
+        {{- end -}}
+        {{ if not $enabled }} disabled{{ end -}}"
           id="{{ $tabid }}" data-bs-toggle="tab" data-bs-target="#{{ $entryid }}" role="tab"
-          {{ if and $persistTab $persistKey -}}
+          {{ if $persistTab -}}
             {{ printf "%s=%q " $tpPersistAttrName $persistKey | safeHTMLAttr -}}
           {{ end -}}
-          aria-controls="{{- $entryid -}}" aria-selected="{{- cond ( and ( not $activeSet ) ( not $disabled ) ) "true" "false" -}}">
+          aria-controls="{{- $entryid -}}" aria-selected="{{ $isActive }}">
         {{ index . "header" | markdownify }}
       </button>
     </li>
 
-    {{- if not $disabled -}}
-      {{ $activeSet = true -}}
-    {{ end -}}
-
-  {{ end }}
+  {{- end }}
 </ul>
 
 {{ if $duplicate -}}
@@ -138,10 +143,7 @@
       {{ $lang = . -}}
     {{ end -}}
 
-    {{ $disabled := false -}}
-    {{ with $element.disabled -}}
-      {{ $disabled = . -}}
-    {{ end -}}
+    {{ $enabled := not $element.disabled -}}
 
     {{ $hloptions := $hloptionsPane -}}
     {{ with $element.highlight -}}
@@ -155,7 +157,12 @@
 
     {{ $tabid := printf "tabs-%02v-%v-tab" $tabPaneOrdinal $index | anchorize -}}
     {{ $entryid := printf "tabs-%02v-%v" $tabPaneOrdinal $index | anchorize }}
-    <div class="{{ if $text }}tab-body {{end}}tab-pane fade{{ if and ( not $activeSet ) ( not $disabled ) }} show active{{ end }}"
+    {{ $isActive := and $enabled (not $activeSet) -}}
+
+    <div class="{{ if $text }}tab-body {{end}}tab-pane fade
+        {{- if $isActive -}}
+          {{ $activeSet = true }} show active
+        {{- end }}"
         id="{{ $entryid }}" role="tabpanel" aria-labelled-by="{{ $tabid }}" tabindex="{{ $tabPaneOrdinal }}">
         {{ if $text -}}
           {{ index . "content" -}}
@@ -164,9 +171,5 @@
         {{ end }}
     </div>
 
-    {{- if not $disabled -}}
-      {{ $activeSet = true -}}
-    {{ end -}}
-
-  {{ end }}
+  {{- end }}
 </div>


### PR DESCRIPTION
- Contributes to #1641
- Improves the default setting of the tabpane key kind, now handling cases were `text=true`
- Refactors `tab.html` slightly, by making use of `.` instead of repeating the `with` expression
- **Preview**: https://deploy-preview-1643--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes

---

The only change in the generated UG is that the [Welcome! tabbed panes](https://deploy-preview-1643--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes) are now persisted using the tab header as a key rather than the language:

```console
$ (cd userguide/public && git diff -I "data-td-tp-persist=\"(en|de|ge|sw)" -- . ':(exclude)*.xml') | grep ^diff
# No change
$ (cd userguide/public && git diff -- . ':(exclude)*.xml') | grep ^diff 
diff --git a/docs/_print/index.html b/docs/_print/index.html
diff --git a/docs/adding-content/_print/index.html b/docs/adding-content/_print/index.html
diff --git a/docs/adding-content/shortcodes/index.html b/docs/adding-content/shortcodes/index.html
$ (cd userguide/public && git diff -- . ':(exclude)*.xml') | head      
...
```
```diff
diff --git a/docs/_print/index.html b/docs/_print/index.html
index 29d8bb8..d250b65 100644
--- a/docs/_print/index.html
+++ b/docs/_print/index.html
@@ -5396,19 +5396,19 @@ in the response headers.&rdquo; you <strong>CAN</strong> embed it, but when the
     </li><li class="nav-item">
       <button class="nav-link active"
           id="tabs-08-01-tab" data-bs-toggle="tab" data-bs-target="#tabs-08-01" role="tab"
-          data-td-tp-persist="en" aria-controls="tabs-08-01" aria-selected="true">
+          data-td-tp-persist="english" aria-controls="tabs-08-01" aria-selected="true">
```