### PR TITLE
Update Hugo to 0.124.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.123.8",
+    "hugo-extended": "0.124.1",
     "markdown-link-check": "^3.11.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.2.5"


### PR DESCRIPTION
Only whitespace and generator version changes in the generated UG / site files:

```console
$ (cd userguide/public && git diff -bw --ignore-blank-lines)                    
diff --git a/index.html b/index.html
index b4cf1f3..b65e905 100644
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage" lang="en" class="no-js">
   <head>
-       <meta name="generator" content="Hugo 0.123.8">
+       <meta name="generator" content="Hugo 0.124.1">
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="robots" content="noindex, nofollow">
```