### PR TITLE
Address Language Dropdown & Search Narrow Display Issue + Farsi Font Update

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -2,13 +2,6 @@
 // Main navbar
 //
 
-.dropup, .dropend, .dropdown, .dropstart, .dropup-center, .dropdown-center {
-  position: static;
-}
-.d-none {
-  display: block !important;
-}
-
 .td-navbar-cover {
   @include media-breakpoint-up(md) {
     background: transparent !important;
@@ -65,6 +58,8 @@
 
   .dropdown {
     min-width: 50px;
+    display: block !important;
+    position: static;
   }
 
   @include media-breakpoint-up(md) {
@@ -78,6 +73,12 @@
 
     .navbar-nav {
       padding-top: 0 !important;
+    }
+
+    .dropdown {
+      min-width: 50px;
+      display: block !important;
+      position: relative;
     }
   }
 
@@ -96,6 +97,12 @@
     .navbar-nav {
       padding-bottom: 2rem;
       overflow-x: auto;
+    }
+
+    .dropdown {
+      min-width: 75px;
+      display: block !important;
+      position: static;
     }
   }
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -2,6 +2,13 @@
 // Main navbar
 //
 
+.dropup, .dropend, .dropdown, .dropstart, .dropup-center, .dropdown-center {
+  position: static;
+}
+.d-none {
+  display: block !important;
+}
+
 .td-navbar-cover {
   @include media-breakpoint-up(md) {
     background: transparent !important;

--- a/assets/scss/support/_rtl.scss
+++ b/assets/scss/support/_rtl.scss
@@ -19,10 +19,4 @@ html[lang="fa"] {
         font-family: 'Vazirmatn', sans-serif;
     }
     // Add additional elements as needed
-    .d-none {
-      display: block !important;
-  }
-  .dropup, .dropend, .dropdown, .dropstart, .dropup-center, .dropdown-center {
-    position: static;
-  }
 }

--- a/assets/scss/support/_rtl.scss
+++ b/assets/scss/support/_rtl.scss
@@ -5,3 +5,24 @@
     }
   }
 }
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@100..900&display=swap');
+ 
+html[lang="fa"] {
+    body {
+        font-family: 'Vazirmatn', sans-serif;
+    }
+    h1, h2, h3, h4, h5, h6 {
+        font-family: 'Vazirmatn', sans-serif;
+        font-weight: 400;
+    }
+    p, span, div, a, li, ul, ol {
+        font-family: 'Vazirmatn', sans-serif;
+    }
+    // Add additional elements as needed
+    .d-none {
+      display: block !important;
+  }
+  .dropup, .dropend, .dropdown, .dropstart, .dropup-center, .dropdown-center {
+    position: static;
+  }
+}


### PR DESCRIPTION
This pull request addresses two user interface issues:

**Language Dropdown and Search Box in Narrow Display**: Fixes the issue reported in #[2035](https://github.com/google/docsy/issues/2035) and #[1944](https://github.com/google/docsy/issues/1944) where the language dropdown menu (and search box) become inaccessible on narrow displays.

**Farsi Font Update**: Updates the Farsi font to the open-source Vazirmatn from Google Fonts. This improves compatibility and potentially resolves issues encountered with previous Vazir font implementations.   
     
PS:  
**The PR has been updated to resolve an issue affecting the dark/light menu on medium and small screens. The updated code ensures consistent menu functionality across all screen dimensions:**  

Demo:  https://deploy-preview-2057--docsydocs.netlify.app/    
Multi-lingual demo: https://rdrp.ir



**_Before_**:
<img src="https://github.com/user-attachments/assets/8ebe4beb-b0ef-4919-8fbe-b962db92c799" width=45% height=50%> <img src="https://github.com/user-attachments/assets/4c7ebead-bf40-4eb9-9793-b99521998e68" width=45% height=50%>

**_After:_**
<img src="https://github.com/user-attachments/assets/bcfd735a-25b3-4ac8-a087-9f1d9ddd838b" width=45% height=50%> <img src="https://github.com/user-attachments/assets/1ff1ba5c-53b6-4e3e-9bb9-28a680012058" width=45% height=50%>  

_Farsi Font correction + Dropdown menu_   

<img src="https://github.com/user-attachments/assets/5cffc6b8-52be-4033-8741-7d5bf397aab4" width=45% height=50%>  

