### PR TITLE
[Dark mode] Fix blocks/lead down arrow color

### DIFF
--- a/assets/scss/_boxes.scss
+++ b/assets/scss/_boxes.scss
@@ -120,14 +120,17 @@
 // Single dark-mode compatibility override for white boxes:
 @include color-mode(dark) {
   .td-box--white {
-    color: var(--bs-body-color) !important;
-    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color);
+    background-color: var(--bs-body-bg);
     p > a, span > a {
       color: var(--bs-link-color);
       &:focus,
       &:hover {
         color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
       }
+    }
+    .td-arrow-down::before {
+      border-color: var(--bs-body-bg) transparent transparent transparent;
     }
   }
 }


### PR DESCRIPTION
- Contributes to #331
- Fixes #1970
- Followup to #1967

### Screenshots (from OTel website with these changes applied)

Before:

> <img width="703" alt="image" src="https://github.com/google/docsy/assets/4140793/d81f4333-e7b1-4f38-ba8c-f4b40e3e99d2">

After:

> <img width="702" alt="image" src="https://github.com/google/docsy/assets/4140793/7ecf6fd8-87ff-4761-a5da-65c352b36cea">

