### PR TITLE
Fix section index partial NPE

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -4,7 +4,8 @@
     {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
     {{ $pages = (where $pages ".Parent" "!=" nil) -}}
-    {{ if and .Parent .Parent.File -}}
+    {{ $pages = (where $pages ".Parent.File" "!=" nil) -}}
+    {{ if and $parent $parent.File -}}
         {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
     {{ end -}}
     {{ if or $parent.Params.no_list (eq (len $pages) 0) -}}


### PR DESCRIPTION
During rendering the section index of a docs list it could happen that a file has no parent for e.g. the homepage. If such scenario is existing the .Parent.File of a file is nil. Therefore this case should be handled within the rendering itself.

Fixes #1874