### PR TITLE
Google analytics: drop deprecated async template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,7 +50,7 @@
   {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.Config.Services.GoogleAnalytics.ID "G-")) -}}
     {{ template "_internal/google_analytics_gtag.html" . -}}
   {{ else -}}
-    {{ template "_internal/google_analytics_async.html" . -}}
+    {{ template "_internal/google_analytics.html" . -}}
   {{ end -}}
 {{ end -}}
 


### PR DESCRIPTION
This PR fixes #1930.