### PR TITLE
Header meta description: use same strategy as Hugo

### DIFF
--- a/layouts/partials/page-description.html
+++ b/layouts/partials/page-description.html
@@ -1,11 +1,3 @@
-{{ with .Description | plainify -}}
-  {{ . -}}
-{{ else -}}
-  {{ if .IsPage -}}
-    {{ .Summary | plainify | chomp -}}
-  {{ else -}}
-    {{ with .Site.Params.description | plainify -}}
-      {{ . -}}
-    {{ end -}}
-  {{ end -}}
+{{ with or .Description .Summary site.Params.description | plainify | htmlUnescape -}}
+  {{ trim . "\n\r\t " -}}
 {{ end -}}

--- a/package.json
+++ b/package.json
@@ -35,23 +35,23 @@
     "update:hugo": "npm install --save-exact -D hugo-extended@latest",
     "update:pkgs": "npx npm-check-updates -u && npm run cd:docs update:pkgs"
   },
-  "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark twbs pkgs userguide ",
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.6.0",
     "bootstrap": "5.3.3"
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.133.1",
+    "hugo-extended": "0.136.1",
     "markdown-link-check": "^3.12.2",
     "mkdirp": "^3.0.1",
     "prettier": "^3.3.3"
   },
   "optionalDependencies": {
-    "netlify-cli": "^17.36.4",
-    "npm-check-updates": "^17.1.3"
+    "netlify-cli": "^17.37.0",
+    "npm-check-updates": "^17.1.4"
   },
   "engines": {
     "node": ">=20"
-  }
+  },
+  "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark twbs netlify pkgs userguide -"
 }


### PR DESCRIPTION
- An updated take at #1092
- Inspired by recent updates to Hugo, including https://github.com/gohugoio/hugo/pull/12901
- More fully completes the fix to #968, trimming any whitespace (a fix I've been waiting for a long time)
- Updates Hugo to 0.136.1, and other pkgs

/cc @LisaFC @geriom @emckean 