### PR TITLE
Enable page feedback even without a Google analytics ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ For the full list of changes, see the [release][0.8.0] notes.
 - SCSS: `@function prepend()` and file `assets/scss/support/_functions.scss`
   have been dropped. Instead use the more general SASS/SCSS list `join()`
   function ([#1385]).
+- **Page feedback**, or [User feedback]: in support of projects configuring
+  analytics outside of Docsy, feedback functionality will be enabled regardless
+  of whether `site.Config.Services.GoogleAnalytics.ID` is set.
+  - TBC
 
 **New**:
 
@@ -34,6 +38,8 @@ For the full list of changes, see the [release][0.8.0] notes.
 
 [#1385]: https://github.com/google/docsy/issues/1385
 [0.8.0]: https://github.com/google/docsy/releases/v0.8.0/#FIXME
+[User feedback]:
+  https://www.docsy.dev/docs/adding-content/feedback/#user-feedback
 
 ## 0.7.2
 

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -8,10 +8,7 @@
 		{{ end -}}
 	</header>
 	{{ .Content }}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback }}
-		<br />
-	{{ end -}}
+	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Params.DisqusShortname) -}}
 		<br />
 		{{- partial "disqus-comment.html" . -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -10,10 +10,7 @@
 	</header>
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
-		<br />
-	{{ end -}}
+	{{ partial "feedback.html" . -}}
 	{{ if (.Site.DisqusShortname) -}}
 		<br />
 		{{- partial "disqus-comment.html" . -}}

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -1,3 +1,5 @@
+{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable)) -}}
+{{ with .Site.Params.ui.feedback -}}
 <style>
   .feedback--answer {
     display: inline-block;
@@ -57,3 +59,6 @@
     sendFeedback(0);
   });
 </script>
+{{ end -}}
+<br />
+{{ end -}}

--- a/layouts/swagger/list.html
+++ b/layouts/swagger/list.html
@@ -10,10 +10,7 @@
 	</header>
 	{{ .Content }}
   {{ partial "section-index.html" . -}}
-	{{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) -}}
-		{{ partial "feedback.html" .Site.Params.ui.feedback -}}
-		<br />
-	{{ end -}}
+	{{ partial "feedback.html" . -}}
 	{{ if (.Site.DisqusShortname) -}}
 		<br />
 		{{ partial "disqus-comment.html" . -}}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
     "postinstall": "npm run _mkdir:hugo-mod && npm run _cp:bs-rfs",
     "serve": "npm run cd:docs serve",
-    "test": "npm run cd:docs test",
+    "test": "npm run cd:docs test && npm run check:links--md",
     "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest",
     "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest"
   },

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -132,9 +132,18 @@ other words!
 
 ### Setup
 
-1.  Open `hugo.toml`/`hugo.yaml`/`hugo.json`.
-2.  Ensure that Google Analytics is enabled, as described [above](#setup).
-3.  Set the response text that users see after clicking **Yes** or **No**.
+{{% alert title="Version note" color=warning %}}
+
+As of Docsy version [0.8.0], feedback will be enabled whether
+`site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
+case where analytics is configured outside of Docsy.
+
+[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
+
+{{% /alert %}}
+
+1.  Open your project's Hugo configuration file.
+2.  Set the response text that users see after clicking **Yes** or **No**.
 
     {{< tabpane >}}
     {{< tab header="Configuration file:" disabled=true />}}
@@ -174,7 +183,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-4.  Save and close `hugo.toml`/`hugo.yaml`/`hugo.json`.
+3.  Save the edits to your configuration file.
 
 ### Access the feedback data
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -30,7 +30,7 @@ menu:
 
 services:
   googleAnalytics:
-    id: UA-00000000-0
+    # id: G-XXXXXXXXX
 
 languages:
   en:

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -30,7 +30,7 @@ menu:
 
 services:
   googleAnalytics:
-    # id: G-XXXXXXXXX
+    # id: G-XXXXXXXXX # Waiting on https://github.com/google/docsy/issues/1097
 
 languages:
   en:


### PR DESCRIPTION
- Contributes to #1667
- Contributes to #1302
- Fixes #1311
- Refactors the `feedback.html` partial and its point of use so that testing whether the feature is enabled happens inside the partial
- Adds an entry to the ChangeLog
- Updates the Feedback section of the docs, and adds a version note.

**Preview**, e.g.: https://deploy-preview-1727--docsydocs.netlify.app/docs/adding-content/feedback/#setup-1 -- navigate to the end of the page to see the feedback form

There are no non-whitespace changes to the generated user guide except for the changes made to the User Feedback section:

```console
$ (cd public && git diff -bw --ignore-blank-lines -- . ':(exclude)*/_print/*' ':(exclude)*.xml') | grep ^diff
diff --git a/docs/adding-content/feedback/index.html b/docs/adding-content/feedback/index.html
```

 