### PR TITLE
Bump FontAwesome to latest released version 6.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 // AUTO-GENERATED using `npm run get:hugo-modules`
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536 h1:LFS9LpoSZYhxQ6clU0NIVbaGR08BlxAs4b+9W+7IGVQ=
-github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome userguide ",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.5.1",
+    "@fortawesome/fontawesome-free": "6.5.2",
     "bootstrap": "5.3.3"
   },
   "devDependencies": {

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -23,7 +23,7 @@
     "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.18",
+    "autoprefixer": "^10.4.19",
     "postcss-cli": "^11.0.0"
   }
 }


### PR DESCRIPTION
This PR bumps FontAwesome to latest released version 6.5.2.
It bumps autoprefixer to its latest version on the way, too.