### PR TITLE
[BS5.3] Replace `.navbar-dark` by data attribute and other style adjustments

### DIFF
--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -27,7 +27,7 @@
     // Styling adjustments for the navbar
     @at-root {
       .td-navbar & {
-        color: $navbar-dark-color;
+        color: inherit;
       }
     }
   }
@@ -44,17 +44,17 @@
     &.form-control:focus {
       border-color: tint-color($primary, 95%);
       box-shadow: 0 0 0 2px tint-color($primary, 40%);
-      color: inherit;
+      color: initial;
     }
 
     // Styling adjustments for the navbar
     @at-root {
       .td-navbar & {
         border: none;
-        color: $navbar-dark-color;
+        color: inherit;
 
         @include placeholder {
-          color: $navbar-dark-color;
+          color: inherit;
         }
       }
     }

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -82,11 +82,6 @@ $td-block-space-bottom-base: 4 * $spacer !default;
 $pagination-color: $gray-600 !default; // TODO: consider using BS default
 $pagination-disabled-color: $gray-300 !default; // TODO: consider using BS default
 
-// Navbar
-
-$navbar-dark-color: rgba($white, 0.75) !default;      // TODO: consider moving into UG SCSS
-$navbar-dark-hover-color: rgba($white, 0.5) !default; // TODO: consider moving into UG SCSS
-
 // Footer
 
 $list-inline-padding: $spacer;

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,8 +4,8 @@
 -}}
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
 
-<nav class="td-navbar navbar-dark js-navbar-scroll
-            {{- if $cover }} td-navbar-cover {{- end }}">
+<nav class="td-navbar js-navbar-scroll
+            {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
 <div class="container-fluid flex-column flex-md-row">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}


### PR DESCRIPTION
- Contributes to #1528
- Replaces `.navbar-dark` by `data-bs-theme="dark"` data attribute
- Adjusts search element styles to work with the new navbar's dark mode _and_ in the left-nav too (not in dark mode)

**Preview**: https://deploy-preview-1896--docsydocs.netlify.app/docs/

### Screenshots

Light mode (default):

>  <img width="1028" alt="image" src="https://github.com/google/docsy/assets/4140793/690b8733-80bf-41c4-ba0c-d4296b37f70d">

> <img width="1030" alt="image" src="https://github.com/google/docsy/assets/4140793/9d44fb74-d65c-4f51-a8c5-a8c18d21d65c">

Dark mode:

> <img width="1028" alt="image" src="https://github.com/google/docsy/assets/4140793/3f758f65-5006-4eb1-af73-be80987cddcc">

> <img width="1027" alt="image" src="https://github.com/google/docsy/assets/4140793/0499a364-e973-4301-b6f5-fb94785f7ddb">
