### PR TITLE
copyright.html: process `.Site.Copyright` as HTML

### DIFF
--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -33,8 +33,9 @@
 {{- else -}}
 
   {{ with .Site.Copyright -}}
+    {{/* For historical reasons we process this as HTML rather than markdown. */ -}}
     <span class="td-footer__copyright">
-      {{- . | $page.RenderString -}}
+      {{- . | safeHTML -}}
     </span>
   {{- end -}}
 


### PR DESCRIPTION
- Fixes #1953 
- Tested with @yann-soubeyrand's:
  ```yaml
  copyright: |
    Copyright Camptocamp SA
    <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><span property="dct:title">Content</span> is licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-SA 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a></p>
  ```
  Yielding:
  > <img width="360" alt="image" src="https://github.com/google/docsy/assets/4140793/620cd78c-2130-43ea-8d39-79187ceb8863">
- **Preview**: https://deploy-preview-1954--docsydocs.netlify.app/community/

