### PR TITLE
Blog posts: show page-meta-lastmod

### DIFF
--- a/assets/scss/_pageinfo.scss
+++ b/assets/scss/_pageinfo.scss
@@ -14,3 +14,12 @@
     }
   }
 }
+
+.td-page-meta {
+  &__lastmod {
+    @extend .text-muted;
+    @extend .border-top;
+    margin-top: map-get($spacers, 5) !important;
+    padding-top: map-get($spacers, 3) !important;
+  }
+}

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -17,10 +17,8 @@
   padding-top: 0.75rem;
   padding-bottom: 1.5rem;
   vertical-align: top;
-}
 
-.td-page-meta {
-  a {
+  .td-page-meta a {
     display: block;
     font-weight: $font-weight-medium;
   }

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -19,4 +19,5 @@
 	{{ end -}}
 
 	{{ partial "pager.html" . }}
+	{{ partial "page-meta-lastmod.html" . -}}
 </div>

--- a/layouts/partials/page-meta-lastmod.html
+++ b/layouts/partials/page-meta-lastmod.html
@@ -1,5 +1,5 @@
-{{ if and (.GitInfo) (.Site.Params.github_repo) -}}
-<div class="text-muted mt-5 pt-3 border-top">
+{{ if and .GitInfo .Site.Params.github_repo -}}
+<div class="td-page-meta__lastmod">
   {{ T "post_last_mod" }} {{ .Lastmod.Format .Site.Params.time_format_default -}}
   {{ with .GitInfo }}: {{/* Trim WS */ -}}
     <a href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">


### PR DESCRIPTION
- Fixes #1196
- Contributes to #783 by defining `td-page-meta__lastmod ` for page-meta lastmod elements. So, in particular, projects that don't want page-meta lastmod elements to display in post pages can hide it.

---

**Preview**: https://deploy-preview-1791--docsydocs.netlify.app/blog/2022/hello/

### Screenshot

> <img width="600" alt="Screen Shot 2024-02-02 at 06 28 08" src="https://github.com/google/docsy/assets/4140793/10d2189c-eb9e-4d55-8909-90cdf61184d2">
