### PR TITLE
Upgrade Hugo, Prettier, and Font-Awesome

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 // AUTO-GENERATED using `npm run get:hugo-modules`
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
-github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de h1:JvHOfdSqvArF+7cffH9oWU8oLhn6YFYI60Pms8M/6tI=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "userguide/public"
 command = "npm run docs-install && npm run build:preview"
 
 [build.environment]
-GO_VERSION = "1.21.6"
+GO_VERSION = "1.22.5"
 HUGO_THEME = "repo"
 
 [context.production]

--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
   },
   "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome userguide ",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.5.2",
+    "@fortawesome/fontawesome-free": "6.6.0",
     "bootstrap": "5.3.3"
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.126.3",
+    "hugo-extended": "0.130.0",
     "markdown-link-check": "^3.12.2",
     "mkdirp": "^3.0.1",
-    "prettier": "^3.3.0"
+    "prettier": "^3.3.3"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
This PR bumps dependency `Font-Awesome` to latest version 6.6.0.
It also bumps `hugo` to latest version 0.130.0 and `prettier` to latest version 3.3.3.