### PR TITLE
[CI] Patch search page HTML until Hugo is fixed, FA upgrade

### DIFF
--- a/assets/scss/shortcodes/tabbed-pane.scss
+++ b/assets/scss/shortcodes/tabbed-pane.scss
@@ -10,7 +10,7 @@
       border: none;
       max-width: 100%;
     }
-    margin-top: 0rem;
+    margin-top: 0;
     margin-bottom: 1.5rem;
     border-left: $nav-tabs-border-width solid $nav-tabs-border-color;
     border-right: $nav-tabs-border-width solid $nav-tabs-border-color;

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 // AUTO-GENERATED using `npm run get:hugo-modules`
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20241118213846-a03a91d68184 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20241118213846-a03a91d68184 h1:KVzLFRNE1Zfzx+cERAChVqALvzqnp0i4apZDe9DFauQ=
-github.com/FortAwesome/Font-Awesome v0.0.0-20241118213846-a03a91d68184/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f h1:3/aWi2Aq8yQsulhJo1lS3NJ3ytCyXNHorms/GoZHn78=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
     "update:pkgs": "npx npm-check-updates -u && npm run cd:docs update:pkgs"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.7.0",
+    "@fortawesome/fontawesome-free": "6.7.1",
     "bootstrap": "5.3.3"
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.139.0",
-    "prettier": "^3.3.3",
+    "hugo-extended": "^0.139.0",
     "netlify-cli": "^17.37.2",
-    "npm-check-updates": "^17.1.11"
+    "npm-check-updates": "^17.1.11",
+    "prettier": "^3.3.3"
   },
   "engines": {
     "node": ">=22"

--- a/userguide/.htmltest.yml
+++ b/userguide/.htmltest.yml
@@ -1,3 +1,5 @@
+# cSpell:ignore github regexs
+CacheExpires: 9000h # ~ 12 months
 DirectoryPath: public
 CheckDoctype: false # Sadly, this is false only because of `static/google*.html`
 IgnoreAltMissing: true # FIXME

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -7,6 +7,7 @@
     "_check:links": "make --keep-going check-links",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
+    "_hugo-0_139_0_gcse-patch": "perl -i -pe 's/gcse :/gcse:/' public/search/index.html",
     "_serve": "npm run _hugo-dev -- serve --minify --disableFastRender --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "build:production": "npm run _hugo -- --minify",
@@ -17,8 +18,8 @@
     "clean": "rm -Rf public",
     "fix:format": "npm run _check:format -- --write",
     "make:public": "git init -b main public",
-    "postbuild:preview": "npm run _check:links--warn",
-    "postbuild:production": "npm run _check:links--warn",
+    "postbuild:preview": "npm run _hugo-0_139_0_gcse-patch",
+    "postbuild:production": "npm run _hugo-0_139_0_gcse-patch",
     "precheck:links:all": "npm run build",
     "precheck:links": "npm run build",
     "prepare": "cd .. && npm install",
@@ -32,5 +33,5 @@
     "postcss-cli": "^11.0.0",
     "rtlcss": "^4.3.0"
   },
-  "cSpell:ignore": "- docsy htmltest pkgs postbuild precheck rtlcss -"
+  "cSpell:ignore": "- docsy gcse htmltest pkgs postbuild precheck rtlcss -"
 }


### PR DESCRIPTION
- Workaround for #2134
- Patches the search page HTML to remove the extra space introduced in the `gcse` tag name by minification
- Other misc updates

**Preview** confirms that the patch works, https://deploy-preview-2135--docsydocs.netlify.app/search/?q=load:

> <img width="685" alt="image" src="https://github.com/user-attachments/assets/ed8c6f91-c541-4f02-b962-df595935c563">
