### PR TITLE
[CI] Smoke tests: fix for repo forks, but also disable on push

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -25,6 +25,7 @@ jobs:
       SHA: ${{ github.sha }}
     # TODO: drop PR testing under Windows because it's too slow?
     # if: github.event_name != 'pull_request' && matrix.os != 'windows-latest'
+    if: github.event_name != 'push' || github.repository == 'google/docsy'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
- Fixes #1826
- Fixes `tools/make-site.sh` so that it can be run on repo forks, but ...
- Restricts the execution of smoke jobs on push to the main repo -- we don't need tests to run again on forks.