### PR TITLE
User guide: use docsy as module (in workspace)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "_cd:docs": "cd userguide &&",
     "_check:format": "npx prettier --check .??* *.md",
-    "_mkdir:hugo-mod": "npx mkdirp ../github.com/FortAwesome/Font-Awesome ../github.com/twbs/bootstrap",
     "_cp:bs-rfs": "cp -R node_modules/bootstrap/scss/vendor/* assets/_vendor/bootstrap/scss/",
     "build:preview": "npm run cd:docs build:preview",
     "build:production": "npm run cd:docs build:production",
@@ -21,7 +20,7 @@
     "fix:format": "npm run _check:format -- --write",
     "get:hugo-modules": "node tools/getHugoModules/index.mjs",
     "get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
-    "postinstall": "npm run _mkdir:hugo-mod && npm run _cp:bs-rfs",
+    "postinstall": "npm run _cp:bs-rfs",
     "serve": "npm run cd:docs serve",
     "test": "npm run cd:docs test",
     "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest",
@@ -35,7 +34,6 @@
   "devDependencies": {
     "hugo-extended": "0.120.4",
     "markdown-link-check": "^3.11.2",
-    "mkdirp": "^3.0.1",
     "prettier": "^3.0.3"
   },
   "engines": {

--- a/userguide/content/en/docs/contribution-guidelines/_index.md
+++ b/userguide/content/en/docs/contribution-guidelines/_index.md
@@ -86,11 +86,10 @@ If you want to run your own local Hugo server to preview your changes as you wor
     ```
 
 1. Change to the `userguide` directory and run the following Hugo command to build the site and start the Hugo server.
-   Note that you need the `themesDir` flag because the site files are inside the theme repo.
 
     ```sh
     cd userguide
-    hugo server --themesDir ../..
+    hugo server
     ```
 
     By default your site will be available at http://localhost:1313/. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.

--- a/userguide/docsy.work
+++ b/userguide/docsy.work
@@ -1,0 +1,4 @@
+go 1.19
+
+use .    // folder userguide
+use ..   // folder docsy (theme sources)

--- a/userguide/docsy.work.sum
+++ b/userguide/docsy.work.sum
@@ -1,0 +1,1 @@
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=

--- a/userguide/go.mod
+++ b/userguide/go.mod
@@ -1,0 +1,5 @@
+module github.com/google/docsy/userguide
+
+go 1.12
+
+require github.com/google/docsy v0.7.2 // indirect

--- a/userguide/go.sum
+++ b/userguide/go.sum
@@ -1,0 +1,7 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.7.2 h1:KzhFgTd3taF1jq9HDemH3omlUqn9qfdE68sxRyTySpM=
+github.com/google/docsy v0.7.2/go.mod h1:ol3w2s1FBUzENdKSAEeNjtuaISUzHYHTw60xv5QH3Dg=
+github.com/google/docsy v0.7.3-0.20231111150834-c36c727b8beb h1:iqazo50LwAWKpKiAao0VzqoM3qVmlNJVSBIW6POE/is=
+github.com/google/docsy v0.7.3-0.20231111150834-c36c727b8beb/go.mod h1:AA0RAVm0Tr5nEC4PX68MoE7RjC8mTcvw4zIrelP1BnA=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -2,7 +2,6 @@ baseURL: /
 title: &title Docsy
 description: &desc Docsy does docs
 enableRobotsTXT: true
-theme: [docsy]
 enableGitInfo: true
 
 pygmentsCodeFences: true
@@ -127,6 +126,11 @@ taxonomies:
   category: categories
 
 module:
+  # Comment the next line to build for latest officially released version:
+  workspace: docsy.work
+  imports:
+    - path: github.com/google/docsy
+      disable: false
   mounts:
     - source: content/en
       target: content


### PR DESCRIPTION
After having #1217 merged, the user guide cannot built successfully using `hugo --themesDir ../..` any more. This PR fixes this by pulling in docsy as a hugo module when building or previewing the user guide. In the module definition inside `userguide/hugo.yaml`, there is a workspace definition in place so that docsy is pulled in from the local docsy sources in the repo root level). Previewing the user guide is now as easy as:

```
cd userguide
hugo server
```
