### PR TITLE
Upgrade Hugo and merge optional deps into dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,11 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.137.0",
+    "hugo-extended": "0.138.0",
     "mkdirp": "^3.0.1",
-    "prettier": "^3.3.3"
-  },
-  "optionalDependencies": {
+    "prettier": "^3.3.3",
     "netlify-cli": "^17.37.2",
-    "npm-check-updates": "^17.1.10"
+    "npm-check-updates": "^17.1.11"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
- Contributes to #2122
- Folds `optionalDependencies` into `devDependencies` to address issue reported in https://github.com/google/docsy/issues/2122#issuecomment-2470428578
  Note that I'm going to leave the GH workflows as they are, installing the full set of NPM packages. We can optimize later.
- Hugo upgraded to 0.138.0. There are no changes to the generated site files, other than the Hugo version ID.