### PR TITLE
Add demosite for "Demo" button on themes.gohugo.io

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,6 +3,7 @@ license = "Apache 2.0"
 licenselink = "https://github.com/google/docsy/blob/main/LICENSE"
 description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
+demosite = "https://example.docsy.dev/"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
 min_version = "0.110.0"


### PR DESCRIPTION
At https://themes.gohugo.io/themes/docsy/ there is no direct link to the demo site. This PR adds the demosite variable (idk what its called) in theme.toml, which is necessary for the "Demo" button. See https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration.