### PR TITLE
Upgrade to Hugo 0.120.4, which include security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bootstrap": "5.2.3"
   },
   "devDependencies": {
-    "hugo-extended": "0.120.3"
+    "hugo-extended": "0.120.4"
   },
   "optionalDependencies": {
     "markdown-link-check": "^3.11.2",


### PR DESCRIPTION
No change in generated UG files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "Hugo 0.1") 
$
```