### PR TITLE
[Dark-mode] Fixes for mobile

### DIFF
--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -54,8 +54,10 @@
     btnToActive.classList.add('active')
     btnToActive.setAttribute('aria-pressed', 'true')
     activeThemeIcon.setAttribute('href', svgOfActiveBtn)
-    const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
-    themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
+    if (themeSwitcherText) {
+      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
+      themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
+    }
 
     if (focus) {
       themeSwitcher.focus()

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -92,15 +92,20 @@
     }
   }
 
-  // Support for showLightDarkModeMenu:
-  .bi {
-    width: 1em;
-    height: 1em;
-    vertical-align: -.125em;
-    fill: currentcolor;
-  }
-  .td-navbar .dropdown-menu .active .bi {
-    display: block !important
+  .td-light-dark-menu {
+    .bi {
+      // Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/_default/examples.html
+      width: 1em;
+      height: 1em;
+      vertical-align: -.125em;
+      fill: currentcolor;
+    }
+
+    &.dropdown {
+      @include media-breakpoint-down(lg) {
+        position: unset;
+      }
+    }
   }
 }
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -58,7 +58,7 @@
       </li>
       {{ end -}}
       {{ if .Site.Params.ui.showLightDarkModeMenu -}}
-      <li class="nav-item dropdown">
+      <li class="td-light-dark-menu nav-item dropdown">
         {{ partial "theme-toggler" . }}
       </li>
       {{ end -}}

--- a/layouts/partials/theme-toggler.html
+++ b/layouts/partials/theme-toggler.html
@@ -27,7 +27,9 @@
         {{ if not $isExamples }}data-bs-display="static"{{ end }}
         aria-label="Toggle theme (auto)">
   <svg class="bi my-1 theme-icon-active"><use href="#circle-half"></use></svg>
-  <span class="{{ if $isExamples }}visually-hidden{{ else }}d-lg-none ms-2{{ end }}" id="bd-theme-text">Toggle theme</span>
+  {{- /* Disable menu name for Docsy:
+    <span class="{{ if $isExamples }}visually-hidden{{ else }}d-lg-none ms-2{{ end }}" id="bd-theme-text">Toggle theme</span>
+  */}}
 </button>
 <ul class="dropdown-menu dropdown-menu-end{{ if $isExamples }} shadow{{ end }}" aria-labelledby="bd-theme-text">
   <li>


### PR DESCRIPTION
- Contributes to #331
- Fixes #1916

**Preview**, e.g.: https://deploy-preview-1917--docsydocs.netlify.app/docs/

## Screenshots

### Before

Note the menu title text (which we don't want). Also the dropdown doesn't drop down, which is why the screenshot doesn't show the dropdown menu open:

> <img width="935" alt="image" src="https://github.com/google/docsy/assets/4140793/785955a7-7072-498d-9f65-313587223d62">

> <img width="518" alt="image" src="https://github.com/google/docsy/assets/4140793/47190fc6-a146-440b-9802-789920a981b1">

### After

> <img width="939" alt="image" src="https://github.com/google/docsy/assets/4140793/116675ae-d980-460e-991e-32619cf7c556">

> <img width="522" alt="image" src="https://github.com/google/docsy/assets/4140793/3b184f57-eea5-40ba-a65e-d8c01888f79f">
