### PR TITLE
Address GA.ID param deprecation warning

### DIFF
--- a/layouts/_internal/google_analytics_gtag.html
+++ b/layouts/_internal/google_analytics_gtag.html
@@ -6,19 +6,19 @@
 
   specifically this version:
 
-  https://github.com/gohugoio/hugo/blob/f7e00c039ff3cea5f991b05c1e325666004cf129/tpl/tplimpl/embedded/templates/google_analytics.html
+  https://github.com/gohugoio/hugo/blob/8d32ca223def4031aa26f98e8efc1a8b4e7b7546/tpl/tplimpl/embedded/templates/google_analytics.html
 
   The only differences between this copy and the original are that we've dropped:
 
   - The `{{ if hasPrefix . "G-"}}` condition
-  - The `{{ else }}` block
+  - The `{{ else ... }}` block
   - The `anonymize_ip` argument to the `gtag()` call, since it is superfluous.
     For details, see https://github.com/gohugoio/hugo/issues/10093.
 
 */}}
 
 {{- $pc := .Site.Config.Privacy.GoogleAnalytics -}}
-{{- if not $pc.Disable }}{{ with .Site.GoogleAnalytics -}}
+{{- if not $pc.Disable }}{{ with .Site.Config.Services.GoogleAnalytics.ID -}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>
 {{ template "__ga_js_set_doNotTrack" $ }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,7 +47,7 @@
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
   {{ $enableGtagForUniversalAnalytics := not .Site.Params.disableGtagForUniversalAnalytics -}}
-  {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.GoogleAnalytics "G-")) -}}
+  {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.Config.Services.GoogleAnalytics.ID "G-")) -}}
     {{ template "_internal/google_analytics_gtag.html" . -}}
   {{ else -}}
     {{ template "_internal/google_analytics_async.html" . -}}

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -57,17 +57,21 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 
-{{% alert title="Warning" color="warning" %}}
+{{% alert title="Deprecation note and warning" color="warning" %}}
   <!-- Remove this warning once the Hugo docs have been updated to include it. -->
 
-  You can configure your project's analytics ID by setting either the top-level
-  `googleAnalytics` config parameter or `services.googleAnalytics.id`. **Do not
-  define both,** otherwise this can result in [unexpected behavior][]. For
-  details, see [Is services.googleAnalytics.id an alias for
+  While you can configure your project's analytics ID by setting either the
+  top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,
+  **`googleAnalytics` was [deprecated in Hugo 0.120.0][v0.120.0]** and
+  will be removed in a future release.
+
+  **Do not define both parameters,** otherwise this can result in [unexpected
+  behavior][]. For details, see [Is services.googleAnalytics.id an alias for
   googleAnalytics][alias-discussion].
 
   [alias-discussion]: https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469
   [unexpected behavior]: https://github.com/google/docsy/issues/921
+  [v0.120.0]: https://github.com/gohugoio/hugo/releases/tag/v0.120.0
 
 {{% /alert %}}
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -28,10 +28,6 @@ menu:
       post: <sup><i class="ps-1 fa-solid fa-up-right-from-square fa-xs"
         aria-hidden="true"></i></sup>
 
-services:
-  googleAnalytics:
-    # id: G-XXXXXXXXX # Waiting on https://github.com/google/docsy/issues/1097
-
 languages:
   en:
     languageName: English


### PR DESCRIPTION
- Switches to use of `.Site.Config.Services.GoogleAnalytics.ID`
- Updates UG to mention deprecation warning
- Fixes #1878
- **Preview**: https://deploy-preview-1879--docsydocs.netlify.app/docs/adding-content/feedback/#setup