### PR TITLE
[Dark mode] Left-nav and taxonomy color fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,22 @@ For the full list of changes, see the [0.x.y] release notes.
 For an introduction to this release, see the [0.10.0 release report]. For the
 full list of changes, see the [0.10.0] release notes.
 
+**New**: color themes and dark-mode support! For details, see [Color themes and
+dark-mode support][dark-mode].
+
 **Breaking changes**:
 
-- Removed shortcode `card-code` that was [deprecated in 0.7.0](#070); use
+- Removes shortcode `card-code` that was [deprecated in 0.7.0](#070); use
   shortcode `card` with named parameter `code=true` instead.
+- The following SCSS variables are inlined in favor of dark-mode compatible
+  styling: `$border-color`, `$td-sidebar-tree-root-color`,
+  `$td-sidebar-bg-color`, `$td-sidebar-border-color` ([#1952])
 
+[#1952]: https://github.com/google/docsy/pull/1952
 [0.10.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.10.0
 [0.10.0 release report]: https://www.docsy.dev/blog/?FIXME=2024/0.10.0/
+[dark-mode]:
+  https://www.docsy.dev/blog/?FIXME=/2024/0.10.0/#color-themes-and-dark-mode-support
 
 ## 0.9.1
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -196,7 +196,7 @@ nav.foldable-nav {
     padding-left: 0.4em;
     padding-right: 0.4em;
     font-size: 1em;
-    color: $gray-900;
+    color: var(--bs-secondary-color);
     transition: all 0.5s;
     &:hover {
       transform: rotate(90deg);
@@ -204,7 +204,7 @@ nav.foldable-nav {
   }
 
   .ul-1 .with-child > input:checked ~ label:before {
-    color: $primary;
+    color: var(--bs-secondary-color);
     transform: rotate(90deg);
     transition: transform 0.5s;
   }
@@ -217,12 +217,12 @@ nav.foldable-nav {
 @media (hover: hover) and (pointer: fine) {
   nav.foldable-nav {
     .ul-1 .with-child > label:hover:before {
-      color: $primary;
+      color: var(--bs-link-color);
       transition: color 0.3s;
     }
 
     .ul-1 .with-child > input:checked ~ label:hover:before {
-      color: $primary;
+      color: var(--bs-link-color);
       transition: color 0.3s;
     }
   }

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -4,7 +4,7 @@
 .td-sidebar-toc {
   @include link-decoration;
 
-  border-left: 1px solid $border-color;
+  border-left: 1px solid var(--bs-border-color);
 
   @supports (position: sticky) {
     position: sticky;

--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -62,7 +62,7 @@
     }
 
     a {
-      color: var(--bs-emphasis-color);
+      color: var(--bs-secondary-color);
     }
   }
 
@@ -79,7 +79,7 @@
   a {
     &:focus,
     &:hover {
-      color: $link-color;
+      color: var(--bs-link-color);
     }
 
     &.active {
@@ -89,7 +89,7 @@
 
   .dropdown {
     a {
-      color: $gray-700;
+      color: var(--bs-tertiary-color);
     }
 
     .nav-link {
@@ -113,8 +113,7 @@
 
   .td-sidebar-link.tree-root {
     font-weight: $font-weight-bold;
-    color: $td-sidebar-tree-root-color;
-    border-bottom: 1px $td-sidebar-tree-root-color solid;
+    border-bottom: 1px solid var(--bs-tertiary-color);
     margin-bottom: 1rem;
   }
 }
@@ -124,16 +123,16 @@
 
   @include media-breakpoint-up(md) {
     padding-top: 4rem;
-    background-color: $td-sidebar-bg-color;
+    background-color: var(--bs-body-tertiary-bg);
     padding-right: 1rem;
-    border-right: 1px solid $td-sidebar-border-color;
+    border-right: 1px solid var(--bs-border-color);
   }
 
   padding-bottom: 1rem;
 
   &__toggle {
     line-height: 1;
-    color: var(--bs-emphasis-color);
+    color: var(--bs-body-color);
     margin: 1rem;
   }
 

--- a/assets/scss/_taxonomy.scss
+++ b/assets/scss/_taxonomy.scss
@@ -25,8 +25,8 @@
     width: 100%;
     font-size: 1rem;
     font-weight: 700;
-    color: $primary;
-    border-bottom: 1px $primary solid;
+    color: var(--bs-primary-text-emphasis);
+    border-bottom: 1px solid var(--bs-tertiary-color);
     margin-bottom: 1em;
     padding-bottom: 0.375rem;
     margin-top: 1em;
@@ -105,14 +105,14 @@
   margin-left: 0.6em;
   text-align: center;
   border-radius: 1em;
-  background-color: $white;
+  background-color: var(--bs-body-bg);
 }
 
 .taxonomy-term {
-  background: $gray-200;
+  background: var(--bs-secondary-bg);
   border-width: 0;
   border-radius: 0 3px 3px 0;
-  color: $gray-600;
+  color: var(--bs-body-color);
   display: inline-block;
   font-size: 1em;
   line-height: 1.5em;
@@ -127,11 +127,11 @@
   clip-path: polygon(100% 0, 100% 100%, 0.8em 100%, 0 50%, 0.8em 0);
 
   &:hover {
-    background-color: $primary;
-    color: $white;
+    background-color: var(--bs-primary-bg-subtle);
+    color: var(--bs-body-color-dark);
 
     .taxonomy-count {
-      color: $dark !important;
+      color: var(--bs-body-color-dark);
     }
   }
 

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -26,11 +26,6 @@ $code-color: shade-color($secondary, 40%) !default;
 
 // UI element colors
 
-$border-color: $gray-300 !default;
-$td-sidebar-tree-root-color: $primary !default;
-$td-sidebar-bg-color: rgba($primary, 0.03) !default;
-$td-sidebar-border-color: $border-color !default;
-
 // Background colors for the sections on home page etc. It is a paint by number
 // system, starting at 0, where the number is taken from the shortcode's ordinal
 // if not provided by the user. These colors are all part of the theme palette,

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -74,7 +74,7 @@ params:
     showLightDarkModeMenu: true
     sidebar_cache_limit: 10
     sidebar_menu_compact: true
-    sidebar_menu_foldable: false
+    sidebar_menu_foldable: true
     sidebar_search_disable: false
     feedback:
       enable: true


### PR DESCRIPTION
- Color fixes for the left nav and taxonomy elements
- Contributes to #331 
- Fixes #1927
- Fixes #1943
- **TEMPORARILY** enables `sidebar_menu_foldable` in the User Guide so that reviewers can validate the fix of #1943.

**Preview**: https://deploy-preview-1952--docsydocs.netlify.app/docs/
