### PR TITLE
Add RTL support using BSv5

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/blog/baseof.print.html
+++ b/layouts/blog/baseof.print.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.print.html
+++ b/layouts/docs/baseof.print.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -11,7 +11,6 @@
     {{ $rtlCSS = . | postCSS | minify | fingerprint -}}
   {{ end -}}
   {{ $css   = $css | postCSS | minify | fingerprint -}}
-
   <link rel="preload" href="{{ $css.RelPermalink }}" as="style">
 {{- end -}}
 
@@ -20,13 +19,9 @@ snappier to develop in Chrome, but makes it look sub-optimal in other browsers.
 */ -}}
 
 {{ with $rtlCSS -}}
-<link href="{{ $rtlCSS.RelPermalink }}" rel="stylesheet"
-  {{- if hugo.IsProduction -}} integrity="{{ $rtlCSS.Data.integrity }}" {{- end -}}
->
+  <link href="{{ $rtlCSS.RelPermalink }}" rel="stylesheet">
 {{ end -}}
 
-<link href="{{ $css.RelPermalink }}" rel="stylesheet"
-  {{- if hugo.IsProduction -}} integrity="{{ $css.Data.integrity }}" {{- end -}}
->
+<link href="{{ $css.RelPermalink }}" rel="stylesheet">
 
 {{- /**/ -}}

--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -1,11 +1,32 @@
+{{ $scssMain := "scss/main.scss" -}}
+{{ $css := resources.Get $scssMain
+      | toCSS (dict "enableSourceMap" (not hugo.IsProduction)) -}}
+{{ $rtlCSS :=
+    cond (eq .Site.Language.LanguageDirection "rtl")
+        (resources.Get "vendor/bootstrap/dist/css/bootstrap.rtl.css")
+        nil -}}
 
-{{ $scssMain := "scss/main.scss"}}
-{{ if not hugo.IsProduction }}
-{{/* Note the missing postCSS. This makes it snappier to develop in Chrome, but makes it look sub-optimal in other browsers. */}}
-{{ $css := resources.Get $scssMain | toCSS (dict "enableSourceMap" true) }}
-<link href="{{ $css.RelPermalink }}" rel="stylesheet">
-{{ else }}
-{{ $css := resources.Get $scssMain | toCSS (dict "enableSourceMap" false) | postCSS | minify | fingerprint }}
-<link rel="preload" href="{{ $css.RelPermalink }}" as="style">
-<link href="{{ $css.RelPermalink }}" rel="stylesheet" integrity="{{ $css.Data.integrity }}">
-{{ end }}
+{{ if hugo.IsProduction -}}
+  {{ with $rtlCSS -}}
+    {{ $rtlCSS = . | postCSS | minify | fingerprint -}}
+  {{ end -}}
+  {{ $css   = $css | postCSS | minify | fingerprint -}}
+
+  <link rel="preload" href="{{ $css.RelPermalink }}" as="style">
+{{- end -}}
+
+{{/* NOTE: when not in production, we don't apply `postCSS`. This makes it
+snappier to develop in Chrome, but makes it look sub-optimal in other browsers.
+*/ -}}
+
+{{ with $rtlCSS -}}
+<link href="{{ $rtlCSS.RelPermalink }}" rel="stylesheet"
+  {{- if hugo.IsProduction -}} integrity="{{ $rtlCSS.Data.integrity }}" {{- end -}}
+>
+{{ end -}}
+
+<link href="{{ $css.RelPermalink }}" rel="stylesheet"
+  {{- if hugo.IsProduction -}} integrity="{{ $css.Data.integrity }}" {{- end -}}
+>
+
+{{- /**/ -}}

--- a/layouts/partials/head-css.html
+++ b/layouts/partials/head-css.html
@@ -18,10 +18,10 @@
 snappier to develop in Chrome, but makes it look sub-optimal in other browsers.
 */ -}}
 
+<link href="{{ $css.RelPermalink }}" rel="stylesheet">
+
 {{ with $rtlCSS -}}
   <link href="{{ $rtlCSS.RelPermalink }}" rel="stylesheet">
 {{ end -}}
-
-<link href="{{ $css.RelPermalink }}" rel="stylesheet">
 
 {{- /**/ -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
 {{ template "_internal/opengraph.html" . -}}
 {{ template "_internal/schema.html" . -}}
 {{ template "_internal/twitter_cards.html" . -}}
-{{ partialCached "head-css.html" . "asdf" -}}
+{{ partialCached "head-css.html" . "head-css-cache-key" }}
 <script
   src="https://code.jquery.com/jquery-3.7.1.min.js"
   integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -1,5 +1,8 @@
 <!doctype html>
-<html itemscope itemtype="http://schema.org/WebPage" lang="{{ .Site.Language.Lang }}" class="no-js">
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>


### PR DESCRIPTION
- Contributes to #1442
- Fixes #2004
- Uses Bootstrap's base support for [RTL](https://getbootstrap.com/docs/5.3/getting-started/rtl/)

**Preview**: https://deploy-preview-2002--docsydocs.netlify.app/docs/language/
