### PR TITLE
Template for new files at GitHub: add info on customization

### DIFF
--- a/assets/stubs/new-page-template.md
+++ b/assets/stubs/new-page-template.md
@@ -6,6 +6,13 @@ description: >-
      Page description for heading and indexes.
 ---
 
+<!--
+In order to change the default frontmatter and the content for new pages,
+add a new template file `assets/stubs/new-page-template` to your project.
+This file will override the default settings of the theme. Adapt this file
+according to your needs.
+-->
+
 ## Heading
 
 Edit this template to create your new page.


### PR DESCRIPTION
The template file `new-page-template.md` specifies the frontmatter and content used for new pages at GitHub (via link `Create new child page` in the right sidebar). This PR adds documentation on how to override the frontmatter and the content defined in this file via a project specific file in your project.