### PR TITLE
NPM dependencies: fix dep install timing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "_cd:docs": "cd userguide &&",
     "_check:format": "npx prettier --check .??* *.md",
-    "_mkdir:hugo-mod": "npx mkdirp ../github.com/FortAwesome/Font-Awesome ../github.com/twbs/bootstrap",
     "_cp:bs-rfs": "cp -R node_modules/bootstrap/scss/vendor/* assets/_vendor/bootstrap/scss/",
+    "_mkdir:hugo-mod": "npx mkdirp ../github.com/FortAwesome/Font-Awesome ../github.com/twbs/bootstrap",
+    "_prebuild": "npm run _cp:bs-rfs",
     "build:preview": "npm run cd:docs build:preview",
     "build:production": "npm run cd:docs build:production",
     "build": "npm run cd:docs build",
@@ -21,11 +22,14 @@
     "fix:format": "npm run _check:format -- --write",
     "get:hugo-modules": "node tools/getHugoModules/index.mjs",
     "get:submodule": "set -x && git submodule update --init ${DEPTH:- --depth 1}",
-    "postinstall": "npm run _mkdir:hugo-mod && npm run _cp:bs-rfs",
+    "postinstall": "npm run _mkdir:hugo-mod",
+    "prebuild:preview": "npm run _prebuild",
+    "prebuild:production": "npm run _prebuild",
+    "prepare": "npm run _cp:bs-rfs",
     "serve": "npm run cd:docs serve",
     "test": "npm run cd:docs test && npm run check:links--md",
-    "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest",
-    "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest"
+    "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
+    "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest"
   },
   "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome userguide ",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "prebuild:preview": "npm run _prebuild",
     "prebuild:production": "npm run _prebuild",
     "prepare": "npm run _cp:bs-rfs",
+    "preserve": "npm run _prebuild",
+    "pretest": "npm run _prebuild",
     "serve": "npm run cd:docs serve",
     "test": "npm run cd:docs test && npm run check:links--md",
     "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",


### PR DESCRIPTION
- Followup to:
  - #1217
  - #1733
  - The latter broke Docsy NPM installs
- Fixes install timing issue of Docsy dependencies: we can't copy over the bootstrap (BS) vendor files from the BS NPM package until it is installed 🤷🏼‍♂️. This PR delegates the copying of vendor files to the `prepare` step.
