### PR TITLE
Change breadcrumb and print links to RelPermalink

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -23,7 +23,7 @@
     {{ if $isActive -}}
       {{ .p1.LinkTitle -}}
     {{ else -}}
-      <a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
+      <a href="{{ .p1.RelPermalink }}">{{ .p1.LinkTitle }}</a>
     {{- end -}}
   </li>
 {{- end -}}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -48,7 +48,7 @@
 
 {{ end -}}
 {{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
-  <a id="print" href="{{ .Permalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+  <a id="print" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
 {{ end }}
 </div>
 {{ end -}}


### PR DESCRIPTION
The breadcrumb links and the print metalink used Permalink instead of RelPermalink, causing them to always link to the full domain referenced in the baseurl of the build. Using relpermalink makes these links work without referencing the baseurl, so they work even in dev environments (for example, when the site is deployed in a local docker container).

---

**Preview**, e.g.: https://deploy-preview-1699--docsydocs.netlify.app/docs/get-started/docsy-as-module/