### PR TITLE
Upgrade to Hugo 0.125.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.125.4",
+    "hugo-extended": "github:chalin/hugo-extended#v0.125.7",
     "markdown-link-check": "^3.11.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.2.5"


### PR DESCRIPTION
- Uses temporary GH branch until the official NPM package is read.
- Upgrading now b/c I'm hitting issues with multilingual support and I want to test with the latest version of Hugo
- There are no changes to the generated UG files other than the generator ID