### PR TITLE
Smoke tests: don't cancel Windows build after an error in Linux build

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -15,6 +15,7 @@ jobs:
   new-site:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
         docsy-src: [NPM, HUGO_MODULE]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
     steps:


### PR DESCRIPTION
This PR follows up on #1196, issue 6 raised:

> Inside the smoke tests there is a matrix defined so that tests can be reused and executed on Linux and Windows machines and for NPM and hugo module build. This seems logical, it comes with one disadvantage, though: as soon as a smoke test for Linux fails, the corresponding smoke test on Windows is cancelled.

This PR overcomes this limitation while still following the DRY principle.