### PR TITLE
Typo in polish translation

### DIFF
--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -12,7 +12,7 @@ other = "Dalej"
 other = "Zobacz więcej"
 
 [ui_search]
-other = "Szukaj ns stronie ..."
+other = "Szukaj na stronie ..."
 
 # Used in sentences such as "Posted in News"
 [ui_in]


### PR DESCRIPTION
There is no word like "ns". It should be "na".