### PR TITLE
section-index.html code cleanup

### DIFF
--- a/layouts/partials/section-index.html
+++ b/layouts/partials/section-index.html
@@ -1,16 +1,16 @@
 <div class="section-index">
-    {{ $parent := .Page -}}
+    {{ $page := .Page -}}
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight -}}
     {{ $pages = (where $pages "Type" "!=" "search") }}
     {{ $pages = (where $pages ".Params.hide_summary" "!=" true) -}}
     {{ $pages = (where $pages ".Parent" "!=" nil) -}}
     {{ $pages = (where $pages ".Parent.File" "!=" nil) -}}
-    {{ if and $parent $parent.File -}}
-        {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) -}}
+    {{ if $page.File -}}
+        {{ $pages = (where $pages "Parent.File.UniqueID" "==" $page.File.UniqueID) -}}
     {{ end -}}
-    {{ if or $parent.Params.no_list (eq (len $pages) 0) -}}
+    {{ if or $page.Params.no_list (eq (len $pages) 0) -}}
     {{/* If no_list is true or we don't have subpages we don't show a list of subpages */}}
-    {{ else if $parent.Params.simple_list -}}
+    {{ else if $page.Params.simple_list -}}
     {{/* If simple_list is true we show a bulleted list of subpages */}}
         <ul>
             {{ range $pages -}}


### PR DESCRIPTION
- Followup to #1890
- Renames `$parent` to `$page`
- Fixes #1946
- Wraps up #1874

/cc @yann-soubeyrand @tobiaskohlbau @chulcher @marshalc