### PR TITLE
Section-index: ensure .Parent isn't nil

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -4,7 +4,7 @@
     {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
     {{ $pages = (where $pages ".Parent" "!=" nil) -}}
-    {{ if .Parent.File -}}
+    {{ if and .Parent .Parent.File -}}
         {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
     {{ end -}}
     {{ if or $parent.Params.no_list (eq (len $pages) 0) -}}


### PR DESCRIPTION
- Follow up to #1633
- Fixes #1863

To test, I ran the following from a local docsy repo:

```console 
$ mkdir tmp
$ cd tmp
$ ../tools/make-site.sh -s HUGO_MODULE
$ echo "---\ntitle: Hello\ntype: docs\n---\nPlaceholder" > content/_index.md
$ hugo # building or serving seems fine now
```

Without the fix in this PR, the commands above yield the error reported in #1863.