### PR TITLE
[RTL] Add CHANGELOG entry and drop RTL for `en`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ For the full list of changes, see the [0.x.y] release notes.
 
 **New**:
 
+- Support for Right-To-Left (RLT) languages is reintroduced via [Bootstrap's
+  base support for RTL][bs-rtl].
+
 **Other changes**:
 
 [0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+[bs-rtl]: https://getbootstrap.com/docs/5.3/getting-started/rtl/
 
 ## 0.10.0
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
 {{ template "_internal/opengraph.html" . -}}
 {{ template "_internal/schema.html" . -}}
 {{ template "_internal/twitter_cards.html" . -}}
-{{ partialCached "head-css.html" . "head-css-cache-key" }}
+{{ partialCached "head-css.html" . "head-css-cache-key" -}}
 <script
   src="https://code.jquery.com/jquery-3.7.1.min.js"
   integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -30,7 +30,6 @@ menu:
 languages:
   en:
     languageName: English
-    languageDirection: rtl
     params:
       description: Docsy does docs
 


### PR DESCRIPTION
- Contributes to #1442
- Adds a preliminary changelog entry for the RTL feature
- Drops temporary commit introduced by previous PR -- darn, I missed my own warning! 🤷🏼‍♂️ 
- Whitespace fix in `head.html` -- also an issue introduced by a recent PR