### PR TITLE
[Dark-mode] Card shortcode style fixes

### DIFF
--- a/assets/scss/shortcodes/cards-pane.scss
+++ b/assets/scss/shortcodes/cards-pane.scss
@@ -12,9 +12,13 @@
     }
   }
 
+  .card-header.code {
+    background-color: $card-bg;
+  }
+
   .card-body {
     &.code {
-      background-color: #f8f9fa;
+      background-color: $card-bg;
       padding: 0 0 0 1ex;
     }
 

--- a/layouts/shortcodes/card-code.html
+++ b/layouts/shortcodes/card-code.html
@@ -4,7 +4,7 @@
 
 <div class="td-card card border me-4">
   {{ with $.Get "header" -}}
-    <div class="card-header bg-white">
+    <div class="card-header code">
       {{ . | markdownify -}}
     </div>
   {{ end -}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -14,7 +14,7 @@
 
 <div class="td-card card border me-4">
 {{ with $.Get "header" -}}
-    <div class="card-header{{- cond $code " bg-white" "" -}}">
+    <div class="card-header{{- cond $code " code" "" -}}">
       {{ . | markdownify }}
     </div>
 {{ end -}}


### PR DESCRIPTION
- Contributes to #331 
- Adjusts `card` background styles so as to be compatible with light & dark modes

**Preview**: https://deploy-preview-1922--docsydocs.netlify.app/docs/adding-content/shortcodes/#shortcode-card-programming-code

## Screenshots

Only dark-mode is shown below. The before and after are the same in light mode.

### Before (dark mode)

> <img width="900" alt="image" src="https://github.com/google/docsy/assets/4140793/749fc951-976b-48cb-9213-962e0f000d69">

### After (dark mode)

> <img width="900" alt="image" src="https://github.com/google/docsy/assets/4140793/f84045c9-6082-447d-8381-eb025d207c95">
