### PR TITLE
[Dark-mode] Tweak of param, file and resource names

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,4 +1,8 @@
 /*!
+ * This is a Docsy-adapted version of https://github.com/twbs/examples/blob/main/color-modes/js/color-modes.js.
+ *
+ * Original header:
+ *
  * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
  * Copyright 2011-2024 The Bootstrap Authors
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
@@ -7,8 +11,9 @@
 (() => {
   'use strict'
 
-  const getStoredTheme = () => localStorage.getItem('theme')
-  const setStoredTheme = theme => localStorage.setItem('theme', theme)
+  const themeKey = 'td-color-theme'
+  const getStoredTheme = () => localStorage.getItem(themeKey)
+  const setStoredTheme = theme => localStorage.setItem(themeKey, theme)
 
   const getPreferredTheme = () => {
     const storedTheme = getStoredTheme()

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -91,6 +91,17 @@
       overflow-x: auto;
     }
   }
+
+  // Support for showLightDarkModeMenu:
+  .bi {
+    width: 1em;
+    height: 1em;
+    vertical-align: -.125em;
+    fill: currentcolor;
+  }
+  .td-navbar .dropdown-menu .active .bi {
+    display: block !important
+  }
 }
 
 // Icons

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,18 +4,6 @@
 -}}
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
 
-<style>
-  .bi {
-    width: 1em;
-    height: 1em;
-    vertical-align: -.125em;
-    fill: currentcolor;
-  }
-  .td-navbar .dropdown-menu .active .bi {
-    display: block !important
-  }
-</style>
-
 <nav class="td-navbar js-navbar-scroll
             {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
 <div class="container-fluid flex-column flex-md-row">
@@ -69,7 +57,7 @@
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}
-      {{ if .Site.Params.ui.colorModeEnabled -}}
+      {{ if .Site.Params.ui.showLightDarkModeMenu -}}
       <li class="nav-item dropdown">
         {{ partial "theme-toggler" . }}
       </li>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -74,7 +74,7 @@ window.markmap = {
 {{ end -}}
 
 {{ if .Site.Params.ui.showLightDarkModeMenu -}}
-  {{ $jsArray = $jsArray | append (resources.Get "js/color-mode.js") -}}
+  {{ $jsArray = $jsArray | append (resources.Get "js/dark-mode.js") -}}
 {{ end -}}
 
 {{ $js := $jsArray | resources.Concat "js/main.js" -}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -73,7 +73,7 @@ window.markmap = {
 {{- partial "scripts/mermaid.html" . -}}
 {{ end -}}
 
-{{ if .Site.Params.ui.colorModeEnabled -}}
+{{ if .Site.Params.ui.showLightDarkModeMenu -}}
   {{ $jsArray = $jsArray | append (resources.Get "js/color-mode.js") -}}
 {{ end -}}
 

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -71,7 +71,7 @@ params:
   search:
     # algolia:
   ui:
-    colorModeEnabled: true
+    showLightDarkModeMenu: true
     sidebar_cache_limit: 10
     sidebar_menu_compact: true
     sidebar_menu_foldable: false


### PR DESCRIPTION
- Contributes to #331
- Followup to #1909
- Renames BS color-modes.js to dark-mode.js
- Renames local-storage key so that it's Docsy specific
- Relocates the light/dark-mode drop-down menu styles into the SCSS assets folder
- Renames the config param to `showLightDarkModeMenu`

/cc @geriom 