### PR TITLE
Add link to example site (themes.gohugo.io)

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -3,6 +3,7 @@ license = "Apache 2.0"
 licenselink = "https://github.com/google/docsy/blob/main/LICENSE"
 description = "A Hugo theme for technical documentation sites"
 homepage = "https://docsy.dev"
+demosite = "https://example.docsy.dev/"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
 min_version = "0.110.0"


### PR DESCRIPTION
This PR adds a to link to the example site on themes.gohugo.io, as raised in #1823 and proposed in #1822.
This PR closes #1823.