### PR TITLE
Post 0.9.0 work - set vers to `0.9.1-dev*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Useful links:
 [releases]: https://github.com/google/docsy/releases
 [tags]: https://github.com/google/docsy/tags
 
+## 0.9.1 or 0.10.0
+
+> ### UNRELEASED: this planned version is still under development
+
+For the full list of changes, see the [0.x.y] release notes.
+
+**Breaking changes**:
+
+- ...
+
+**New**:
+
+**Other changes**:
+
+[0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+
 ## 0.9.0
 
 For an introduction and commentary, see the [0.9.0 release report]. For the full
@@ -59,7 +75,7 @@ For details concerning all footer changes, see [#1818].
   ([#1410]).
 - [Look and feel] updates.
 
-[0.9.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.9.0
+[0.9.0]: https://github.com/google/docsy/releases/v0.9.0
 [0.9.0 release report]: https://www.docsy.dev/blog/2024/0.9.0/
 [#1410]: https://github.com/google/docsy/pull/1410
 [#1744]: https://github.com/google/docsy/pull/1744

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,8 @@ repo.
     git tag $REL
     ```
 
-11. **Push the new tags** to the main repo, which is named `upstream` in the
-    following example:
+11. **Push the new tags** to the main remote (`origin` or `upstream` depending
+    on your setup):
 
     ```console
     $ git push upstream $REL
@@ -93,7 +93,8 @@ repo.
       ```markdown
       ## Release summary
 
-      See, https://github.com/google/docsy/blob/main/CHANGELOG.md#0XY
+      - [Release report](https://www.docsy.dev/blog/2024/0.X.Y/)
+      - [CHANGELOG](https://github.com/google/docsy/blob/main/CHANGELOG.md#0XY)
       ```
 
     - Select **Create a discussion for this release**.
@@ -118,7 +119,7 @@ further changes are merged into the default branch:
    - **Pin the 0.X.Y release URL**, which ends with `latest?FIXME=...`, to the
      v0.X.Y release at `https://github.com/google/docsy/releases/v0.x.y`.
 3. **Submit a PR with your changes**, using a title like "Set NPM package
-   version to next unreleased dev".
+   version to next unreleased dev vers".
 4. **Get PR approved and merged**.
 
 [CHANGELOG]: CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "docsy",
-  "version": "0.9.0",
+  "version": "0.9.1-dev.0-unreleased",
+  "version.next": "0.9.2-dev.0-unreleased",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Results of [Post-release followup](https://github.com/google/docsy/blob/main/CONTRIBUTING.md#post-release-followup) following #1759