### PR TITLE
Recover RSS round-button style

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -4,6 +4,7 @@
     @extend .btn-info;
     @extend .btn-lg;
 
+    border-radius: 2rem;
     float: right;
 
     display: none;


### PR DESCRIPTION
- Contributes to #1666
- Recovers the round-button style of the RSS button, post-#1656 changes.

### Before

> <img width="996" alt="image" src="https://github.com/google/docsy/assets/4140793/472753c0-c145-445d-abbd-287e9d7ce9f2">

### After

> <img width="996" alt="image" src="https://github.com/google/docsy/assets/4140793/4de8cc43-2e9f-4588-8488-cb6a4e5c49f2">