### PR TITLE
Fix repo-links page-meta class names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ For the full list of changes, see the [0.9.0] release notes.
   [path_base_for_github_subdir]. Projects will need to adjust the value of
   [path_base_for_github_subdir] to be relative to the file's physical location.
 
+- Class names to disable [repository links] were misnamed with a suffix of the
+  form `--KIND`. The new suffix is `__KIND`. For details, see [Disabling links].
+
 - Docsy statically generates anchor-links after headings using Hugo's
   [render-heading.html](https://gohugo.io/templates/render-hooks/) hook. This is
   _potentially_ a breaking change for projects that override the hook.
@@ -65,12 +68,14 @@ For the full list of changes, see the [0.9.0] release notes.
 [#1814]: https://github.com/google/docsy/issues/1814
 [#1815]: https://github.com/google/docsy/pull/1815
 [#1818]: https://github.com/google/docsy/pull/1818
+[disabling links]:
+  https://www.docsy.dev/docs/adding-content/repository-links/#disabling-links
 [mermaid]:
   https://www.docsy.dev/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid
 [multi-language]: https://www.docsy.dev/docs/language/
 [path_base_for_github_subdir]:
   https://www.docsy.dev/docs/adding-content/repository-links/#path_base_for_github_subdir-optional
-[Repository Links]: https://www.docsy.dev/docs/adding-content/repository-links/
+[repository links]: https://www.docsy.dev/docs/adding-content/repository-links/
 [union file system]:
   https://gohugo.io/getting-started/directory-structure/#union-file-system
 

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,4 +1,6 @@
 {{/* cSpell:ignore querify subdir */ -}}
+{{/* Class names ending with `--KIND` are deprecated in favor of `__KIND`, but we're keeping them for a few releases after 0.9.0 */ -}}
+
 {{ if .File -}}
 {{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
 {{ $gh_repo := $.Param "github_repo" -}}
@@ -33,13 +35,13 @@
   {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
   {{ $newPageURL := printf "%s/new/%s?%s" $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}
 
-  <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
-  <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-  <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
-  <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
+  <a href="{{ $viewURL }}" class="td-page-meta--view td-page-meta__view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
+  <a href="{{ $editURL }}" class="td-page-meta--edit td-page-meta__edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+  <a href="{{ $newPageURL }}" class="td-page-meta--child td-page-meta__child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
   {{ with $gh_project_repo -}}
     {{ $project_issueURL := printf "%s/issues/new" . -}}
-    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project td-page-meta__project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
   {{ end -}}
 
 {{ end -}}

--- a/userguide/content/en/docs/adding-content/repository-links.md
+++ b/userguide/content/en/docs/adding-content/repository-links.md
@@ -330,23 +330,32 @@ following to your [projects's `_styles_project.scss`][project-style-files] file
 to hide **Create child page** links from all pages:
 
 ```scss
-.td-page-meta--child { display: none !important; }
+.td-page-meta__child { display: none !important; }
 ```
 
-Each link kind has an associated unique class named `.td-page-meta--KIND`, as
+Each link kind has an associated unique class named `.td-page-meta__KIND`, as
 defined by the following table:
 
 Link kind | Class name
 --- | ---
-View page source | `.td-page-meta--view`
-Edit this page | `.td-page-meta--edit`
-Create child page | `.td-page-meta--child`
-Create documentation issue | `.td-page-meta--issue`
-Create project issue | `.td-page-meta--project-issue`
+View page source | `.td-page-meta__view`
+Edit this page | `.td-page-meta__edit`
+Create child page | `.td-page-meta__child`
+Create documentation issue | `.td-page-meta__issue`
+Create project issue | `.td-page-meta__project-issue`
 
 Of course, you can also use these classes to give repository links unique styles
 for your project.
 
+{{% alert title="Version note" color=warning %}}
+
+Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
+
+[v0.9.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#090
+
+{{% /alert %}}
+
+
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[multiple languages]: {{< relref "language" >}}
-[project-style-files]: {{< relref "lookandfeel#project-style-files" >}}
+[multiple languages]: {{% relref "language" %}}
+[project-style-files]: {{% relref "lookandfeel#project-style-files" %}}


### PR DESCRIPTION
- Class names to disable [repository links] were misnamed with a suffix of the form `--KIND`. The new suffix is `__KIND`. I noticed the misnaming while working on #1196
- Fixing sooner is better than later.
- The old class names will still work but are deprecated

**Preview**: https://deploy-preview-1819--docsydocs.netlify.app/docs/adding-content/repository-links/#disabling-links