### PR TITLE
Fix use of deprecated param .Site.Params.DisqusShortname

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -9,7 +9,7 @@
 	</header>
 	{{ .Content }}
 	{{ partial "feedback.html" . -}}
-	{{ if (.Site.Params.DisqusShortname) -}}
+	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />
 		{{- partial "disqus-comment.html" . -}}
 	{{ end -}}

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -12,7 +12,7 @@
 		{{ end -}}
 	</header>
 	{{ .Content }}
-	{{ if (.Site.Params.DisqusShortname) -}}
+	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />
 		{{- partial "disqus-comment.html" . -}}
 		<br />


### PR DESCRIPTION
This is a follow-up to my merged PR #1895.
It switches to the recommended use of `.Site.Config.Services.Disqus.Shortname` in two more places.
For background info, see: #1894