### PR TITLE
Show only one year when copyright year range is a single year

### DIFF
--- a/theme/layouts/_partials/footer/copyright.html
+++ b/theme/layouts/_partials/footer/copyright.html
@@ -1,21 +1,22 @@
 {{ $page := .Page -}}
 {{ with .Site.Params.copyright -}}
-  {{ $fromYear := "" -}}
-  {{ $toYear := "" -}}
+  {{ $yearDisplay := now.Year -}}
   {{ $authors := "" -}}
   {{ if reflect.IsMap . -}}
-    {{ $fromYear = .from_year -}}
-    {{ $toYear = .to_year -}}
+    {{ $to := .to_year | default now.Year -}}
+    {{ $yearDisplay = $to -}}
+    {{ with .from_year -}}
+      {{ if ne (string .) (string $to) -}}
+        {{ $yearDisplay = printf "%v–%v" . $to -}}
+      {{ end -}}
+    {{ end -}}
     {{ $authors = .authors -}}
   {{ else -}}
     {{ $authors = . -}}
   {{ end -}}
 
   <span class="td-footer__copyright">&copy;
-    {{ with $fromYear -}}
-      {{ . }}&ndash;
-    {{- end -}}
-    {{ $toYear | default now.Year }}
+    {{ $yearDisplay }}
     <span class="td-footer__authors">
       {{- $authors
             | default (printf "%s Authors" ($.Site.Title | default "Site"))


### PR DESCRIPTION
Updates the copyright template so a single year or a range is shown as appropriate.

For example, given `from_year` and `to_year` are set to 2024.

Previous output:

> © 2024–2024

New output:

> © 2024

Closes #2047 