### PR TITLE
[CI] Fix markdown-link-check ignore pattern & NPM link vers update

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,7 +4,10 @@
       "pattern": "^http://localhost"
     },
     {
-      "pattern": "^https://badges.netlify.com/api/docsydocs.svg?branch=main"
+      "pattern": "^https://badges.netlify.com/api/docsydocs.svg\\?branch=main"
+    },
+    {
+      "pattern": "https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish"
     }
   ],
   "timeout": "3s",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,7 +307,7 @@ Proceed as usual to build or serve your site.
 [hugo module]: https://www.docsy.dev/docs/get-started/docsy-as-module/
 [other docsy setups]: https://www.docsy.dev/docs/get-started/other-options/
 [prepare]:
-  https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
+  https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
 
 ## 0.3.0
 

--- a/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -91,7 +91,7 @@ If no `git` client is installed on your system yet, go to the [Git website](http
 
 ## Install PostCSS
 
-To build or update your site's CSS resources, you also need [`PostCSS`](https://postcss.org/) to create the final assets. If you need to install it, you must have a recent version of [NodeJS](https://nodejs.org/en/) installed on your machine so you can use `npm`, the Node package manager. By default `npm` installs tools under the directory where you run [`npm install`](https://docs.npmjs.com/cli/v6/commands/npm-install#description):
+To build or update your site's CSS resources, you also need [`PostCSS`](https://postcss.org/) to create the final assets. If you need to install it, you must have a recent version of [NodeJS](https://nodejs.org/en/) installed on your machine so you can use `npm`, the Node package manager. By default `npm` installs tools under the directory where you run [`npm install`](https://docs.npmjs.com/cli/v10/commands/npm-install#description):
 
 ```bash
 npm install -D autoprefixer

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -351,6 +351,6 @@ from scratch as it provides defaults for many required configuration parameters.
 [lts release]: https://nodejs.org/en/about/releases/
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
-[npm scripts]: https://docs.npmjs.com/cli/v8/using-npm/scripts
+[npm scripts]: https://docs.npmjs.com/cli/v10/using-npm/scripts
 [prepare]:
-  https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish
+  https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish


### PR DESCRIPTION
- Contributes to #1781 in that it fixes the `markdown-link-check` ignore pattern to remove the most flaky external link
- Updates links into NPM docs to access most recent version