### PR TITLE
[Dark-mode] Firefox search text color fix

### DIFF
--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -44,7 +44,7 @@
     &.form-control:focus {
       border-color: tint-color($primary, 95%);
       box-shadow: 0 0 0 2px tint-color($primary, 40%);
-      color: initial;
+      color: var(--bs-body-color);
     }
 
     // Styling adjustments for the navbar


### PR DESCRIPTION
- Contributes to #331
- Fixes #1906

**Preview**: https://deploy-preview-1918--docsydocs.netlify.app/docs/

Tested with:

- Firefox 124.0.2 (64-bit)
- Safari 17.4.1
- Chrome 123.0.6312.107 (Official Build) (x86_64)

## Screenshots using Firefox

### Before

> <img width="1019" alt="image" src="https://github.com/google/docsy/assets/4140793/2e9f32e6-cda7-4559-8937-e7526a572829">


### After

> <img width="1020" alt="image" src="https://github.com/google/docsy/assets/4140793/df0c98a5-b50c-4c1b-8fe4-0b0d6ffe35d9">

> ![image](https://github.com/google/docsy/assets/4140793/daec3ae0-38b5-4d8a-9028-330b716defba)