### PR TITLE
Fall back to Hugo's default behavior for disableHugoGeneratorInject

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,5 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{ hugo.Generator }}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}


### PR DESCRIPTION
- Fixes #1707 
  That is, without this PR we get the `generator` meta tag in **every page**:
  ```console
  $ find userguide/public/* -type f -name "*.html" -exec grep -nH -e 'name="generator"' {} +
  userguide/public/404.html:6:<meta name="generator" content="Hugo 0.120.4">
  userguide/public/about/index.html:6:<meta name="generator" content="Hugo 0.120.4">
  userguide/public/blog/2022/hello/index.html:6:<meta name="generator" content="Hugo 0.120.4">
  ...
  ```
- With this fix, with or without disableHugoGeneratorInject set to true, we get the Hugo-default behavior of at most adding the meta tag to the homepage:
  ```console
  $ npm run build 
  $ find userguide/public/* -type f -name "*.html" -exec grep -nH -e 'name="generator"' {} +
  userguide/public/index.html:4:  <meta name="generator" content="Hugo 0.120.4">
  $ HUGO_DISABLEHUGOGENERATORINJECT=true npm run build                                                
  $ find userguide/public/* -type f -name "*.html" -exec grep -nH -e 'name="generator"' {} +
  $ 
  ```
