### PR TITLE
Issue template 'enhancement': Fix error

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,6 +1,7 @@
 ---
 name: Enhancement proposal
 labels: [enhancement, needs-triage]
+about: Propose an enhancement or submit a feature request
 ---
 
-<!-- Describe this new feature. Think about if it really belongs in the docsy theme; you may want to discuss it on https://github.com/google/docsy/discussions first.  -->
+<!-- Tell us about the enhancement or describe your feature wish. Think about if it really belongs in the docsy theme; you may want to discuss it on https://github.com/google/docsy/discussions first. -->


### PR DESCRIPTION
This is a follow up on merged PR #1824.
As you can see [here](https://github.com/google/docsy/blob/main/.github/ISSUE_TEMPLATE/enhancement.md), there is an error with the issue template `enhancement.md`:

```
There is a problem with this template

About can't be blank. 
```

This PR fixes this error.