### PR TITLE
remove reference to non-existent Google Analytics partial

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -49,8 +49,6 @@
   {{ $enableGtagForUniversalAnalytics := not .Site.Params.disableGtagForUniversalAnalytics -}}
   {{ if (or $enableGtagForUniversalAnalytics (hasPrefix .Site.Config.Services.GoogleAnalytics.ID "G-")) -}}
     {{ template "_internal/google_analytics_gtag.html" . -}}
-  {{ else -}}
-    {{ template "_internal/google_analytics.html" . -}}
   {{ end -}}
 {{ end -}}
 


### PR DESCRIPTION
it looks like the non-gtag Google Analytics partial was removed (makes sense, given the GA migration to gtag) but the head partial is still trying to reference it.

this causes build errors (https://discourse.gohugo.io/t/error-error-building-site/49340).