### PR TITLE
Link styles: follow recommended practice and underline by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,19 @@ For the full list of changes, see the [0.9.0] release notes.
   [path_base_for_github_subdir]. Projects will need to adjust the value of
   [path_base_for_github_subdir] to be relative to the file's physical location.
 
-**New**:
+- Docsy statically generates anchor-links after headings using Hugo's
+  [render-heading.html](https://gohugo.io/templates/render-hooks/) hook. This is
+  potentially a breaking change for projects that override the hook.
 
 **Other changes**:
 
+- Docsy follows recommended accessibility practice: page-body links are
+  underlined. For details, see [#1814] and [#1815].
+
 [0.9.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.9.0
 [#1744]: https://github.com/google/docsy/pull/1744
+[#1814]: https://github.com/google/docsy/issues/1814
+[#1815]: https://github.com/google/docsy/pull/1815
 [multi-language]: https://www.docsy.dev/docs/language/
 [path_base_for_github_subdir]:
   https://www.docsy.dev/docs/adding-content/repository-links/#path_base_for_github_subdir-optional

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -50,9 +50,9 @@
     a {
       color: $gray-600;
 
+      &:focus,
       &:hover {
-        color: $blue;
-        text-decoration: none;
+        color: initial;
       }
     }
   }

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -2,6 +2,8 @@
 // Right side toc
 //
 .td-sidebar-toc {
+  @include link-decoration;
+
   border-left: 1px solid $border-color;
 
   @supports (position: sticky) {

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -120,6 +120,8 @@
 }
 
 .td-sidebar {
+  @include link-decoration;
+
   @include media-breakpoint-up(md) {
     padding-top: 4rem;
     background-color: $td-sidebar-bg-color;

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -77,9 +77,9 @@
   }
 
   a {
+    &:focus,
     &:hover {
-      color: $blue;
-      text-decoration: none;
+      color: $link-color;
     }
 
     &.active {

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -35,7 +35,6 @@ $td-box-colors: $dark, $primary, $secondary, $info, $white, $gray-600, $success,
   $warning, $dark, $danger, $primary, $secondary, $info !default;
 
 $link-color: $blue-500 !default;
-$link-decoration: none !default;
 $link-shade-percentage: 30% !default;
 
 // Fonts

--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -1,5 +1,16 @@
 // Mixins
 
+@mixin link-decoration($base: none, $focus_or_hover: initial) {
+  a {
+    text-decoration: $base;
+
+    &:focus,
+    &:hover {
+      text-decoration: $focus_or_hover;
+    }
+  }
+}
+
 @mixin link-variant($parent, $color, $hover-color, $underline: false) {
   #{$parent} {
     color: $color;


### PR DESCRIPTION
- Fixes #1814
- Closes #1684 by superseding it

**Preview**, e.g.: https://deploy-preview-1815--docsydocs.netlify.app/docs/

---

Projects that wish to preserve Docsy's old behavior can add the following to their `assets/scss/_variables_project.scss`, among other ways:

```scss
$link-decoration: none !default;
```
