### PR TITLE
css: fix an issue on `.highlight pre` border radius

### DIFF
--- a/assets/scss/_code.scss
+++ b/assets/scss/_code.scss
@@ -17,6 +17,7 @@
     pre {
       margin: 0;
       padding: 1rem;
+      border-radius: inherit;
 
       // Default click-to-copy button
 


### PR DESCRIPTION
Class .td-content.highlight has a border radius of 6px but .td-content.highlight pre had a border radius of 0. This fixes the visual discomfort of seing a square on a rounded border on codeblocks.

Notice the corners of codeblock, this thing has been annoying me for ages, notably on https://kubernetes.io and all the other websites using Docsy.

Before: 
<img width="547" alt="image" src="https://github.com/google/docsy/assets/11256051/07c85360-485e-47b2-97f7-bb30ed24145f">

After:
<img width="541" alt="image" src="https://github.com/google/docsy/assets/11256051/06d99471-4622-4fac-84a0-4c1b4ddc6492">
