### PR TITLE
Use cpy-cli for OS-independent file copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "_cd:docs": "cd userguide &&",
     "_check:format": "npx prettier --check .??* *.md",
-    "_cp:bs-rfs": "cp -R node_modules/bootstrap/scss/vendor/* assets/_vendor/bootstrap/scss/",
+    "_cp:bs-rfs": "npx cpy 'node_modules/bootstrap/scss/vendor/*' assets/_vendor/bootstrap/scss/",
     "_mkdir:hugo-mod": "npx mkdirp ../github.com/FortAwesome/Font-Awesome ../github.com/twbs/bootstrap",
     "_prebuild": "npm run _cp:bs-rfs",
     "_test:docs": "npm run cd:docs test",
@@ -26,7 +26,6 @@
     "postinstall": "npm run _mkdir:hugo-mod",
     "prebuild:preview": "npm run _prebuild",
     "prebuild:production": "npm run _prebuild",
-    "prepare": "npm run _cp:bs-rfs",
     "preserve": "npm run _prebuild",
     "pretest": "npm run _prebuild",
     "serve": "npm run cd:docs serve",
@@ -41,6 +40,7 @@
     "bootstrap": "5.2.3"
   },
   "devDependencies": {
+    "cpy-cli": "^5.0.0",
     "hugo-extended": "0.122.0",
     "markdown-link-check": "^3.11.2",
     "mkdirp": "^3.0.1",


### PR DESCRIPTION
- Proposed solution to #1793, which uses the popular NPM package `cpy-cli` to copy files rather than the Linux `cp`
- Fixes #973
- Proposed alternatives to the following, which it closes:
  - Closes #1797
  - Closes #1806

/cc @marshalc @deining 