### PR TITLE
Display content of blog index or blog-section index

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -22,8 +22,10 @@
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
           <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            {{ if .IsSection }}
             <h1>{{ .Title }}</h1>
             {{ .Content }}
+            {{ end -}}
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="td-rss-button" title="RSS" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
               <i class="fa-solid fa-rss" aria-hidden="true"></i>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -22,6 +22,8 @@
             {{ partial "taxonomy_terms_clouds.html" . }}
           </aside>
           <main class="col-12 col-md-9 col-xl-8 ps-md-5 pe-md-4" role="main">
+            <h1>{{ .Title }}</h1>
+            {{ .Content }}
             {{ with .CurrentSection.OutputFormats.Get "rss" -}}
             <a class="td-rss-button" title="RSS" href="{{ .RelPermalink | safeURL }}" target="_blank" rel="noopener">
               <i class="fa-solid fa-rss" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #1787.

I needed this for my project and saw the issue open. Currently Blog Section pages don't have a `h1` either, so this adds the title of the section as well.