### PR TITLE
[feat] Support `contributingUrl` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ For the full list of changes, see the [0.x.y] release notes.
 
 - Support for Right-To-Left (RLT) languages is reintroduced via [Bootstrap's
   base support for RTL][bs-rtl].
+- The URL to your project's contribution guidelines is configurable. For
+  details, see [Adding a community page].
 
-**Other changes**:
+**Other changes**: TBC
 
 [0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
 [bs-rtl]: https://getbootstrap.com/docs/5.3/getting-started/rtl/
+[Adding a community page]:
+  https://www.docsy.dev/docs/adding-content/content/#adding-a-community-page
 
 ## 0.10.0
 

--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -1,4 +1,5 @@
 {{ $links := .Site.Params.links -}}
+{{ $contribUrl := .Params.contributingUrl | default "docs/contribution-guidelines" -}}
 
 <section class="row td-box td-box--white td-box--height-auto linkbox">
   <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
@@ -16,7 +17,7 @@
     {{ end }}
     <p>
       {{ T "community_how_to" . }}
-      <a href="{{ "docs/contribution-guidelines" | relURL }}">{{ T "community_guideline" }}</a>.
+      <a href="{{ $contribUrl | relURL }}">{{ T "community_guideline" }}</a>.
     </p>
   </div>
 </section>

--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -599,6 +599,16 @@ params:
 
 If you're creating your own site and want to add a page using this template, add a `/community/_index.md` file in your content root directory. If you've copied the example site and *don't* want a community page, just delete the `/content/en/community/` directory in your project repo.
 
+By default, Docsy layouts assume that your project's contributing page is found
+at `<baseURL>/docs/contribution-guidelines`. To specify another URL, add it to
+the front matter of `/community/_index.md` as illustrated next. The URL can be
+an external URL or a local path:
+
+```yaml
+params:
+  contributingUrl: docs/contributing/
+```
+
 ## Adding static content
 
 You may want to serve some non-Hugo-built content along with your site: for example, if you have generated reference docs using Doxygen, Javadoc, or other doc generation tools.


### PR DESCRIPTION
- Fixes #2065
- **Preview**: https://deploy-preview-2067--docsydocs.netlify.app/docs/adding-content/content/#adding-a-community-page