### PR TITLE
Page feedback & GA4 docs adjustments

### DIFF
--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -191,41 +191,31 @@ integer. Docsy uses 0 for "no" events.
 
 ### Access the feedback data
 
+Page feedback is reported to Google Analytics through [events].
+
+{{% alert title="Version note" color=warning %}}
+
+As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful` events,
+rather than `click` events.
+
+[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
+
+{{% /alert %}}
+
 This section assumes basic familiarity with Google Analytics. For example, you
 should know how to check pageviews over a certain time range and navigate
 between accounts if you have access to multiple documentation sites.
 
 1. Open Google Analytics.
-2. Open **Behavior** > **Events** > **Overview**.
-3. In the **Event Category** table click the **Helpful** row. Click **view full
-   report** if you don't see the **Helpful** row.
-4. Click **Event Label**. You now have a page-by-page breakdown of ratings.
+2. Open **Reports** > **Engagement** > **Events**.
+3. Click **page_helpful** in the events table. If there is no `page_helpful`
+   event, then none have been registered for the selected period. Adjust the
+   period as necessary.
 
-Here's what the 4 columns represent:
+Note that you might be required to create a custom report if you'd like better
+visualize individual data points (per page) along with average values.
 
-- **Total Events** is the total number of times that users clicked _either_
-  **Yes** or **No**.
-- **Unique Events** provides a rough indication of how frequently users are
-  rating your pages per session. For example, suppose your **Total Events** is
-  5000, and **Unique Events** is 2500. This means that you have 2500 users who
-  are rating 2 pages per session.
-- **Event Value** isn't that useful.
-- **Avg. Value** is the aggregated rating for that page. The value is always
-  between 0 and 1. When users click **No** a value of 0 is sent to Google
-  Analytics. When users click **Yes** a value of 1 is sent. You can think of it
-  as a percentage. If a page has an **Avg. Value** of 0.67, it means that 67% of
-  users clicked **Yes** and 33% clicked **No**.
-
-[events]:
-  https://developers.google.com/analytics/devguides/collection/analyticsjs/events
-[pr]: https://github.com/google/docsy/pull/1/files
-
-The underlying Google Analytics infrastructure that stores the "was this page
-helpful?" data is called [Events][events]. See [docsy pull request #1][pr] to
-see exactly what happens when a user clicks **Yes** or **No**. It's just a
-`click` event listener that fires the Google Analytics JavaScript function for
-logging an Event, disables the **Yes** and **No** buttons, and shows the
-response text.
+[events]: https://support.google.com/analytics/answer/9322688
 
 ### Disable feedback on a single page
 


### PR DESCRIPTION
- Contributes to
  - #1096
  - #1302
- Updates the "Access the feedback data" section so that
  - It reflects GA4 i/f
  - Directs the reader to select the right event named `page_helpful`

**Preview**: https://deploy-preview-1742--docsydocs.netlify.app/docs/adding-content/feedback/#access-the-feedback-data