### PR TITLE
User guide, LaTeX: typesetting of formulae using standard syntax

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,13 +1,5 @@
-{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem -}}
-{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem -}}
-{{ if ge hugo.Version "0.93.0" -}}
-  {{ $needKaTeX = or $needKaTeX (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
-  {{ $needmhchem = or $needmhchem (.Page.Store.Get "hasmhchem") -}}
-{{ else -}}
-  {{ if or $needKaTeX $needmhchem -}}
-    {{ warnf "Outdated Hugo version %s, consider upgrading to make full use of all theme features" hugo.Version  }}
-  {{ end -}}
-{{ end -}}
+{{ $needKaTeX  := or .Params.math .Site.Params.katex.enable .Params.chem .Site.Params.chem (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
+{{ $needmhchem := or .Params.chem .Site.Params.katex.mhchem.enable (.Page.Store.Get "hasmhchem") -}}
 
 {{ if .Site.Params.markmap.enable -}}
 <style>
@@ -34,27 +26,8 @@ window.markmap = {
   <script src='{{ "js/deflate.js" | relURL }}'></script>
 {{ end -}}
 
-{{ if  $needKaTeX -}}
-{{/* load stylesheet and scripts for KaTeX support */ -}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.css"
-      integrity="sha512-6a/jH+OTfV56Vs9Mm+Kl7ZsXWJRM2+EV+JDrW7HLHaf4OU2+9eLkHKFbzpSSbfJ5b60m+7/tQAevrzu7NP7Q2g==" crossorigin="anonymous">
-  {{/* The loading of KaTeX is deferred to speed up page rendering */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.js"
-        integrity="sha512-FkmlbBiAj8fgfoZ8zJ+bZQCU5pdU55irXmJzFF/mXlSvBr2x/gmyLHaRu5iSpcA5Hw6CMLCCFSjB1GmgtNL2Qg=="
-        crossorigin="anonymous">
-</script>
-  {{ if $needmhchem -}}
-  {{/* To add support for displaying chemical equations and physical units, load the mhchem extension: */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/mhchem.min.js"
-        integrity="sha512-Cl4bz7Rt9ppgcBOQa4z96q3UqAzHgBzNDm66u2+lDe0ZJQu0Fgz+6jO57E+IZqzlhGzfNBY++pg7Ue+iopaLrg=="
-        crossorigin="anonymous">
-</script>
-  {{ end -}}
-  {{/* To automatically render math in text elements, include the auto-render extension: */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/auto-render.min.js"
-       integrity="sha512-6bKDPShiPRjAcdeO8T6cedaVEi0pavPbzue/G/ZRiwVlurWZOSZ/vI9fr2lhk8IPXK7z51AZac+zBvZzgDJzDQ==" crossorigin="anonymous"
-       {{ printf "onload='renderMathInElement(%s, %s);'" (( $.Page.Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Page.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}>
-</script>
+{{ if $needKaTeX -}}
+  {{ partial "scripts/katex.html" (dict "mhchem" $needmhchem) -}}
 {{ end -}}
 
 {{ $jsBs := resources.Get "vendor/bootstrap/dist/js/bootstrap.bundle.js" -}}

--- a/layouts/partials/scripts/katex.html
+++ b/layouts/partials/scripts/katex.html
@@ -2,10 +2,10 @@
 
 {{/* load stylesheet and scripts for KaTeX support */ -}}
 {{ $katex_css_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/katex.min.css" $version -}}
-{{ with resources.GetRemote $katex_css_url -}}
+{{ with try (resources.GetRemote $katex_css_url) -}}
   {{ with .Err -}}
     {{ errorf "Could not retrieve KaTeX css file from CDN. Reason: %s." . -}}
-  {{ else -}}
+  {{ else with.Value -}}
     {{ $secureCSS := . | resources.Fingerprint "sha512" -}}
 <link rel="stylesheet" href="{{- $katex_css_url -}}" integrity="{{- $secureCSS.Data.Integrity -}}" crossorigin="anonymous">
   {{ end -}}
@@ -15,12 +15,12 @@
 
 {{/* The loading of KaTeX is deferred to speed up page rendering */ -}}
 {{ $katex_js_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/katex.min.js" $version -}}
-{{ with resources.GetRemote $katex_js_url -}}
+{{ with try (resources.GetRemote $katex_js_url) -}}
   {{ with .Err -}}
     {{ errorf "Could not retrieve KaTeX script from CDN. Reason: %s." . -}}
-  {{ else -}}
+  {{ else with.Value -}}
     {{ $secureJS := . | resources.Fingerprint "sha512" -}}
-<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>    
+<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>
   {{ end -}}
 {{ else -}}
   {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." $version -}}
@@ -34,14 +34,14 @@
 {{/* To automatically render math in text elements, include the auto-render extension: */ -}}
 
 {{ $katex_autorender_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/contrib/auto-render.min.js" $version -}}
-{{ with resources.GetRemote $katex_autorender_url -}}
+{{ with try (resources.GetRemote $katex_autorender_url) -}}
   {{ with .Err -}}
     {{ errorf "Could not retrieve KaTeX auto render extension from CDN. Reason: %s." . -}}
-  {{ else -}}
+  {{ else with .Value -}}
     {{ $secureJS := . | resources.Fingerprint "sha512" -}}
 <script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous"
 {{ printf "onload='renderMathInElement(%s, %s);'" (( $.Page.Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Page.Site.Params.katex.options | jsonify )) | safeHTMLAttr -}} >
-</script>    
+</script>
   {{ end -}}
 {{ else -}}
   {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." $version -}}

--- a/layouts/partials/scripts/katex.html
+++ b/layouts/partials/scripts/katex.html
@@ -1,0 +1,48 @@
+{{ $version := .Site.Params.katex.version | default "latest" -}}
+
+{{/* load stylesheet and scripts for KaTeX support */ -}}
+{{ $katex_css_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/katex.min.css" $version -}}
+{{ with resources.GetRemote $katex_css_url -}}
+  {{ with .Err -}}
+    {{ errorf "Could not retrieve KaTeX css file from CDN. Reason: %s." . -}}
+  {{ else -}}
+    {{ $secureCSS := . | resources.Fingerprint "sha512" -}}
+<link rel="stylesheet" href="{{- $katex_css_url -}}" integrity="{{- $secureCSS.Data.Integrity -}}" crossorigin="anonymous">
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." $version -}}
+{{ end -}}
+
+{{/* The loading of KaTeX is deferred to speed up page rendering */ -}}
+{{ $katex_js_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/katex.min.js" $version -}}
+{{ with resources.GetRemote $katex_js_url -}}
+  {{ with .Err -}}
+    {{ errorf "Could not retrieve KaTeX script from CDN. Reason: %s." . -}}
+  {{ else -}}
+    {{ $secureJS := . | resources.Fingerprint "sha512" -}}
+<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>    
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." $version -}}
+{{ end -}}
+
+{{/* Add support for displaying chemical equations and physical units by loading the mhchem extension: */ -}}
+{{ if .mhchem -}}
+{{ partial "scripts/mhchem.html" (dict "version" $version) -}}
+{{ end -}}
+
+{{/* To automatically render math in text elements, include the auto-render extension: */ -}}
+
+{{ $katex_autorender_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/contrib/auto-render.min.js" $version -}}
+{{ with resources.GetRemote $katex_autorender_url -}}
+  {{ with .Err -}}
+    {{ errorf "Could not retrieve KaTeX auto render extension from CDN. Reason: %s." . -}}
+  {{ else -}}
+    {{ $secureJS := . | resources.Fingerprint "sha512" -}}
+<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous"
+{{ printf "onload='renderMathInElement(%s, %s);'" (( $.Page.Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Page.Site.Params.katex.options | jsonify )) | safeHTMLAttr -}} >
+</script>    
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." $version -}}
+{{ end -}}

--- a/layouts/partials/scripts/mhchem.html
+++ b/layouts/partials/scripts/mhchem.html
@@ -1,11 +1,11 @@
 {{/* Add support for displaying chemical equations and physical units by loading the mhchem extension: */ -}}
 {{ $mhchem_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/contrib/mhchem.min.js" .version -}}
-{{ with resources.GetRemote $mhchem_url -}}
+{{ with try (resources.GetRemote $mhchem_url) -}}
   {{ with .Err -}}
     {{ errorf "Could not retrieve mhchem script from CDN. Reason: %s." . -}}
-  {{ else -}}
+  {{ else with .Value -}}
     {{ $secureJS := . | resources.Fingerprint "sha512" -}}
-<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>    
+<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>
   {{ end -}}
 {{ else -}}
   {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." .version -}}

--- a/layouts/partials/scripts/mhchem.html
+++ b/layouts/partials/scripts/mhchem.html
@@ -1,0 +1,12 @@
+{{/* Add support for displaying chemical equations and physical units by loading the mhchem extension: */ -}}
+{{ $mhchem_url := printf "https://cdn.jsdelivr.net/npm/katex@%s/dist/contrib/mhchem.min.js" .version -}}
+{{ with resources.GetRemote $mhchem_url -}}
+  {{ with .Err -}}
+    {{ errorf "Could not retrieve mhchem script from CDN. Reason: %s." . -}}
+  {{ else -}}
+    {{ $secureJS := . | resources.Fingerprint "sha512" -}}
+<script defer src="{{- .RelPermalink -}}" integrity="{{- $secureJS.Data.Integrity -}}" crossorigin="anonymous" ></script>    
+  {{ end -}}
+{{ else -}}
+  {{ errorf "Invalid KaTeX version %s, could not retrieve this version from CDN." .version -}}
+{{ end -}}

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -81,14 +81,8 @@ markup:
       passthrough:
         enable: true
         delimiters:
-          block:
-          - - \[
-            - \]
-          - - $$
-            - $$
-          inline:
-          - - \(
-            - \)
+          block: [['\[', '\]'], ['$$', '$$']]
+          inline: [['\(', '\)']]
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -43,7 +43,7 @@ The probability of getting \(k\) heads when flipping \(n\) coins is:
 \tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 ````
-Both standard syntax and `math` block renders to the same formula:
+Both standard syntax and `math` block render to the same formula:
 
 The probability of getting \(k\) heads when flipping \(n\) coins is:
 ```math
@@ -51,7 +51,7 @@ The probability of getting \(k\) heads when flipping \(n\) coins is:
 ```
 
 {{% alert title="Attention" color="warning" %}}
-In order to display mathematical formulae and/or chemical equations inside your page(s), you need to run hugo version 0.141.0 or above. With older hugo versions, an error is thrown.
+In order to display mathematical formulae and/or chemical equations in your page(s), you need to run Hugo version 0.141.0 or above. With older Hugo versions, an error is thrown.
 {{% /alert %}}
 
 {{% alert title="Tip" %}}
@@ -60,7 +60,7 @@ This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-de
 
 ### \(\LaTeX\) typesetting using standard syntax
 
-As of hugo v0.122, \(\LaTeX\) you can enable typesetting in Markdown using the standard syntax. To do so, you have make use of the goldmark `passthrough` extension inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
+As of Hugo v0.122, \(\LaTeX\) you can enable typesetting in Markdown using the standard syntax. To do so, you need to use of the goldmark `passthrough` extension inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
@@ -117,7 +117,7 @@ markup:
 {{< /tab >}}
 {{< /tabpane >}}
 
-You may alter this definition according to your needs. For details, please refer to the official [hugo docs](https://gohugo.io/content-management/mathematics/#step-1).
+You can edit this definition to meet your own needs. For details, see the official [Hugo docs](https://gohugo.io/content-management/mathematics/#step-1).
 
 ### Activating and configuring \(\KaTeX\) support
 
@@ -172,7 +172,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-By default, docsy pulls in the latest officially released version of \(\KaTeX\) / mhchem extension at build time. If that doesn't fit your needs, you can specify the wanted \(\KaTeX\) version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+By default, Docsy pulls in the latest officially released version of \(\KaTeX\) / mhchem extension at build time. If that doesn't fit your needs, you can specify the \(\KaTeX\) version you want in your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -471,24 +471,24 @@ sequenceDiagram
 
 Support of Mermaid diagrams is automatically enabled as soon as you use a `mermaid` code block on your page.
 
-By default, docsy pulls in the latest officially released version of Mermaid at build time. If that doesn't fit your needs, you can specify the wanted mermaid version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+By default, Docsy pulls in the latest officially released version of Mermaid at build time. If that doesn't fit your needs, you can specify the wanted mermaid version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 [params.mermaid]
-version = "10.9.0"
+version = "11.4.1"
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
 params:
   mermaid:
-    version: 10.9.0
+    version: 11.4.1
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
   "params": {
     "mermaid": {
-      "version": "10.9.0"
+      "version": "11.4.1"
     }
   }
 }

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -6,66 +6,134 @@ math: true
 chem: true
 ---
 
-Docsy has built-in support for a number of diagram creation and typesetting tools you can use to add rich content to your site, including \\(\KaTeX\\), Mermaid, Diagrams.net, PlantUML, and MarkMap.
+Docsy has built-in support for a number of diagram creation and typesetting tools you can use to add rich content to your site, including \(\KaTeX\), Mermaid, Diagrams.net, PlantUML, and MarkMap.
 
-## \\(\LaTeX\\) support with \\(\KaTeX\\)
+## \(\LaTeX\) support with \(\KaTeX\)
 
-[\\(\LaTeX\\)](https://www.latex-project.org/) is a high-quality typesetting system for the production of technical and scientific documentation. Due to its excellent math typesetting capabilities, \\(\TeX\\) became the de facto standard for the communication and publication of scientific documents, especially if these documents contain a lot of mathematical formulae. Designed and mostly written by Donald Knuth, the initial version was released in 1978. Dating back that far, \\(\LaTeX\\) has `pdf` as its primary output target and is not particularly well suited for producing HTML output for the Web. Fortunately, with [\\(\KaTeX\\)](https://katex.org/) there exists a fast and easy-to-use JavaScript library for \\(\TeX\\) math rendering on the web, which was integrated into the Docsy theme.
+[\(\LaTeX\)](https://www.latex-project.org/) is a high-quality typesetting system for the production of technical and scientific documentation. Due to its excellent math typesetting capabilities, \(\TeX\) became the de facto standard for the communication and publication of scientific documents, especially if these documents contain a lot of mathematical formulae. Designed and mostly written by Donald Knuth, the initial version was released in 1978. Dating back that far, \(\LaTeX\) has `pdf` as its primary output target and is not particularly well suited for producing HTML output for the Web. Fortunately, with [\(\KaTeX\)](https://katex.org/) there exists a fast and easy-to-use JavaScript library for \(\TeX\) math rendering on the web, which was integrated into the Docsy theme.
 
-With \\(\KaTeX\\) support [enabled](#activating-and-configuring-katex-support) in Docsy, you can include complex mathematical formulae into your web page, either inline or centred on its own line. Since \\(\KaTeX\\) relies on server side rendering, it produces the same output regardless of your browser or your environment. Formulae can be shown either inline or in display mode:
+With \(\KaTeX\) support [enabled](#activating-and-configuring-katex-support) in Docsy, you can include complex mathematical formulae into your web page, either inline or centred on its own line. Since \(\KaTeX\) relies on server side rendering, it produces the same output regardless of your browser or your environment. Formulae can be shown either inline or in display mode:
 
 ### Inline formulae
 
 The following code sample produces a text line with three inline formulae:
 
 ```tex
-When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c= 0\\) and they are \\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\\).
+When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c= 0\) and they are \(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\).
 ```
 
-When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c= 0\\) and they are \\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\\).
+When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c= 0\) and they are \(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\).
 
 ### Formulae in display mode
 
 The following code sample produces an introductory text line followed by a formula numbered as `(1)` residing on its own line:
 
 ````markdown
-The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
+The probability of getting \(k\) heads when flipping \(n\) coins is:
+\[
+\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
+\]
+````
+
+As an alternative to the standard syntax used above, formulae can also be authored using a [GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math):
+
+````markdown
+The probability of getting \(k\) heads when flipping \(n\) coins is:
 ```math
 \tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 ````
+Both standard syntax and `math` block renders to the same formula:
 
-The formula itself is written inside a [GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math). The above code fragment renders to:
-
-The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
+The probability of getting \(k\) heads when flipping \(n\) coins is:
 ```math
 \tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 
 {{% alert title="Warning" color="warning" %}}
-`math` code blocks are only supported as of hugo version 0.93.
-
-In case of hugo version 0.92 or lower, use this code snippet to display the formula:
-```tex
-$$
-\tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
-$$
-```
+`math` code blocks are supported as of hugo version 0.93, using the standard syntax is possible as of hugo version 0.122.
 {{% /alert %}}
 
 {{% alert title="Tip" %}}
-This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth information about typesetting mathematical formulae using the \\(\LaTeX\\) typesetting system.
+This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth information about typesetting mathematical formulae using the \(\LaTeX\) typesetting system.
 {{% /alert %}}
 
-### Activating and configuring \\(\KaTeX\\) support
+### \(\LaTeX\) typesetting using standard syntax
+
+As of hugo v0.122, \(\LaTeX\) you can enable typesetting in Markdown using the standard syntax. To do so, you have make use of the goldmark `passthrough` extension inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
+
+{{< tabpane >}}
+{{< tab header="Site configuration file:" disabled=true />}}
+{{< tab header="hugo.toml" lang="toml" >}}
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
+{{< /tab >}}
+{{< tab header="hugo.yaml" lang="yaml" >}}
+markup:
+  goldmark:
+    extensions:
+      passthrough:
+        enable: true
+        delimiters:
+          block:
+          - - \[
+            - \]
+          - - $$
+            - $$
+          inline:
+          - - \(
+            - \)
+{{< /tab >}}
+{{< tab header="hugo.json" lang="json" >}}
+{
+   "markup": {
+      "goldmark": {
+         "extensions": {
+            "passthrough": {
+               "delimiters": {
+                  "block": [
+                     [
+                        "\\[",
+                        "\\]"
+                     ],
+                     [
+                        "$$",
+                        "$$"
+                     ]
+                  ],
+                  "inline": [
+                     [
+                        "\\(",
+                        "\\)"
+                     ]
+                  ]
+               },
+               "enable": true
+            }
+         }
+      }
+   }
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+You may alter this definition according to your needs. For details, please refer to the official [hugo docs](https://gohugo.io/content-management/mathematics/#step-1).
+
+### Activating and configuring \(\KaTeX\) support
 
 #### Auto activation
 
-As soon as you use a `math` code block on your page, support of \\(\KaTeX\\) is automatically enabled.
+As soon as you use a `math` code block on your page, support of \(\KaTeX\) is automatically enabled.
 
-#### Manual activation (no `math` code block present or hugo 0.92 or lower)
+#### Manual activation (use of standard syntax, no `math` code block present)
 
-If you want to use inline formulae and don't have a `math` code block present in your page which triggers auto activation, you need to manually activate \\(\KaTeX\\) support. The easiest way to do so is to add a `math` attribute to the frontmatter of your page and set it to `true`:
+If you want to use formulae (block or inline) and don't have a `math` code block present in your page which triggers auto activation, you need to manually activate \(\KaTeX\) support. The easiest way to do so is to add a `math` attribute to the frontmatter of your page and set it to `true`:
 
 {{< tabpane >}}
 {{< tab header="Page front matter:" disabled=true />}}
@@ -86,7 +154,7 @@ math: true
 {{< /tab >}}
 {{< /tabpane >}}
 
-If you use formulae in most of your pages, you can also enable sitewide \\(\KaTeX\\) support inside the Docsy theme. To do so update `hugo.toml`/`hugo.yaml`/`hugo.json`:
+If you use formulae in most of your pages, you can also enable sitewide \(\KaTeX\) support inside the Docsy theme. To do so update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
@@ -110,7 +178,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-Additionally, you can customize various \\(\KaTeX\\) options inside `hugo.toml`/`hugo.yaml`/`hugo.json`, if needed:
+Additionally, you can customize various \(\KaTeX\) options inside `hugo.toml`/`hugo.yaml`/`hugo.json`, if needed:
 
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
@@ -222,19 +290,31 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-For a complete list of options and their detailed description, have a look at the documentation of \\({\KaTeX}\\)'s [Rendering API options](https://katex.org/docs/autorender.html#api) and of \\({\KaTeX}\\)'s [configuration options](https://katex.org/docs/options.html).
+{{% alert title="Note" %}}
+If you define custom delimiters, please make sure they match with the delimiters defined [above](#latex-typesetting-using-standard-syntax) as passthrough extension.
+{{% /alert %}}
+
+For a complete list of options and their detailed description, have a look at the documentation of \({\KaTeX}'s\) [Rendering API options](https://katex.org/docs/autorender.html#api) and of \({\KaTeX}'s\) [configuration options](https://katex.org/docs/options.html).
 
 ### Display of Chemical Equations and Physical Units
 
-[mhchem](https://www.ctan.org/pkg/mhchem) is a \\(\LaTeX\\) package for typesetting chemical molecular formulae and equations. Fortunately, \\(\KaTeX\\) provides the `mhchem` [extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes the `mhchem` package accessible when authoring content for the web. With `mhchem` extension [enabled](#activating-rendering-support-for-chemical-formulae), you can easily include chemical equations into your page. An equation can be shown either inline or can reside on its own line. The following code sample produces a text line including a chemical equation:
+[mhchem](https://www.ctan.org/pkg/mhchem) is a \(\LaTeX\) package for typesetting chemical molecular formulae and equations. Fortunately, \(\KaTeX\) provides the `mhchem` [extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes the `mhchem` package accessible when authoring content for the web. With `mhchem` extension [enabled](#activating-rendering-support-for-chemical-formulae), you can easily include chemical equations into your page. An equation can be shown either inline or can reside on its own line. The following code sample produces a text line including a chemical equation:
 
 ```mhchem
-*Precipitation of barium sulfate:* \\(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\\)
+*Precipitation of barium sulfate:* \(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\)
 ```
 
-*Precipitation of barium sulfate:* \\(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\\)
+*Precipitation of barium sulfate:* \(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\)
 
-More complex equations need to be displayed on their own line. Use a code block adorned with `chem` in order to achieve this:
+More complex equations can be displayed on their own line using the block delimiters defined:
+
+````markdown
+\[
+\tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
+\]
+````
+
+Alternatively, you can use a code block adorned with `chem` in order to render the equation:
 
 ````markdown
 ```chem
@@ -242,34 +322,29 @@ More complex equations need to be displayed on their own line. Use a code block 
 ```
 ````
 
-```chem
+Both standard syntax and `chem` block renders to the same equation:
+
+\[
 \tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
-```
+\]
 
 {{% alert title="Warning" color="warning" %}}
-`chem` code blocks are only supported as of hugo version 0.93.
-
-In case of hugo version 0.92 or lower, use this code snippet to display the formula:
-```tex
-$$
-\tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
-$$
-```
+`chem` code blocks are supported as of hugo version 0.93, using the standard syntax is possible as of hugo version 0.122.
 {{% /alert %}}
 
 {{% alert title="Note" %}}
 The [manual](https://mhchem.github.io/MathJax-mhchem/) for mchem’s input syntax provides in-depth information about typesetting chemical formulae and physical units using the `mhchem` tool.
 {{% /alert %}}
 
-Use of `mhchem` is not limited to the authoring of chemical equations, using the included `\pu` command, pretty looking physical units can be written with ease, too. The following code sample produces two text lines with four numbers plus their corresponding physical units:
+Use of `mhchem` is not limited to the authoring of chemical equations. By using the included `\pu` command, pretty looking physical units can be written with ease, too. The following code sample produces two text lines with four numbers plus their corresponding physical units:
 
 ```mhchem
-* Scientific number notation: \\(\pu{1.2e3 kJ}\\) or \\(\pu{1.2E3 kJ}\\) \\
-* Divisions: \\(\pu{123 kJ/mol}\\) or \\(\pu{123 kJ//mol}\\)
+* Scientific number notation: \(\pu{1.2e3 kJ}\) or \(\pu{1.2E3 kJ}\) \\
+* Divisions: \(\pu{123 kJ/mol}\) or \(\pu{123 kJ//mol}\)
 ```
 
-* Scientific number notation: \\(\pu{1.2e3 kJ}\\) or \\(\pu{1.2E3 kJ}\\)
-* Divisions: \\(\pu{123 kJ/mol}\\) or \\(\pu{123 kJ//mol}\\)
+* Scientific number notation: \(\pu{1.2e3 kJ}\) or \(\pu{1.2E3 kJ}\)
+* Divisions: \(\pu{123 kJ/mol}\) or \(\pu{123 kJ//mol}\)
 
 For a complete list of options when authoring physical units, have a look at the [section](https://mhchem.github.io/MathJax-mhchem/#pu) on physical units in the `mhchem` documentation.
 
@@ -279,7 +354,7 @@ For a complete list of options when authoring physical units, have a look at the
 
 As soon as you use a `chem` code block on your page, rendering support for chemical equations is automatically enabled.
 
-##### Manual activation (no `chem` code block present or hugo 0.92 or lower)
+##### Manual activation (use of standard syntax, no `chem` code block present)
 
 If you want to use chemical formulae inline and don't have a `chem` code block present in your page which triggers auto activation, you need to manually activate rendering support for chemical formulae. The easiest way to do so is to add a `chem` attribute to the frontmatter of your page and set it to `true`:
 

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -50,8 +50,8 @@ The probability of getting \(k\) heads when flipping \(n\) coins is:
 \tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 
-{{% alert title="Warning" color="warning" %}}
-`math` code blocks are supported as of hugo version 0.93, using the standard syntax is possible as of hugo version 0.122.
+{{% alert title="Attention" color="warning" %}}
+In order to display mathematical formulae and/or chemical equations inside your page(s), you need to run hugo version 0.141.0 or above. With older hugo versions, an error is thrown.
 {{% /alert %}}
 
 {{% alert title="Tip" %}}
@@ -166,6 +166,30 @@ params:
   "params": {
     "katex": {
       "enable": true
+    }
+  }
+}
+{{< /tab >}}
+{{< /tabpane >}}
+
+By default, docsy pulls in the latest officially released version of \(\KaTeX\) / mhchem extension at build time. If that doesn't fit your needs, you can specify the wanted \(\KaTeX\) version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+
+{{< tabpane >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="hugo.toml" lang="toml" >}}
+[params.katex]
+version = "0.16.21"
+{{< /tab >}}
+{{< tab header="hugo.yaml" lang="yaml" >}}
+params:
+  mermaid:
+    version: 0.16.21
+{{< /tab >}}
+{{< tab header="hugo.json" lang="json" >}}
+{
+  "params": {
+    "mermaid": {
+      "version": "0.16.21"
     }
   }
 }
@@ -322,10 +346,6 @@ Both standard syntax and `chem` block renders to the same equation:
 \tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
 \]
 
-{{% alert title="Warning" color="warning" %}}
-`chem` code blocks are supported as of hugo version 0.93, using the standard syntax is possible as of hugo version 0.122.
-{{% /alert %}}
-
 {{% alert title="Note" %}}
 The [manual](https://mhchem.github.io/MathJax-mhchem/) for mchem’s input syntax provides in-depth information about typesetting chemical formulae and physical units using the `mhchem` tool.
 {{% /alert %}}
@@ -342,7 +362,7 @@ Use of `mhchem` is not limited to the authoring of chemical equations. By using 
 
 For a complete list of options when authoring physical units, have a look at the [section](https://mhchem.github.io/MathJax-mhchem/#pu) on physical units in the `mhchem` documentation.
 
-#### Activating rendering support for chemical formulae
+#### Activating rendering support for chemical equations
 
 ##### Auto activation
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -33,6 +33,18 @@ markup:
     parser:
       attribute:
         block: true
+    extensions:
+      passthrough:
+        enable: true
+        delimiters:
+          block:
+          - - \[
+            - \]
+          - - $$
+            - $$
+          inline:
+          - - \(
+            - \)
     renderer:
       unsafe: true
   highlight:
@@ -119,6 +131,10 @@ params:
     enable: true
   drawio:
     enable: true
+  katex:
+    enable: false
+    mhchem:
+      enable: false
 
 taxonomies:
   tag: tags

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -47,6 +47,18 @@ markup:
             - \)
     renderer:
       unsafe: true
+    extensions:
+      passthrough:
+        enable: true
+        delimiters:
+          block:
+          - - \[
+            - \]
+          - - $$
+            - $$
+          inline:
+          - - \(
+            - \)
   highlight:
     noClasses: false # Required for dark-mode
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -37,28 +37,10 @@ markup:
       passthrough:
         enable: true
         delimiters:
-          block:
-          - - \[
-            - \]
-          - - $$
-            - $$
-          inline:
-          - - \(
-            - \)
+          block: [['\[', '\]'], ['$$', '$$']]
+          inline: [['\(', '\)']]
     renderer:
       unsafe: true
-    extensions:
-      passthrough:
-        enable: true
-        delimiters:
-          block:
-          - - \[
-            - \]
-          - - $$
-            - $$
-          inline:
-          - - \(
-            - \)
   highlight:
     noClasses: false # Required for dark-mode
 
@@ -143,10 +125,6 @@ params:
     enable: true
   drawio:
     enable: true
-  katex:
-    enable: false
-    mhchem:
-      enable: false
 
 taxonomies:
   tag: tags


### PR DESCRIPTION
This PR closes #1837 by addressing all four tasks listed in this issue.

The first commit alters the way the scripts are retrieved (now: at build time) and allows for custom KaTeX versions while bringing in the latest version by default.
The second commit updates and extends the section [LaTe​X support with KaTe​X](https://www.docsy.dev/docs/adding-content/diagrams-and-formulae/#latex-support-with-katex) of user guide. This chapter now describes how one can do [LaTeX or TeX typsetting](https://gohugo.io/content-management/mathematics) directly from Markdown using standard syntax (needs hugo v0.122 or above).
There are no breaking changes introduced with this PR.

You may have a look at the **preview on [Netlify](https://deploy-preview-1858--docsydocs.netlify.app/docs/adding-content/diagrams-and-formulae/#latex-support-with-katex).**
