### PR TITLE
Mermaid: stick to default when not dark mode

### DIFF
--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -39,8 +39,9 @@
 
     var settings = norm(mermaid.mermaidAPI.defaultConfig, params);
     settings.startOnLoad = true;
-    const isDark = $('html[data-bs-theme="dark"]').length;
-    settings.theme = isDark ? 'dark' : 'base';
+    if ($('html[data-bs-theme="dark"]').length) {
+      settings.theme = 'dark';
+    }
     mermaid.initialize(settings);
 
     // Handle light/dark mode theme changes


### PR DESCRIPTION
- Contributes to #331
- Wraps up and closes #1961
- Don't use `base` Mermaid style
- Only set `dark` theme when dark mode is in use, otherwise use the default Mermaid theme
- **Preview**: https://deploy-preview-1965--docsydocs.netlify.app/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid