### PR TITLE
user guide, multi-language settings: improve config options

### DIFF
--- a/userguide/content/en/docs/get-started/basic-configuration.md
+++ b/userguide/content/en/docs/get-started/basic-configuration.md
@@ -19,18 +19,20 @@ If you don't intend to translate your site, you can remove the language switcher
 
 ```toml
 [languages.no]
-title = "Docsy"
-description = "Docsy er operativsystem for skyen"
 languageName ="Norsk"
 contentDir = "content/no"
+[languages.no.params]
+title = "Goldydocs"
+description = "Docsy er operativsystem for skyen"
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 
 [languages.fa]
-title = "اسناد گلدی"
-description = "یک نمونه برای پوسته داکسی"
 languageName ="فارسی"
 contentDir = "content/fa"
+[languages.fa.params]
+title = "اسناد گلدی"
+description = "یک نمونه برای پوسته داکسی"
 time_format_default = "2006.01.02"
 time_format_blog = "2006.01.02"
 ```

--- a/userguide/content/en/docs/language/_index.md
+++ b/userguide/content/en/docs/language/_index.md
@@ -21,16 +21,18 @@ defaultContentLanguageInSubdir = false
 ...
 [languages]
 [languages.en]
-title = "Docsy"
-description = "Docsy does docs"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
+[languages.en.params]
+title = "Goldydocs"
+description = "Docsy does docs"
 [languages.no]
-title = "Docsy"
-description = "Docsy er operativsystem for skyen"
 languageName ="Norsk"
 contentDir = "content/no"
+[languages.no.params]
+title = "Goldydocs"
+description = "Docsy er operativsystem for skyen"
 time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 {{< /tab >}}
@@ -41,17 +43,19 @@ defaultContentLanguageInSubdir: false
 …
 languages:
   en:
-    title: Docsy
-    description: Docsy does docs
     languageName: English
     weight: 1 # used for sorting
+    params:
+      title: Docsy
+      description: Docsy does docs
   'no':
-    title: Docsy
-    description: Docsy er operativsystem for skyen
     languageName: Norsk
     contentDir: content/no
-    time_format_default: 02.01.2006
-    time_format_blog: 02.01.2006
+    params:
+      title: Docsy
+      description: Docsy er operativsystem for skyen
+      time_format_default: 02.01.2006
+      time_format_blog: 02.01.2006
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
@@ -60,18 +64,22 @@ languages:
   "defaultContentLanguageInSubdir": false,
   "languages": {
     "en": {
-      "title": "Docsy",
-      "description": "Docsy does docs",
       "languageName": "English",
-      "weight": 1
-    },
+      "weight": 1,
+      "params": {
+        "title": "Docsy",
+        "description": "Docsy does docs"
+      }
+  },
     "no": {
-      "title": "Docsy",
-      "description": "Docsy er operativsystem for skyen",
       "languageName": "Norsk",
       "contentDir": "content/no",
-      "time_format_default": "02.01.2006",
-      "time_format_blog": "02.01.2006"
+      "params": {
+        "title": "Docsy",
+        "description": "Docsy er operativsystem for skyen",
+        "time_format_default": "02.01.2006",
+        "time_format_blog": "02.01.2006"
+      }
     }
   }
 }


### PR DESCRIPTION
As of hugo v0.112.0, adding custom parameters to the top level language configuration is deprecated, see [hugo docs](https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120) for details.
This PR reflects this change in the docsy user guide. The old config was outdated and led to deprecation warnings emitted from hugo.