### PR TITLE
Support date range in footer copyright element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ For the full list of changes, see the [0.9.0] release notes.
 
 **Breaking changes**:
 
-- [Repository Links] now work for [multi-language] sites ([#1744]).
+- **[Repository Links]** now work for [multi-language] sites ([#1744]).
 
   For any given page, repository links are now computed from a page's _resolved_
   `File` path &mdash; as resolved _through_ mount points, if any. That is, the
@@ -41,26 +41,29 @@ For the full list of changes, see the [0.9.0] release notes.
 - Class names to disable [repository links] were misnamed with a suffix of the
   form `--KIND`. The new suffix is `__KIND`. For details, see [Disabling links].
 
-- Docsy statically generates anchor-links after headings using Hugo's
-  [render-heading.html](https://gohugo.io/templates/render-hooks/) hook. This is
-  _potentially_ a breaking change for projects that override the hook.
-
-- The footer layout has been factored into parts: left, right, and center, with
-  copyright a subpart of center. Each part has its own style tag, for example:
-  `td-footer__left`. Note that the style `td-footer__copyright-etc` has been
-  renamed to `td-footer__center`. For details concerning all foot changes, see
-  [#1818].
-
-- **Footer, copyright notice**:
-  - display of year can now be customized via .Site.Params.copyright.year
-  - title displayed after year must now be given via
-    .Site.Params.copyright.title
+- **Footer layout** has been factored into parts: _left_, _right_, and _center_,
+  with _copyright_ a subpart of center. Each part has its own style tag, for
+  example: `td-footer__left`. Note that the style `td-footer__copyright-etc` has
+  been renamed to `td-footer__center`. For details concerning all foot changes,
+  see [#1818].
 
 **Other changes**:
 
-- The latest release of [Mermaid] resources are fetched at build time ([#1410]).
-- Docsy follows recommended accessibility practice: page-body links are
-  underlined. For details, see [#1814] and [#1815].
+- **Footer copyright**:
+  - The Hugo config option `params.copyright` can be a map with the following
+    optional fields: `authors`, `from_year`, `to_year`. When unset, `to_year`
+    defaults to the year that the site built. The default `authors` is "Site
+    Authors" and is it rendered as markdown.
+  - If `params.copyright` is unset, then the [site `copyright`] option will be
+    used and rendered as markdown, "as is" &mdash; with no year is added.
+- Docsy statically generates **anchor links** after headings using Hugo's
+  [render-heading.html](https://gohugo.io/templates/render-hooks/) hook, rather
+  than having them generated dynamically using Anchor.js. Projects that override
+  the heading hook will need to reintegrate the functionality.
+- The latest release of **[Mermaid] resources** are fetched at build time
+  ([#1410]).
+- Docsy follows recommended accessibility practice: page-body **links are
+  underlined**. For details, see [#1814] and [#1815].
 
 [0.9.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.9.0
 [#1410]: https://github.com/google/docsy/pull/1410
@@ -75,7 +78,8 @@ For the full list of changes, see the [0.9.0] release notes.
 [multi-language]: https://www.docsy.dev/docs/language/
 [path_base_for_github_subdir]:
   https://www.docsy.dev/docs/adding-content/repository-links/#path_base_for_github_subdir-optional
-[repository links]: https://www.docsy.dev/docs/adding-content/repository-links/
+[Repository Links]: https://www.docsy.dev/docs/adding-content/repository-links/
+[site `copyright`]: https://gohugo.io/methods/site/copyright/
 [union file system]:
   https://gohugo.io/getting-started/directory-structure/#union-file-system
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -80,6 +80,10 @@
     }
   }
 
+  &__authors,
+  &__all_rights_reserved {
+    padding-left: map-get($spacers, 1);
+  }
 }
 
 // Adjust anchors vs the fixed menu.

--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,5 +1,39 @@
+{{ $page := .Page -}}
 {{ with .Site.Params.copyright -}}
-  <span class="td_footer__copyright">&copy; {{ with .year -}}{{- . -}}{{- else -}}{{- now.Year -}}{{- end }} {{ with .title -}}{{- . -}}{{- end }} {{ T "footer_all_rights_reserved" }}</span>
-  {{- else }}
-    {{ with .Site.Copyright }}{{ . | safeHTML }}{{ end }}
-{{- end -}}
+  {{ $fromYear := "" -}}
+  {{ $toYear := "" -}}
+  {{ $authors := "" -}}
+  {{ if reflect.IsMap . -}}
+    {{ $fromYear = .from_year -}}
+    {{ $toYear = .to_year -}}
+    {{ $authors = .authors -}}
+  {{ else -}}
+    {{ $authors = . -}}
+  {{ end -}}
+
+  <span class="td-footer__copyright">&copy;
+    {{ with $fromYear -}}
+      {{ . }}&ndash;
+    {{- end -}}
+    {{ $toYear | default now.Year }}
+    <span class="td-footer__authors">
+      {{- $authors | default "Site Authors" | $page.RenderString -}}
+    </span>
+    {{- /* Trim WS */ -}}
+  </span>
+
+  {{- with T "footer_all_rights_reserved" -}}
+    <span class="td-footer__all_rights_reserved">
+      {{- . -}}
+    </span>
+  {{- end }}
+
+{{- else -}}
+
+  {{ with .Site.Copyright -}}
+    <span class="td-footer__copyright">
+      {{- . | $page.RenderString -}}
+    </span>
+  {{- end -}}
+
+{{ end -}}

--- a/userguide/assets/scss/_styles_project.scss
+++ b/userguide/assets/scss/_styles_project.scss
@@ -1,0 +1,5 @@
+.td-footer {
+  &__all_rights_reserved {
+    display: none;
+  }
+}

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -51,8 +51,10 @@ markup:
 
 params:
   copyright:
-    title: The Docsy Authors
-    year: 2024
+    authors: >-
+      Docsy Authors |
+      [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) | 
+    from_year: 2018
   privacy_policy: https://policies.google.com/privacy
   version_menu: Releases
   archived_version: false
@@ -72,6 +74,7 @@ params:
   search:
     # algolia:
   ui:
+    footer_about_disable: true
     sidebar_cache_limit: 10
     sidebar_menu_compact: true
     sidebar_menu_foldable: false


### PR DESCRIPTION
- Contributes to:
  - #1818
  - #783
- Fixes #436
- From the CHANGELOG:
  > - **Footer copyright**:
  >   - The Hugo config option `params.copyright` can be a map with the following
  >     optional fields: `authors`, `from_year`, `to_year`. When unset, `to_year`
  >     defaults to the year that the site built. The default `authors` is "Site Authors"
  >     and is rendered as markdown.
  >   - If `params.copyright` is unset, then the [site `copyright`] option will be
  >     used and rendered as markdown, "as is" &mdash; with no year is added.
- Sets the **User Guide Hugo config options** as an example, illustrating the use case shown in #2 of "Copyright 2018 The <product_name> Authors | Documentation Distributed under CC BY 4.0"
  ```yaml
  params:
    copyright:
      authors: >-
        Docsy Authors |
        [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) | 
      from_year: 2018
    # ...
    ui:
      footer_about_disable: true
  ```

### User Guide screenshots

Wide screen:

> <img width="1225" alt="image" src="https://github.com/google/docsy/assets/4140793/aa47484b-8612-4be4-8f4b-7966a53ee57c">

Narrow screen:

> <img width="674" alt="image" src="https://github.com/google/docsy/assets/4140793/b0891925-2897-407d-85a7-5c0c6d50fdb1">

[site `copyright`]: https://gohugo.io/methods/site/copyright/