### PR TITLE
Algolia search, fix: show search box in the sidebar

### DIFF
--- a/layouts/partials/search-input.html
+++ b/layouts/partials/search-input.html
@@ -4,7 +4,8 @@
   <input type="search" class="td-search__input form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
 </div>
 {{ else if .Site.Params.algolia_docsearch -}}
-<div id="docsearch"></div>
+{{ $.Scratch.Add "docsearch-id-num" 1 -}}
+<div id="docsearch-{{ mod (.Scratch.Get "docsearch-id-num") 2 }}"></div>
 {{ else if .Site.Params.offlineSearch -}}
 {{ $offlineSearchIndex := resources.Get "json/offline-search-index.json" | resources.ExecuteAsTemplate "offline-search-index.json" . -}}
 {{ if hugo.IsProduction -}}

--- a/userguide/content/en/docs/adding-content/search.md
+++ b/userguide/content/en/docs/adding-content/search.md
@@ -141,20 +141,25 @@ algolia_docsearch: true
    * In `head-end.html` add the DocSearch CSS:
 
       ```html
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" integrity="sha512-O6ywtjtiV4QGgC6cD75C2Tf04SlTn9vvka8oV/dYpDL1JWM4lVP0QoZbdZt5RLtOWDpaP+MObzUrwl43ssqfvg==" crossorigin="anonymous" />
       ```
 
-
-   * In `body-end.html` add the DocSearch script, replacing the `docsearch` details with the snippet you get from Algolia (the example below is Algolia's own site index!). You must provide `#docsearch` as your `container` value as that's the ID of the `div` we provide in Docsy's layout:
+   * In `body-end.html` add the DocSearch script. In the code below, replace `docsearch` argument values for `appId`, `apiKey` and `indexName` with those provided by Algolia. Use the `container` values given below, they correspond to the IDs found in Docsy's layout:
 
       ```html
-      <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
-      <script type="text/javascript">docsearch({
-        container: '#docsearch',
-        appId: 'R2IYF7ETH7',
-        apiKey: '599cec31baffa4868cae4e79f180729b',
-        indexName: 'docsearch',
-        });</script>
+      <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" integrity="sha512-sQFwlNnBlEyWdI4EwJ9d2wjViu0ZPmIMjPP8kCmBoOjqcljGndf2gb4mldT4ZHxKCQcrdJ0+rxnMFKHuGWB7ag==" crossorigin="anonymous" ></script>
+      <script type="text/javascript">
+        for (let i = 0; i < 2; i++) {
+          docsearch({
+            container: `#docsearch-${i}`,
+            // Replace the values below with those for your site.
+            // These are Algolia's test values used for illustrative purposes:
+            appId: 'R2IYF7ETH7',
+            apiKey: '599cec31baffa4868cae4e79f180729b',
+            indexName: 'docsearch',
+          });
+        }
+      </script>
      ```
 
 You can find out more about how to configure DocSearch in the Algolia DocSearch V3 [Getting started](https://docsearch.algolia.com/docs/DocSearch-v3) guide.


### PR DESCRIPTION
When enabling algolia search, only the search box in the navbar appears, the search box in the sidebar doesn't show up. As correctly analysed [here](https://github.com/google/docsy/issues/1250#issuecomment-1273359341), this is due to the fact that currently both search boxes use the same id in their corresponding div element (which violates the principle that ids should be unique(!)).

This PR solves this issue, both search boxes show up with this patch applied. This PR also updates the documentation on algolia search in the user guide: we now have to provide **two** `docsearch` functions in the docsearch javascript code.

---

- Closes #1433