### PR TITLE
Footer: factor out copyright, and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,14 @@ For the full list of changes, see the [0.9.0] release notes.
   [render-heading.html](https://gohugo.io/templates/render-hooks/) hook. This is
   _potentially_ a breaking change for projects that override the hook.
 
+- The footer layout has been factored into parts: left, right, and center, with
+  copyright a subpart of center. Each part has its own style tag, for example:
+  `td-footer__left`. Note that the style `td-footer__copyright-etc` has been
+  renamed to `td-footer__center`. For details concerning all foot changes, see
+  [#1818].
+
 **Other changes**:
 
-- The footer parts can be individually customized: left, right, center, and
-  copyright. ([#1818]).
 - The latest release of [Mermaid] resources are fetched at build time ([#1410]).
 - Docsy follows recommended accessibility practice: page-body links are
   underlined. For details, see [#1814] and [#1815].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ For the full list of changes, see the [0.9.0] release notes.
 
 **Other changes**:
 
-- The latest release of [Mermaid] resources are fetch at build time ([#1410])
+- The footer parts can be individually customized: left, right, center, and
+  copyright. ([#1818]).
+- The latest release of [Mermaid] resources are fetched at build time ([#1410]).
 - Docsy follows recommended accessibility practice: page-body links are
   underlined. For details, see [#1814] and [#1815].
 
@@ -53,6 +55,7 @@ For the full list of changes, see the [0.9.0] release notes.
 [#1744]: https://github.com/google/docsy/pull/1744
 [#1814]: https://github.com/google/docsy/issues/1814
 [#1815]: https://github.com/google/docsy/pull/1815
+[#1818]: https://github.com/google/docsy/pull/1818
 [mermaid]:
   https://www.docsy.dev/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid
 [multi-language]: https://www.docsy.dev/docs/language/

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -49,9 +49,17 @@
     min-height: 200px;
   }
 
-  &__copyright-etc {
+  /* &__left { } */
+
+  &__center {
     @extend .small;
+    text-align: center;
   }
+
+  &__right {
+    text-align: right;
+  }
+
   &__about {
     font-size: initial;
   }

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,13 +1,15 @@
 <footer class="td-footer row d-print-none">
   <div class="container-fluid">
     <div class="row mx-md-2">
-      <div class="col-6 col-sm-4 text-xs-center order-sm-1">
+      <div class="td-footer__left col-6 col-sm-4 order-sm-1">
         {{ partial "footer/left.html"  . }}
       </div>
-      <div class="col-6 col-sm-4 text-end text-xs-center order-sm-3">
+      {{- /* Trim WS */ -}}
+      <div class="td-footer__right col-6 col-sm-4 order-sm-3">
         {{ partial "footer/right.html"  . }}
       </div>
-      <div class="td-footer__copyright-etc col-12 col-sm-4 text-center py-2 order-sm-2">
+      {{- /* Trim WS */ -}}
+      <div class="td-footer__center col-12 col-sm-4 py-2 order-sm-2">
         {{ partial "footer/center.html"  . }}
       </div>
     </div>

--- a/layouts/partials/footer/center.html
+++ b/layouts/partials/footer/center.html
@@ -1,11 +1,11 @@
-{{ with .Site.Params.copyright -}}
-<span>&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
-{{- end }}
+{{ partial "footer/copyright.html"  . -}}
+
 {{ with .Site.Params.privacy_policy -}}
-<span class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></span>
-{{- end }}
-{{ if not .Site.Params.ui.footer_about_disable -}}
-{{ with .Site.GetPage "about" -}}
-	<p class="td-footer__about mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>
+  <span class="ms-2"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></span>
 {{- end -}}
-{{ end }}
+
+{{ if not .Site.Params.ui.footer_about_disable -}}
+  {{ with .Site.GetPage "about" -}}
+    <p class="td-footer__about mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>
+  {{- end -}}
+{{ end -}}

--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,0 +1,3 @@
+{{ with .Site.Params.copyright -}}
+  <span>&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
+{{- end -}}

--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,3 +1,3 @@
 {{ with .Site.Params.copyright -}}
-  <span>&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
+  <span class="td_footer__copyright">&copy; {{ now.Year }} {{ . }} {{ T "footer_all_rights_reserved" }}</span>
 {{- end -}}

--- a/layouts/partials/footer/left.html
+++ b/layouts/partials/footer/left.html
@@ -1,5 +1,5 @@
-{{ with .Site.Params.links }}
-{{ with index . "user" }}
-{{ partial "footer/links.html"  . }}
-{{ end }}
-{{ end }}
+{{ with .Site.Params.links -}}
+  {{ with index . "user" -}}
+    {{- partial "footer/links.html"  . -}}
+  {{ end -}}
+{{ end -}}

--- a/layouts/partials/footer/right.html
+++ b/layouts/partials/footer/right.html
@@ -1,5 +1,5 @@
-{{ with .Site.Params.links }}
-{{ with index . "developer" }}
-{{ partial "footer/links.html"  . }}
-{{ end }}
-{{ end }}
+{{ with .Site.Params.links -}}
+  {{ with index . "developer" -}}
+    {{- partial "footer/links.html"  . -}}
+  {{ end -}}
+{{ end -}}


### PR DESCRIPTION
- Contributes to #1818
- Followup to #1500 
- Factors out the copyright element from the center element
- Formats new footer-layout parts
- Adds a CHANGELOG entry
- Contributes to #783

**Preview**: https://deploy-preview-1817--docsydocs.netlify.app/docs/

**Compare with**: https://www.docsy.dev/docs/