### PR TITLE
[Dark-mode] Use default BS nav-item padding

### DIFF
--- a/layouts/partials/theme-toggler.html
+++ b/layouts/partials/theme-toggler.html
@@ -19,7 +19,10 @@
 {{/* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/theme-toggler.html */ -}}
 
 {{ $isExamples := eq .Layout "examples" -}}
-<button class="btn {{ if $isExamples }}btn-bd-primary{{ else }}btn-link nav-link px-0 px-lg-2{{ end }} py-2 dropdown-toggle d-flex align-items-center"
+<button class="btn
+              {{- if $isExamples }} btn-bd-primary
+              {{- else }} btn-link nav-link
+              {{- end }} dropdown-toggle d-flex align-items-center"
         id="bd-theme"
         type="button"
         aria-expanded="false"


### PR DESCRIPTION
- Contributes to #331 
- Drops the BS dropdown `button` padding styles `px-0 px-lg-2 py-2`, in favor of the default BS `nav-link` padding

**Preview**: https://deploy-preview-1919--docsydocs.netlify.app/docs/

### Screenshots

Before:

> <img width="551" alt="image" src="https://github.com/google/docsy/assets/4140793/9dde0705-f460-41ac-8e41-e9987dd437cf">

After:

> <img width="548" alt="image" src="https://github.com/google/docsy/assets/4140793/a5d961f4-0bed-44c4-9c6f-857510942cf4">

