### PR TITLE
Dark-mode override for `.td-box--white`

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -116,3 +116,16 @@
 @each $color, $value in $grays {
   @include box-variant(".td-box", $color, $value);
 }
+
+// Single dark-mode compatibility override for white boxes:
+.td-box--white {
+  color: var(--bs-body-color) !important;
+  background-color: var(--bs-body-bg) !important;
+  p > a, span > a {
+    color: var(--bs-link-color);
+    &:focus,
+    &:hover {
+      color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+    }
+  }
+}


### PR DESCRIPTION
- Contributes to #331
- Overrides the bg and text color for `.td-box--white` so that it's compatible with dark mode.
- **Preview**: https://deploy-preview-1966--docsydocs.netlify.app/community

### Screenshots

Light:

> <img width="876" alt="image" src="https://github.com/google/docsy/assets/4140793/98cc4e7d-e378-4c12-811f-8c8aa95cc494">

Dark:

> <img width="876" alt="image" src="https://github.com/google/docsy/assets/4140793/41002b56-86c5-46d2-910a-2a6364011057">
