### PR TITLE
Adds a warning when truncating sidebar section entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For the full list of changes, see the [0.x.y] release notes.
   base support for RTL][bs-rtl].
 - The URL to your project's contribution guidelines is configurable. For
   details, see [Adding a community page].
+- A warning is now output when a section's sidebar entries are truncated because
+  there are more than [params.ui.sidebar_menu_truncate] section entries.
 
 **Other changes**: TBC
 
@@ -39,6 +41,8 @@ For the full list of changes, see the [0.x.y] release notes.
 [bs-rtl]: https://getbootstrap.com/docs/5.3/getting-started/rtl/
 [Adding a community page]:
   https://www.docsy.dev/docs/adding-content/content/#adding-a-community-page
+[params.ui.sidebar_menu_truncate]:
+  https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options
 
 ## 0.10.0
 

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -50,7 +50,11 @@
 {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
 {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
 {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
-{{ if ge (len $pages_tmp) $sidebarMenuTruncate -}}{{ warnf "Warning: Some ToC entries won't be displayed on %s. Increase [params.ui.sidebar_menu_truncate] in your config file to avoid that. " $s -}}{{ end -}}
+{{ $truncatedEntryCount := sub (len $pages_tmp) $sidebarMenuTruncate -}}
+{{ if gt $truncatedEntryCount 0 -}}
+  {{ warnf "WARNING: %d sidebar entries have been truncated. To avoid this, increase `params.ui.sidebar_menu_truncate` to at least %d (from %d) in your config file. Section: %s"
+      $truncatedEntryCount (len $pages_tmp) $sidebarMenuTruncate  $s.Path -}}
+{{ end -}}
 {{ $withChild := gt (len $pages) 0 -}}
 {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
 {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}
@@ -72,4 +76,4 @@
   </ul>
   {{- end }}
 </li>
-{{- end }}
+{{- end -}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -50,6 +50,7 @@
 {{ $mid := printf "m-%s" ($s.RelPermalink | anchorize) -}}
 {{ $pages_tmp := where (union $s.Pages $s.Sections).ByWeight ".Params.toc_hide" "!=" true -}}
 {{ $pages := $pages_tmp | first $sidebarMenuTruncate -}}
+{{ if ge (len $pages_tmp) $sidebarMenuTruncate -}}{{ warnf "Warning: Some ToC entries won't be displayed on %s. Increase [params.ui.sidebar_menu_truncate] in your config file to avoid that. " $s -}}{{ end -}}
 {{ $withChild := gt (len $pages) 0 -}}
 {{ $manualLink := cond (isset $s.Params "manuallink") $s.Params.manualLink ( cond (isset $s.Params "manuallinkrelref") (relref $s $s.Params.manualLinkRelref) $s.RelPermalink) -}}
 {{ $manualLinkTitle := cond (isset $s.Params "manuallinktitle") $s.Params.manualLinkTitle $s.Title -}}

--- a/layouts/partials/sidebar-tree.html
+++ b/layouts/partials/sidebar-tree.html
@@ -30,7 +30,7 @@
     {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
     {{ $ulNr := 0 -}}
     {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
-    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 50 -}}
+    {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
       {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -222,7 +222,7 @@ By default, the section menu shows the current section fully expanded all the wa
 
 With the compact menu (`.ui.sidebar_menu_compact = true`), only the current page's ancestors, siblings and direct descendants are shown. You can use the optional parameter `.ui.ul_show` to set a desired menu depth to always be visible. For example, with `.ui.ul_show = 1` the first menu level is always displayed.
 
-The number of sidebar entries shown per section can be configured using the `.ui.sidebar_menu_truncate` parameter (default: 50).
+The number of sidebar entries shown per section can be configured using the `.ui.sidebar_menu_truncate` parameter (default: 100).
 
 As well as the completely expanded and compact menu options, you can also create a foldable menu by setting the site parameter `ui.sidebar_menu_foldable = true` in `hugo.toml`. The foldable menu lets users expand and collapse menu sections by toggling arrow icons beside the section parents in the menu.
 


### PR DESCRIPTION
- The **first commit** is the **original contribution** & submission from #1438 **by @fekete-robert**, and sorry again for the git snafu! 
- Second commit contains warning-message edits and whitespace cleanup
- Double the current truncation limit value, as suggested by @fekete-robert -- https://github.com/google/docsy/issues/979#issuecomment-2273889864