### PR TITLE
Tabbed panes: fix styling when not at top-level & other tweaks

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -1,16 +1,12 @@
-.tab-content {
-  .tab-pane {
-    pre {
-      margin: 0rem 0 0rem 0;
-    }
-  }
+// Only constrain max-width for top-level tabbed panes not, e.g., those in lists.
+.td-content > .tab-content .tab-pane {
+  @extend .td-max-width-on-larger-screens;
 }
 
 .tab-content {
   .tab-pane {
-    @extend .td-max-width-on-larger-screens;
     .highlight {
-      margin: 0rem 0 0rem 0;
+      margin: 0;
       border: none;
       max-width: 100%;
     }
@@ -28,6 +24,15 @@
   color: inherit;
   border-radius: 0;
   padding: 1.5rem;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  > .highlight:only-child {
+    margin: -1.5rem;
+    max-width: calc(100% + 3rem);
+  }
 
   @each $color, $value in $theme-colors {
     &-#{$color} {


### PR DESCRIPTION
Closes

- #1660

Compare tabbed panes inside an ordered list:

- Before: https://www.docsy.dev/docs/adding-content/search/#adding-the-search-page
- After: https://deploy-preview-1671--docsydocs.netlify.app/docs/adding-content/search/#adding-the-search-page

---

### Remove bottom margin for last element in tab

Compare the "Tabbed panes" sections, the "Languages" tabbed pane:

- Before: https://www.docsy.dev/docs/adding-content/shortcodes/#tabbed-panes
- After: https://deploy-preview-1671--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes