### PR TITLE
Params to toggle UI visibility of Git meta links

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -6,6 +6,12 @@ params:
   time_format_blog: Monday, January 02, 2006
   time_format_default: January 2, 2006
   rss_sections: [blog]
+  ui:
+    enable_meta_link_git_remote_view_page: true
+    enable_meta_link_git_remote_edit_page: true
+    enable_meta_link_git_remote_create_child_page: true
+    enable_meta_link_git_remote_create_doc_issue: true
+    enable_meta_link_git_remote_create_project_issue: true
 
 outputFormats:
   PRINT:

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -37,13 +37,23 @@
   {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
   {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}
 
+  {{ if (.Site.Params.ui.enable_meta_link_git_remote_view_page) -}}
   <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
+  {{ end -}}
+  {{ if (.Site.Params.ui.enable_meta_link_git_remote_edit_page) -}}
   <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+  {{ end -}}
+  {{ if (.Site.Params.ui.enable_meta_link_git_remote_create_child_page) -}}
   <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
+  {{ end -}}
+  {{ if (.Site.Params.ui.enable_meta_link_git_remote_create_doc_issue) -}}
   <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
-  {{ with $gh_project_repo -}}
-    {{ $project_issueURL := printf "%s/issues/new" . -}}
-    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+  {{ if (.Site.Params.ui.enable_meta_link_git_remote_create_project_issue) -}}
+    {{ with $gh_project_repo -}}
+      {{ $project_issueURL := printf "%s/issues/new" . -}}
+      <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+    {{ end -}}
   {{ end -}}
 
 {{ end -}}


### PR DESCRIPTION
First of all I just want to say I'm loving the work being done here!

This PR is to introduce new params to toggle the visibility of the Git meta links (view/edit page source, create child page/issues).

From:
![image](https://github.com/google/docsy/assets/32237469/7ea40ae0-868b-4e5b-a586-97955c7922ff)

To: (if all the params are disabled)
![image](https://github.com/google/docsy/assets/32237469/f4975807-746d-42d7-a451-7100117aa82f)

Went ahead with `"git_remote"` to remain generic, as opposed to some params with `"github"` or `"gh"` names.

Let me know what you think. Cheers!