### PR TITLE
Added docs.layer5.io on Docsy theme examples

### DIFF
--- a/userguide/content/en/docs/examples/_index.md
+++ b/userguide/content/en/docs/examples/_index.md
@@ -32,6 +32,7 @@ Example sites that have low to no customization:
 | [CloudWeGo](https://www.cloudwego.io/) | https://github.com/cloudwego/cloudwego.github.io |
 | [etcd](https://etcd.io/) | https://github.com/etcd-io/website |
 | [protobuf.dev](https://protobuf.dev) | https://github.com/protocolbuffers/protocolbuffers.github.io |
+| [Layer5 Docs](https://docs.layer5.io/) | https://github.com/layer5io/docs |
 
 ## Customized Docsy examples
 


### PR DESCRIPTION
Layer5 Docs - https://www.docs.layer5.io/

---

https://deploy-preview-1752--docsydocs.netlify.app/docs/examples/