### PR TITLE
Upgrade Hugo to 0.120.3, and Node engine constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "bootstrap": "5.2.3"
   },
   "devDependencies": {
-    "hugo-extended": "0.115.1"
+    "hugo-extended": "0.120.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
- Contributes to #1666
- Upgrades Hugo to 0.120.3
- Updates min Node version to be currently active Node LTS version (20.x)

The only change in generated files (other than the Hugo version) is the Shortcodes page:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.1" -- . ':(exclude)*.xml') | grep ^diff | grep -v print
diff --git a/docs/adding-content/shortcodes/index.html b/docs/adding-content/shortcodes/index.html
```

And the only difference is in syntax highlighting of Java:

### Before

> <img width="689" alt="Screen Shot 2023-11-03 at 18 03 16" src="https://github.com/google/docsy/assets/4140793/f2793faf-db9f-475f-a4d8-2ac76c19e591">

### After

> <img width="680" alt="Screen Shot 2023-11-03 at 18 03 23" src="https://github.com/google/docsy/assets/4140793/3a28ed7a-bac7-4ca5-8689-2afe9e2620ca">
