### PR TITLE
[Dark-mode] Tabbed panes fix

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -12,16 +12,16 @@
     }
     margin-top: 0rem;
     margin-bottom: 1.5rem;
-    border-left: 1px solid rgba(0, 0, 0, 0.125);
-    border-right: 1px solid rgba(0, 0, 0, 0.125);
-    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    border-left: $nav-tabs-border-width solid $nav-tabs-border-color;
+    border-right: $nav-tabs-border-width solid $nav-tabs-border-color;
+    border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
   }
 }
 
 .tab-body {
   font-weight: $font-weight-medium;
-  background: $gray-100;
-  color: inherit;
+  background: var(--td-pre-bg);
+  color: var(--bs-body-color);
   border-radius: 0;
   padding: 1.5rem;
 


### PR DESCRIPTION
- Contributes to #331 
- Adjusts tab-pane tab styles so as to be compatible with light & dark modes

**Preview**: https://deploy-preview-1920--docsydocs.netlify.app/docs/adding-content/shortcodes/#tabbed-panes

## Screenshots

### Before (dark mode)

> <img width="1184" alt="image" src="https://github.com/google/docsy/assets/4140793/1ea8d0cc-47c3-4382-a1f7-d68292d28ad6">

### After (dark mode)

> <img width="1186" alt="image" src="https://github.com/google/docsy/assets/4140793/c74b4e8c-3a92-446b-8394-7286824da993">

### Before (light mode)

> <img width="1187" alt="image" src="https://github.com/google/docsy/assets/4140793/843e889c-9fa1-4d22-a588-58f5d394d610">

### After (dark mode) -- same as before

> <img width="1190" alt="image" src="https://github.com/google/docsy/assets/4140793/e93e751d-eecc-4c97-82e5-1534904b8d1e">
