### PR TITLE
infrastructure: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+labels: [bug, needs-triage]
+about: Create a report to help us improve
+---
+
+<!-- Describe you environment by answering the questions below. Put your answers after the colon on each line. -->
+
+### Environment
+
+- [ ] Version of Docsy you are using:
+- [ ] How are you using Docsy? As a:
+  - [ ] Hugo module
+  - [ ] NPM module
+  - [ ] Git submodule
+  - [ ] Other:
+- [ ] Version of Hugo you are using (output of `hugo version`):
+- [ ] OS:
+  - [ ] Linux
+  - [ ] macOS
+  - [ ] Windows
+  - [ ] Other:
+
+### Problem
+
+<!-- Concisely describe the problem you are seeing, ideally provide steps to reproduce it. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: SUPPORT, ISSUES, and TROUBLESHOOTING
+    url: https://github.com/google/docsy/discussions
+    about:
+      Please DO NOT use GitHub issues for support requests, instead start a
+      discussion thread at https://github.com/google/docsy/discussions. Feel
+      free to open an issue once your problem is confirmed by the docsy
+      maintainers and/or the docsy community.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,6 @@
+---
+name: Enhancement proposal
+labels: [enhancement, needs-triage]
+---
+
+<!-- Describe this new feature. Think about if it really belongs in the docsy theme; you may want to discuss it on https://github.com/google/docsy/discussions first.  -->


### PR DESCRIPTION
This PR is a follow-up on the discussion we had in #1632.
It adds issue templates with the hope that most requests come in as discussions and not as issues any more.
This PR is closely related to this [discussion post](https://github.com/google/docsy/discussions/1632#discussioncomment-8138357).