### PR TITLE
Set Mermaid theme based on light/dark mode

### DIFF
--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -39,6 +39,28 @@
 
     var settings = norm(mermaid.mermaidAPI.defaultConfig, params);
     settings.startOnLoad = true;
+    const isDark = $('html[data-bs-theme="dark"]').length;
+    settings.theme = isDark ? 'dark' : 'base';
     mermaid.initialize(settings);
+
+    // Handle light/dark mode theme changes
+    const lightDarkModeThemeChangeHandler = function (mutationsList, observer) {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-bs-theme') {
+          // Mermaid doesn't currently support reinitialization, see
+          // https://github.com/mermaid-js/mermaid/issues/1945. Until then,
+          // just reload the page.
+          location.reload();
+        }
+      }
+    };
+
+    const observer = new MutationObserver(lightDarkModeThemeChangeHandler);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-bs-theme']
+    });
+    // observer.disconnect();
+
   })(jQuery);
 </script>


### PR DESCRIPTION
- Contributes to #331
- Fixes #1961
- Uses a "mutation" observer to trigger a page reload when `data-bs-theme` is changed (only for pages containing mermaid diagrams).
- - **Preview**: https://deploy-preview-1964--docsydocs.netlify.app/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid