### PR TITLE
Properly set baseURL for the User Guide

### DIFF
--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: /
+baseURL: https://www.docsy.dev/
 title: &title Docsy
 description: &desc Docsy does docs
 enableRobotsTXT: true


### PR DESCRIPTION
- Fixes the User-guide Hugo-config param `baseURL`, setting it to the full site URL, as recommended by Hugo folks; see https://discourse.gohugo.io/t/permalink-not-permalinking/42613.
- In preparation for https://github.com/google/docsy/issues/1337#issuecomment-1808180217