### PR TITLE
Upgrade to Hugo 0.125.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.125.2",
+    "hugo-extended": "github:chalin/hugo-extended#v0.125.4",
     "markdown-link-check": "^3.11.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.2.5"

--- a/tools/install-hugo.sh
+++ b/tools/install-hugo.sh
@@ -6,7 +6,11 @@ set -e
 
 PKG_JSON=${1:-package.json}
 
-if ! npm ls hugo-extended; then
-  _HUGO_EXTENDED_PKG=`perl -ne 'print "$1\@$2" if /"(hugo-extended)":\s*"\D*(.+?)"/' $PKG_JSON`
-  (set -x && npm install --save-exact -D $_HUGO_EXTENDED_PKG --omit=optional)
+if ! npm ls hugo-extended2; then
+  _HUGO_EXTENDED_VERS=`perl -ne 'print "$1" if /"hugo-extended":\s*"\D*(.+?)"/' $PKG_JSON`
+  set -x
+  if ! npm install --save-exact -D hugo-extended@$_HUGO_EXTENDED_VERS --omit=optional; then
+    echo "Trying fork instead:"
+    npm install --save-exact -D chalin/hugo-extended#v$_HUGO_EXTENDED_VERS --omit=optional
+  fi
 fi


### PR DESCRIPTION
- Use Hugo 0.125.4 from my fork until https://github.com/jakejarvis/hugo-extended/issues/167 is resolved
- Confirms https://github.com/gohugoio/hugo/issues/12418
- This Hugo update:
  - Resolves https://github.com/gohugoio/hugo/issues/12418
  - Cleans up `og:description` and `article:section` meta data entries

```console
$ npm test
$ cd userguide
$ (cd public && git diff -bw --ignore-blank-lines -I 'og:desc|article:section|^\s$|"\s*/>$|">$|<generator>Hugo') 
$
```