### PR TITLE
Use official hugo-extended NPM package + UG tweak

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "github:chalin/hugo-extended#v0.125.4",
+    "hugo-extended": "0.125.4",
     "markdown-link-check": "^3.11.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.2.5"

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -74,7 +74,7 @@ params:
     showLightDarkModeMenu: true
     sidebar_cache_limit: 10
     sidebar_menu_compact: true
-    sidebar_menu_foldable: true
+    sidebar_menu_foldable: false
     sidebar_search_disable: false
     feedback:
       enable: true


### PR DESCRIPTION
- Closes #1907
- Reverts the temporary enabling of foldable left-nav section entries introduced by #1952