### PR TITLE
Fix left-nav height and padding

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -2,14 +2,36 @@
 // Left side navigation
 //
 .td-sidebar-nav {
+  $_max-height: calc(100vh - 8.5rem);
+
   padding-right: 0.5rem;
   margin-right: -15px;
   margin-left: -15px;
 
   @include media-breakpoint-up(md) {
     @supports (position: sticky) {
-      max-height: calc(100vh - 10rem);
+      max-height: $_max-height;
       overflow-y: auto;
+    }
+  }
+
+  // Adjust height and padding when sidebar_search_disable is true
+  &.td-sidebar-nav--search-disabled {
+    padding-top: 1rem;
+
+    @include media-breakpoint-up(md) {
+      @supports (position: sticky) {
+        max-height: calc(#{$_max-height} + 4.5rem);
+      }
+    }
+  }
+
+  // Handle the case where #content-mobile is displayed with a search box,
+  // regardless of the value of sidebar_search_disable:
+  @include media-breakpoint-only(md) {
+    padding-top: 0 !important;
+    @supports (position: sticky) {
+      max-height: $_max-height !important;
     }
   }
 
@@ -22,7 +44,7 @@
       list-style: none;
     }
 
-    ul {
+    &.ul-0, ul {
       padding: 0;
       margin: 0;
     }
@@ -119,9 +141,7 @@
   }
 
   &__search {
-    padding: 1rem 15px;
-    margin-right: -15px;
-    margin-left: -15px;
+    padding: 1rem 0;
   }
 
   &__inner {
@@ -132,7 +152,7 @@
         position: sticky;
         top: 4rem;
         z-index: 10;
-        height: calc(100vh - 6rem);
+        height: calc(100vh - 5rem);
       }
     }
 

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -26,9 +26,9 @@
     }
   }
 
-  // Handle the case where #content-mobile is displayed with a search box,
-  // regardless of the value of sidebar_search_disable:
-  @include media-breakpoint-only(md) {
+  // Handle cases for tablet (`md`) and mobile (<= `sm`) where the search box is
+  // displayed regardless of the value of sidebar_search_disable:
+  @include media-breakpoint-down(lg) {
     padding-top: 0 !important;
     @supports (position: sticky) {
       max-height: $_max-height !important;

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -15,23 +15,18 @@
     }
   }
 
-  // Adjust height and padding when sidebar_search_disable is true
+  // Adjust height and padding when sidebar_search_disable is true, but only for
+  // >= `lg` views, because on tablet (`md`) and mobile (<= `sm`), the search
+  // box is displayed regardless of the value of sidebar_search_disable:
   &.td-sidebar-nav--search-disabled {
-    padding-top: 1rem;
+    @include media-breakpoint-up(lg) {
+      // There's no search box so add top padding
+      // and adjust max-height:
+      padding-top: 1rem;
 
-    @include media-breakpoint-up(md) {
       @supports (position: sticky) {
         max-height: calc(#{$_max-height} + 4.5rem);
       }
-    }
-  }
-
-  // Handle cases for tablet (`md`) and mobile (<= `sm`) where the search box is
-  // displayed regardless of the value of sidebar_search_disable:
-  @include media-breakpoint-down(lg) {
-    padding-top: 0 !important;
-    @supports (position: sticky) {
-      max-height: $_max-height !important;
     }
   }
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -18,7 +18,10 @@
   </div>
   <div id="content-desktop"></div>
   {{ end -}}
-  <nav class="collapse td-sidebar-nav{{ if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" id="td-section-nav">
+  <nav class="td-sidebar-nav collapse
+      {{- if .Site.Params.ui.sidebar_search_disable }} td-sidebar-nav--search-disabled{{ end -}}
+      {{- if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end -}}
+      " id="td-section-nav">
     {{ if  (gt (len .Site.Home.Translations) 0) -}}
     <div class="td-sidebar-nav__section nav-item dropdown d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}


### PR DESCRIPTION
- Closes #1657
- Closes #1658
- Supersedes #1659 by providing a solution that doesn't involve CSS variables
- Adjusts the `max-height` and top-padding of the `td-sidebar-nav` depending on
  - The value of `.Site.Params.ui.sidebar_search_disable`
  - The view width: when the view is `md`, the sidebar search is always shown, regardless of the value of `sidebar_search_disable`
- This PR fix works for all **six cases**:
  (`lg`, `md` and `sm` screens) x (each case of whether `sidebar_search_disable` is true or not)
- I've also tested with `sidebar_menu_foldable` set to true
- **Preview**: https://deploy-preview-1661--docsydocs.netlify.app/docs/adding-content/

Possible followup change to be addressed:

- #257

---

### Screenshots - `sidebar_search_disable:true`

Notes:

- `lg` and `md` screenshots were taken with Firefox
- "After" images are from my local build, where I set `sidebar_search_disable:true`

**View: `lg`** - notice the full sidenav height in the "After" image, and the top padding fix

The "Before" image is from the current production server, but with the search-box manually hidden.

| Before | After |
|--------|--------|
<img width="1016" alt="image" src="https://github.com/google/docsy/assets/4140793/eb149f20-d00a-4abb-9442-2c52ca8317a4"> | <img width="1013" alt="image" src="https://github.com/google/docsy/assets/4140793/cbb537aa-0793-4d60-abc0-96fe78a1f172">


**View: `md`** - notice the full sidenav height in the "After" image

| Before | After |
|--------|--------|
<img width="783" alt="image" src="https://github.com/google/docsy/assets/4140793/e6deeba0-fb1a-4438-8c9c-1b17cbb1ea6b"> | <img width="784" alt="image" src="https://github.com/google/docsy/assets/4140793/e91f6631-f29a-4b7a-ad01-949a546f91c9">

**View: `sm`** - no change here (other than a tweak to the bottom padding

| Before | After |
|--------|--------|
<img width="767" alt="image" src="https://github.com/google/docsy/assets/4140793/48ebd912-e61b-435a-a844-a5c6fa8c1e38"> | <img width="765" alt="image" src="https://github.com/google/docsy/assets/4140793/fe2af116-0098-4999-bd61-7e7eb6b6ab83">

---

### Screenshots - `sidebar_search_disable:false`

**View: `lg`** - notice the full sidenav height in the "After" image

| Before | After |
|--------|--------|
<img width="1009" alt="image" src="https://github.com/google/docsy/assets/4140793/ff37976c-3a72-4e7b-9115-d1e75bc0f813"> | <img width="1009" alt="image" src="https://github.com/google/docsy/assets/4140793/fea33bd8-e36e-4398-b207-5bb604118466">

**View: `md`** - notice the full sidenav height in the "After" image

| Before | After |
|--------|--------|
<img width="862" alt="image" src="https://github.com/google/docsy/assets/4140793/74ec0e5a-348b-4f6b-9e03-baef7137f3a1"> | <img width="863" alt="image" src="https://github.com/google/docsy/assets/4140793/4760541f-fd73-4463-94a6-2b8ed575e8ef">

**View: `sm`** - no change here (other than a tweak to the bottom padding

| Before | After |
|--------|--------|
<img width="765" alt="image" src="https://github.com/google/docsy/assets/4140793/9a65f419-9095-45c7-aa52-6734b841dc7d"> | <img width="765" alt="image" src="https://github.com/google/docsy/assets/4140793/04be9e1e-58ac-497e-9799-0befd57fd1a8">
