### PR TITLE
Support multiple fonts from Google

### DIFF
--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -51,7 +51,7 @@ $td-fonts-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
   "Segoe UI Symbol";
 
 @if $td-enable-google-fonts {
-  $td-fonts-serif: join("#{$google_font_name}", $td-fonts-serif);
+  $td-fonts-serif: join($google_font_name, $td-fonts-serif);
 }
 
 $font-family-sans-serif: $td-fonts-serif !default; // TODO: consider moving into UG SCSS or namespace the var (td-)


### PR DESCRIPTION
Strip interpolation to prevent the font list from being unexpectedly merged into one single string element.

When we have these SCSS variables set in `assets/scss/_variables_project.scss`

```scss
$google_font_name: "Noto Sans", "Noto Sans TC";
$google_font_family: "Noto+Sans:300,300i,400,400i,700,700i|Noto+Sans+TC:300,400,700";
```

Before the patch, we have this in our generated `main.css`

```css
font-family: "Noto Sans, Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
```

and this after the patch

```css
font-family: "Noto Sans", "Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
```

## References

- https://www.docsy.dev/docs/adding-content/lookandfeel/#fonts
- https://developers.google.com/fonts/docs/getting_started#specifying_font_families_and_styles_in_a_stylesheet_url