### PR TITLE
[BS5.3] Replace text-muted by text-body-secondary

### DIFF
--- a/assets/js/offline-search.js
+++ b/assets/js/offline-search.js
@@ -145,7 +145,7 @@
           const $entry = $('<div>').addClass('mt-4');
 
           $entry.append(
-            $('<small>').addClass('d-block text-muted').text(r.ref)
+            $('<small>').addClass('d-block text-body-secondary').text(r.ref)
           );
 
           $entry.append(

--- a/assets/scss/_pageinfo.scss
+++ b/assets/scss/_pageinfo.scss
@@ -17,7 +17,7 @@
 
 .td-page-meta {
   &__lastmod {
-    @extend .text-muted;
+    @extend .text-body-secondary;
     @extend .border-top;
     margin-top: map-get($spacers, 5) !important;
     padding-top: map-get($spacers, 3) !important;

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -3,7 +3,7 @@
 	{{ with .Params.description }}<div class="lead">{{ . | markdownify }}</div>{{ end }}
 	<div class="td-byline mb-4">
 		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
-		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-muted">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
+		<time datetime="{{  $.Date.Format "2006-01-02" }}" class="text-body-secondary">{{ $.Date.Format $.Site.Params.time_format_blog  }}</time>
 	</div>
 	<header class="article-meta">
 		{{ partial "taxonomy_terms_article_wrapper.html" . -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -15,7 +15,7 @@
       <li class="td-blog-posts-list__item">
         <div class="td-blog-posts-list__body">
           <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
-          <p class="mb-2 mb-md-3"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+          <p class="mb-2 mb-md-3"><small class="text-body-secondary">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
           <header class="article-meta">
             {{ partial "taxonomy_terms_article_wrapper.html" . -}}
             {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}

--- a/layouts/partials/featured-image.html
+++ b/layouts/partials/featured-image.html
@@ -8,7 +8,7 @@
 <figure class="{{ $class }}" style="width: {{ $image.Width }}px">
 <img src="{{ $image.RelPermalink }}" alt="Featured Image for {{ $p.Title }}" width="{{ $image.Width }}" height="{{ $image.Height }}">
 {{ with $image.Params.byline }}
- <figcaption class="mt-2 mt-md-0"><small class="text-muted">{{ . | html }}</small></figcaption>
+ <figcaption class="mt-2 mt-md-0"><small class="text-body-secondary">{{ . | html }}</small></figcaption>
 {{ end }}
 </figure>
 {{ end }}

--- a/layouts/partials/print/content-blog.html
+++ b/layouts/partials/print/content-blog.html
@@ -6,7 +6,7 @@
 	<div class="td-byline mb-4">
 		{{ with .Params.author }}{{ T "post_byline_by" }} <b>{{ . | markdownify }}</b> |{{ end}}
         {{if .Date }}
-		<time datetime="{{  .Date.Format "2006-01-02" }}" class="text-muted">{{ .Date.Format .Site.Params.time_format_blog  }}</time>
+		<time datetime="{{  .Date.Format "2006-01-02" }}" class="text-body-secondary">{{ .Date.Format .Site.Params.time_format_blog  }}</time>
         {{ end }}
 	</div>
 	{{ .Content }}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -25,7 +25,7 @@
       </h5>
     {{ end -}}
     {{ with $.Get "subtitle" -}}
-      <h6 class="card-title ms-2 text-muted">
+      <h6 class="card-title ms-2 text-body-secondary">
         {{ . | markdownify -}}
       </h6>
     {{ end -}}

--- a/layouts/shortcodes/imgproc.html
+++ b/layouts/shortcodes/imgproc.html
@@ -20,7 +20,7 @@
 <figcaption class="card-body px-0 pt-2 pb-0">
 <p class="card-text">
 {{/* Do **not** remove this comment! It ends above html block! See https://spec.commonmark.org/0.30/#html-blocks, 7. */}}
-{{ . }}{{ with $image.Params.byline }}<small class="text-muted"><br/>{{ . }}</small>{{ end }}
+{{ . }}{{ with $image.Params.byline }}<small class="text-body-secondary"><br/>{{ . }}</small>{{ end }}
 </p>
 </figcaption>
 {{ end -}}


### PR DESCRIPTION
-  Replaces use of `.text-muted` by `.text-body-secondary` 
- Contributes to #1528

**Preview**:

- https://deploy-preview-1892--docsydocs.netlify.app/docs/ -- see pageinfo at the base of the page
- https://deploy-preview-1892--docsydocs.netlify.app/blog
