### PR TITLE
Make links underlined by default

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -50,12 +50,24 @@
 
       &:hover {
         color: $blue;
-        text-decoration: none;
       }
     }
   }
 
   ul {
     padding-left: 0;
+  }
+}
+
+.td-page-meta,
+.td-sidebar-toc,
+.td-toc {
+  a {
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
   }
 }

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -63,6 +63,7 @@
 
     a {
       color: $gray-900;
+      text-decoration: none;
     }
   }
 
@@ -79,7 +80,7 @@
   a {
     &:hover {
       color: $blue;
-      text-decoration: none;
+      text-decoration: underline;
     }
 
     &.active {

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -78,7 +78,8 @@
   }
 
   a {
-    &:hover {
+    &:hover,
+    &:focus {
       color: $blue;
       text-decoration: underline;
     }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -35,7 +35,7 @@ $td-box-colors: $dark, $primary, $secondary, $info, $white, $gray-600, $success,
   $warning, $dark, $danger, $primary, $secondary, $info !default;
 
 $link-color: $blue-500 !default;
-$link-decoration: none !default;
+$link-decoration: underline !default;
 $link-shade-percentage: 30% !default;
 
 // Fonts


### PR DESCRIPTION
As per the change upstream in Bootstrap 5 https://github.com/twbs/bootstrap/pull/30389

Removing the underline from links was in vogue for a while, but WebAIM [recommends not doing that](https://webaim.org/techniques/hypertext/link_text#underlining).

> Browsers underline hypertext links by default. It is possible to remove the underline using Cascading Style Sheets (CSS), but this is a bad idea most of the time. 