### PR TITLE
Fix left-nav height and padding

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -2,14 +2,27 @@
 // Left side navigation
 //
 .td-sidebar-nav {
+  --sidebar_search_disabled: 0; // 0 or 1; set to 1 in sidebar-tree layout
+
+  // If --sidebar_search_disabled is 1, then add some top padding
+  padding-top: calc(1rem * var(--sidebar_search_disabled));
   padding-right: 0.5rem;
   margin-right: -15px;
   margin-left: -15px;
 
   @include media-breakpoint-up(md) {
     @supports (position: sticky) {
-      max-height: calc(100vh - 10rem);
+      max-height: calc(100vh - 8.5rem + 4.5rem * var(--sidebar_search_disabled));
       overflow-y: auto;
+    }
+  }
+
+  // Handle the case where #content-mobile is displayed with a search box
+  // (regardless of the value of --sidebar_search_disabled):
+  @include media-breakpoint-only(md) {
+    padding-top: 0;
+    @supports (position: sticky) {
+      max-height: calc(100vh - 8.5rem);
     }
   }
 
@@ -22,7 +35,7 @@
       list-style: none;
     }
 
-    ul {
+    &.ul-0, ul {
       padding: 0;
       margin: 0;
     }
@@ -119,9 +132,7 @@
   }
 
   &__search {
-    padding: 1rem 15px;
-    margin-right: -15px;
-    margin-left: -15px;
+    padding: 1rem 0;
   }
 
   &__inner {
@@ -132,7 +143,7 @@
         position: sticky;
         top: 4rem;
         z-index: 10;
-        height: calc(100vh - 6rem);
+        height: calc(100vh - 5rem);
       }
     }
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -9,6 +9,7 @@
     </button>
   </form>
   {{ else -}}
+  <style>.td-sidebar-nav { --sidebar_search_disabled: 1; }</style>
   <div id="content-mobile">
   <form class="td-sidebar__search d-flex align-items-center">
     {{ partial "search-input.html" . }}

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -73,7 +73,6 @@ params:
     sidebar_menu_foldable: false
     sidebar_cache_limit: 10
     breadcrumb_disable: false
-    sidebar_search_disable: false
     feedback:
       enable: true
       'yes': >-


### PR DESCRIPTION
- Closes #1657
- Closes #1658
- Declares and uses a CSS variable (named `--sidebar_search_disabled`) to handle the variable height requirements of the `.td-sidebar-nav` depending on the `sidebar_search_disable` config setting. I thought of getting Hugo to generate some SCSS, but that got messy (and we don't do any other template processing for SCSS anyway).
- This PR fix works for all **six cases**:
  (`lg`, `md` and `sm` screens) x (each case of whether `sidebar_search_disable` is true or not)
- **Preview**: https://deploy-preview-1659--docsydocs.netlify.app/docs/adding-content/

### Screenshots

(I'll add screenshots tomorrow.)