### PR TITLE
Adjust pageinfo bg to be compatible with dark-mode

### DIFF
--- a/assets/scss/_pageinfo.scss
+++ b/assets/scss/_pageinfo.scss
@@ -1,16 +1,15 @@
 .pageinfo {
   font-weight: $font-weight-medium;
-  background: $gray-100;
+  background: var(--bs-alert-bg);
   color: inherit;
-  border-radius: 0;
-  margin: 2rem;
+  margin: 2rem auto;
   padding: 1.5rem;
   padding-bottom: 0.5rem;
 
   @each $color, $value in $theme-colors {
     &-#{$color} {
-      border-style: solid;
-      border-color: $value;
+      @extend .alert-#{$color};
+      border-width: 0;
     }
   }
 }

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -174,14 +174,14 @@ This is a warning.
 The **pageinfo** shortcode creates a text box that you can use to add banner information for a page: for example, letting users know that the page contains placeholder content, that the content is deprecated, or that it documents a beta feature.
 
 ```go-html-template
-{{%/* pageinfo color="primary" */%}}
+{{%/* pageinfo color="info" */%}}
 This is placeholder content.
 {{%/* /pageinfo */%}}
 ```
 
 Renders to:
 
-{{% pageinfo color="primary" %}}
+{{% pageinfo color="info" %}}
 This is placeholder content
 {{% /pageinfo %}}
 


### PR DESCRIPTION
- Contributes to #331
- Makes the `pageinfo` backgrounds compatible with dark-mode by making them match the alert background.
  - It's tricky to design [dark-mode] compatible colors, and I didn't want to reinvent the wheel, so adopting the [alert component]'s colors and CSS color variable (used for both light and dark modes), seemed like a winning move. 
  - This is a BREAKING CHANGE

**Preview**: https://deploy-preview-1915--docsydocs.netlify.app/docs/adding-content/shortcodes/#pageinfo

[dark-mode]: https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode
[alert component]: https://getbootstrap.com/docs/5.3/components/alerts/

---

## Screenshots (TBC)

### Before

### Light mode

> <img width="750" alt="image" src="https://github.com/google/docsy/assets/4140793/4cc05296-5532-4735-baab-02dd577ad720">

### Dark mode

> <img width="757" alt="image" src="https://github.com/google/docsy/assets/4140793/a92f1d71-89d7-40a8-9f2d-7f4be79d6dc4">

### After

Also notice the tweak in margins.

### Light mode

> <img width="750" alt="image" src="https://github.com/google/docsy/assets/4140793/7e40208a-0038-47fa-b005-40dad345c877">

### Dark mode

> <img width="758" alt="image" src="https://github.com/google/docsy/assets/4140793/a9b5c847-2d30-45bc-8e82-e092e33b5384">

---

p.s. I know that there's `pageinfo` work to be done in the context of #939, but I want to keep focused on wrapping up dark-mode implementation and getting 0.10.0 out.