### PR TITLE
Restrict `.td-box--white` style changes to dark mode

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -118,14 +118,16 @@
 }
 
 // Single dark-mode compatibility override for white boxes:
-.td-box--white {
-  color: var(--bs-body-color) !important;
-  background-color: var(--bs-body-bg) !important;
-  p > a, span > a {
-    color: var(--bs-link-color);
-    &:focus,
-    &:hover {
-      color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+@include color-mode(dark) {
+  .td-box--white {
+    color: var(--bs-body-color) !important;
+    background-color: var(--bs-body-bg) !important;
+    p > a, span > a {
+      color: var(--bs-link-color);
+      &:focus,
+      &:hover {
+        color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+      }
     }
   }
 }


### PR DESCRIPTION
- I don't think that guarding the style changes to `.td-box--white` is necessary, but just in case.
- Fixes #1967
- **Preview**: https://deploy-preview-1968--docsydocs.netlify.app/community