### PR TITLE
[GA4] Emit `page_helpful` events for page feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ For the full list of changes, see the [release][0.8.0] notes.
 
 **Breaking changes**:
 
-- **Page feedback**, or [User feedback] ([#1726]):
-  - Feedback-event attribute changes:
+- **Page feedback**, or [User feedback]:
+  - In support of projects configuring analytics outside of Docsy, feedback
+    functionality is enabled regardless of whether
+    `site.Config.Services.GoogleAnalytics.ID` is set ([#1727]).
+  - Feedback-event attribute changes ([#1726]):
     - Event `name` is `page_helpful`rather than`click`
     - Event `value` for "yes" is 100 by default, rather than 1, allowing for
       more response options in the future. To override the default set
@@ -33,10 +36,6 @@ For the full list of changes, see the [release][0.8.0] notes.
 - SCSS: `@function prepend()` and file `assets/scss/support/_functions.scss`
   have been dropped. Instead use the more general SASS/SCSS list `join()`
   function ([#1385]).
-- **Page feedback**, or [User feedback]: in support of projects configuring
-  analytics outside of Docsy, feedback functionality will be enabled regardless
-  of whether `site.Config.Services.GoogleAnalytics.ID` is set.
-  - TBC
 
 **New**:
 
@@ -44,6 +43,7 @@ For the full list of changes, see the [release][0.8.0] notes.
 
 [#1385]: https://github.com/google/docsy/issues/1385
 [#1726]: https://github.com/google/docsy/pull/1726
+[#1727]: https://github.com/google/docsy/pull/1727
 [0.8.0]: https://github.com/google/docsy/releases/v0.8.0/#FIXME
 [User feedback]:
   https://www.docsy.dev/docs/adding-content/feedback/#user-feedback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ For the full list of changes, see the [release][0.8.0] notes.
 
 **Breaking changes**:
 
+- **Page feedback**, or [User feedback] ([#1726]):
+  - Feedback-event attribute changes:
+    - Event `name` is `page_helpful`rather than`click`
+    - Event `value` for "yes" is 100 by default, rather than 1, allowing for
+      more response options in the future. To override the default set
+      `params.ui.feedback.max_value`.
 - SCSS: `@function prepend()` and file `assets/scss/support/_functions.scss`
   have been dropped. Instead use the more general SASS/SCSS list `join()`
   function ([#1385]).
@@ -37,6 +43,7 @@ For the full list of changes, see the [release][0.8.0] notes.
 **Other changes**:
 
 [#1385]: https://github.com/google/docsy/issues/1385
+[#1726]: https://github.com/google/docsy/pull/1726
 [0.8.0]: https://github.com/google/docsy/releases/v0.8.0/#FIXME
 [User feedback]:
   https://www.docsy.dev/docs/adding-content/feedback/#user-feedback

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -47,7 +47,8 @@
   yesButton.addEventListener('click', () => {
     yesResponse.classList.add('feedback--response__visible');
     disableButtons();
-    sendFeedback(1);
+    {{ $maxValue := .max_value | default 100 -}}
+    sendFeedback({{ $maxValue }});
   });
   noButton.addEventListener('click', () => {
     noResponse.classList.add('feedback--response__visible');

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -37,16 +37,12 @@
     noButton.disabled = true;
   };
   const sendFeedback = (value) => {
-    if (typeof ga !== 'function') return;
-    const args = {
-      command: 'send',
-      hitType: 'event',
-      category: 'Helpful',
-      action: 'click',
-      label: window.location.pathname,
-      value: value
-    };
-    ga(args.command, args.hitType, args.category, args.action, args.label, args.value);
+    if (typeof gtag !== 'function') return;
+    gtag('event', 'page_helpful', {
+      'event_category': 'Helpful',
+      'event_label': window.location.pathname,
+      'value': value
+    });
   };
   yesButton.addEventListener('click', () => {
     yesResponse.classList.add('feedback--response__visible');

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -94,7 +94,7 @@ of every documentation page, as shown in Figure 1.
 </figure>
 
 After clicking **Yes** the user should see a response like Figure 2. You can
-[configure] the response text in the project's [configuration file] `hugo.toml`.
+[configure] the response text in your project's [configuration file].
 
 <figure>
   <img src="/images/yes.png"
@@ -184,6 +184,10 @@ params:
 {{< /tabpane >}}
 
 3.  Save the edits to your configuration file.
+
+By default, Docsy emits an event value of 100 when a user clicks "yes". You can
+change this value by setting `params.ui.feedback.max_value` to a positive
+integer. Docsy uses 0 for "no" events.
 
 ### Access the feedback data
 


### PR DESCRIPTION
- Contributes to #1667
- Contributes to #1302
- Switches to emitting a `page_helpful` rather than a `click` event when the page feedback button is clicked. This makes it easier to view page feedback in the GA4 analytics console. FYI, the code in this PR has been used and vetted as part of the falco.org website, see https://github.com/falcosecurity/falco-website/issues/974.
- Adds support for a configurable `max_value` emitted for "yes" events, whose default value is now 100
- Updates the docs to mention the new configuration parameter.
- Adds changelog entry

**Preview**, e.g.: https://deploy-preview-1726--docsydocs.netlify.app/docs/adding-content/feedback/#search-engine-optimization-meta-tags -- navigate to the end of the page to see the feedback form