### PR TITLE
Algolia search, fix: point js + css file to specific version

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -58,8 +58,8 @@
 {{ define "algolia/head" -}}
 
 {{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"
-  integrity="sha512-O6ywtjtiV4QGgC6cD75C2Tf04SlTn9vvka8oV/dYpDL1JWM4lVP0QoZbdZt5RLtOWDpaP+MObzUrwl43ssqfvg=="
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.5.2"
+  integrity="sha512-TW5eKlwwg7OfQUVBqxjp94/uqtjJJbhkRE3++XGEQjAL1n3y//QVqS3acPkwqkzInaFRtj+w05uyxDbfDXiI1A=="
   crossorigin="anonymous" />
 {{ end -}}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -108,8 +108,8 @@ window.markmap = {
 {{ partial "hooks/body-end.html" . -}}
 
 {{ define "algolia/scripts" -}}
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"
-  integrity="sha512-sQFwlNnBlEyWdI4EwJ9d2wjViu0ZPmIMjPP8kCmBoOjqcljGndf2gb4mldT4ZHxKCQcrdJ0+rxnMFKHuGWB7ag=="
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.5.2"
+  integrity="sha512-LzxWPDNELae1RSIsDRSitKYPJpRtjYo22GbOl+d+xLcjKiZQRRdxSTI3cRRHw7O05e0MbIIu33QnU2rt6ymQ6A=="
   crossorigin="anonymous" ></script>
 <script type="text/javascript">
 const containers = ['#docsearch-0', '#docsearch-1'];


### PR DESCRIPTION
Currently js + css file for algolia docsearch are pulled in via these URLs:

* https://cdn.jsdelivr.net/npm/@docsearch/css@3
* https://cdn.jsdelivr.net/npm/@docsearch/js@3

When pulling in these files, they are checked via a SRI hash. In both cases, SRI hashes are given for version 3.5.1. However, meanwhile @docsearch npm is at version 3.5.2. This means, that given SRI hashes are invalid now, algolia docsearch does not work and more.

This PR fixes this by pulling in specific version `3.5.2`.