### PR TITLE
Ensure hamburger isn't underlined, for real

### DIFF
--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -9,6 +9,10 @@
       text-decoration: $focus_or_hover;
     }
   }
+
+  .btn-link {
+    text-decoration: $base;
+  }
 }
 
 @mixin link-variant($parent, $color, $hover-color, $underline: false) {


### PR DESCRIPTION
- Fixes #1832
- Contributes to #1814
- Followup to #1815 

**Preview**: https://deploy-preview-1833--docsydocs.netlify.app/docs/

### Screenshot

Before:

> <img width="500" alt="image" src="https://github.com/google/docsy/assets/4140793/3d8bfaa2-0675-4b12-a734-2c69ee559fc9">

After:

> <img width="500" alt="image" src="https://github.com/google/docsy/assets/4140793/6d2af715-50bd-4b73-9d18-4c0da0c428f3">
