### PR TITLE
Whitespace cleanup in page-meta-links.html

### DIFF
--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,4 +1,4 @@
-{{ if .File }}
+{{ if .File -}}
 {{ $pathFormatted := strings.TrimPrefix hugo.WorkingDir $.File.Filename -}}
 {{ $gh_repo := ($.Param "github_repo") -}}
 {{ $gh_url := ($.Param "github_url") -}}


### PR DESCRIPTION
This is in support of #1807, to make it easier to manage diffs in downstream projects.