### PR TITLE
 Add params to offlineSearch examples 

### DIFF
--- a/userguide/content/en/docs/adding-content/search.md
+++ b/userguide/content/en/docs/adding-content/search.md
@@ -199,19 +199,23 @@ To add Lunr search to your Docsy site:
     {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
+[params]
 offlineSearch = true
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
-offlineSearch: true
+params:
+  offlineSearch: true
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
-  "offlineSearch": true
+  "params": {
+    "offlineSearch": true
+  }
 }
 {{< /tab >}}
     {{< /tabpane >}}
 
-2. Remove or comment out any GCSE ID in `hugo.toml`/`hugo.yaml`/`hugo.json` and ensure Algolia DocSearch is set to `false`, as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
+3. Remove or comment out any GCSE ID in `hugo.toml`/`hugo.yaml`/`hugo.json` and ensure Algolia DocSearch is set to `false`, as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
 
 Once you've completed these steps, local search is enabled for your site and results appear in a drop down when you use the search box.
 

--- a/userguide/content/en/docs/adding-content/search.md
+++ b/userguide/content/en/docs/adding-content/search.md
@@ -231,17 +231,21 @@ You can customize the summary length by setting `offlineSearchSummaryLength` in 
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 #Enable offline search with Lunr.js
+[params]
 offlineSearch = true
 offlineSearchSummaryLength = 200
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
-offlineSearch: true
-offlineSearchSummaryLength: 200
+params:
+  offlineSearch: true
+  offlineSearchSummaryLength: 200
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
-  "offlineSearch": true,
-  "offlineSearchSummaryLength": 200
+  "params": {
+    "offlineSearch": true,
+    "offlineSearchSummaryLength": 200
+  }
 }
 {{< /tab >}}
 {{< /tabpane >}}
@@ -253,17 +257,21 @@ You can customize the maximum result count by setting `offlineSearchMaxResults` 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
+[params]
 offlineSearch = true
 offlineSearchMaxResults = 25
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
-offlineSearch: true
-offlineSearchMaxResults: 25
+params:
+  offlineSearch: true
+  offlineSearchMaxResults: 25
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
-  "offlineSearch": true,
-  "offlineSearchMaxResults": 25
+  "params": {
+    "offlineSearch": true,
+    "offlineSearchMaxResults": 25
+  }
 }
 {{< /tab >}}
 {{< /tabpane >}}

--- a/userguide/content/en/docs/adding-content/search.md
+++ b/userguide/content/en/docs/adding-content/search.md
@@ -215,7 +215,7 @@ params:
 {{< /tab >}}
     {{< /tabpane >}}
 
-3. Remove or comment out any GCSE ID in `hugo.toml`/`hugo.yaml`/`hugo.json` and ensure Algolia DocSearch is set to `false`, as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
+2. Remove or comment out any GCSE ID in `hugo.toml`/`hugo.yaml`/`hugo.json` and ensure Algolia DocSearch is set to `false`, as you can only have one type of search enabled. See [Disabling GCSE search](#disabling-gcse-search).
 
 Once you've completed these steps, local search is enabled for your site and results appear in a drop down when you use the search box.
 


### PR DESCRIPTION
While trying out the offline search feature I struggled to get it working until I figured out that the `offlineSearch` should be within `params`.