### PR TITLE
WIP: Adds optional banner hooks for docs and blog pages

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -19,6 +19,14 @@
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
           <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ if .Page.Params.banner }}
+              {{ if .Page.Params.banner_file }}
+                {{ $bannerfile := printf "hooks/%s" $.Page.Params.banner_file }}
+                {{ partial $bannerfile . }}
+              {{ else }}
+                {{ partial "hooks/banner.html" . }}
+              {{ end }}
+            {{ end }}
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="td-rss-button" title="RSS" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
               <i class="fa-solid fa-rss" aria-hidden="true"></i>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -20,6 +20,14 @@
           </aside>
           <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
             {{ partial "version-banner.html" . }}
+            {{ if .Page.Params.banner }}
+              {{ if .Page.Params.banner_file }}
+                {{ $bannerfile := printf "hooks/%s" $.Page.Params.banner_file }}
+                {{ partial $bannerfile . }}
+              {{ else }}
+                {{ partial "hooks/banner.html" . }}
+              {{ end }}
+            {{ end }}
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
           </main>


### PR DESCRIPTION
Makes it possible to optionally add banners to the top of the doc and blog pages, just above the content.

NOTE: I haven't updated the userguide yet, will do it if the users who reported the related issues think this PR is good enough to solve their problem.

Related issues: https://github.com/google/docsy/issues/1784 and https://github.com/google/docsy/issues/1773

To trigger the banner, you have to:

1. Create a file in your project called `layouts/partials/hooks/banner.html`
2. Add the HTML code you want in the banner to appear
3. Set the `banner: yes` parameter in the frontmatter of the page you want the banner on.

If you want to use multiple different banners in your docs, you can create multiple files like:  `layouts/partials/hooks/<custom-banner-filename>`, and set `banner: yes` and `banner_file: <custom-banner-filename>` in the frontmatter to display the specified file as banner. Note that currently only one banner can be displayed on a page 