### PR TITLE
Blocks cover nooverlay

### DIFF
--- a/layouts/shortcodes/blocks/cover.html
+++ b/layouts/shortcodes/blocks/cover.html
@@ -7,6 +7,7 @@
 {{ $logo_anchor := .Get "logo_anchor" | default "smart" -}}
 {{/* Height can be one of: auto, min, med, max, full. */ -}}
 {{ $height := .Get "height" | default "max" -}}
+{{ $disable_overlay := .Get "disable_overlay" | default false }}
 
 {{ with $promo_image -}}
 {{ $promo_image_big := (.Fill (printf "1920x1080 %s" $image_anchor)) -}}
@@ -27,7 +28,7 @@
 
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
   {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
-  {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
+  {{- end }} {{ if not $disable_overlay }} td-overlay td-overlay--dark {{ end }} -bg-{{ $col_id }}">
   <div class="col-12">
     <div class="container td-overlay__inner">
       <div class="text-center">

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -61,7 +61,7 @@ Note that the relevant shortcode parameters above will have sensible defaults, b
 | image_anchor | |
 | height | | See above.
 | color | | See above.
-| byline | Byline text on featured image. |
+| byline | | Byline text on featured image. |
 | disable_overlay | false |By default, Docsy adds an overlay to the hero image. Use `disable_overlay=true` to avoid that.|
 
 To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en), in the same directory.

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -62,7 +62,7 @@ Note that the relevant shortcode parameters above will have sensible defaults, b
 | height | | See above.
 | color | | See above.
 | byline | Byline text on featured image. |
-
+| disable_overlay | false |By default, Docsy adds an overlay to the hero image. Use `disable_overlay=true` to avoid that.|
 
 To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en), in the same directory.
 


### PR DESCRIPTION
It seems that the blocks/cover shortcode automatically adds an overlay to the hero section, which changes the colors when using a background image. This PR adds an option to the shortcode to disable the overlay. It keeps the overlay by default to retain the way docsy worked originally.