### PR TITLE
[CI] Run npm test scripts under Linux and Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,3 +1,6 @@
+# Smoke test across OSs: build a Docsy-based site from scratch, fetching Docsy
+# via NPM.
+
 name: smoke
 
 on:

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -2,10 +2,10 @@ name: smoke
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   schedule: # midnight every day
-    - cron:  '0 0 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,6 @@
+# Runs `npm test` to build Docsy & the User Guide and run all repo checks across
+# OSs.
+
 name: test
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '11 0 * * *' # 11 past midnight every day
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package.json
+      - run: npm install --omit=optional
+      - run: npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .editorconfig
+.gitattributes
 .gitignore
 .nvmrc
 .prettierignore

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cd:docs": "npm run _cd:docs -- npm run",
     "check": "npm run check:format && npm run check:links--md",
     "check:format": "npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
-    "check:links--md": "npx markdown-link-check --config .markdown-link-check.json *.md",
+    "check:links--md": "ls *.md | xargs npx markdown-link-check --config .markdown-link-check.json",
     "check:links:all": "npm run cd:docs check:links:all",
     "check:links": "npm run cd:docs check:links",
     "docs-install": "npm run _cd:docs -- npm install",
@@ -31,6 +31,7 @@
     "pretest": "npm run _prebuild",
     "serve": "npm run cd:docs serve",
     "test": "npm run cd:docs test && npm run check",
+    "test-windows": "npm run cd:docs test",
     "update:pkg:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
     "update:pkg:hugo": "npm install --save-exact -D hugo-extended@latest"
   },

--- a/tools/make-site.sh
+++ b/tools/make-site.sh
@@ -88,4 +88,4 @@ $HUGO
 
 set +x
 
-echo "[INFO] $SITE_NAME has been successfully created, set up, and built."
+echo "[INFO] $SITE_NAME successfully created, set up, and built."


### PR DESCRIPTION
- Fixes #1777
- The switch to `ls *.md | xargs ...` in the `check:links--md` script is to accommodate Windows.