### PR TITLE
[CI] Upgrade NPM pkgs, Hugo to 0.139.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,8 +106,8 @@ this release are listed next.
   [path_base_for_github_subdir]. Projects will need to adjust the value of
   [path_base_for_github_subdir] to be relative to the file's physical location.
 
-- Class names to disable [repository links] were misnamed with a suffix of the form
-  `--KIND`. The new suffix is `__KIND`. For details, see [Disabling links].
+- Class names to disable [repository links] were misnamed with a suffix of the
+  form `--KIND`. The new suffix is `__KIND`. For details, see [Disabling links].
 
 - **Heading self-link** support has been reimplemented and projects must now
   explicitly enable the feature. For details, see [Heading self links].
@@ -157,9 +157,9 @@ For the full list of changes, see the [0.8.0] release notes.
 
 - Docsy is packaged as a **single Hugo module** ([#1120]). For details, see [Use
   Docsy as a Hugo Module].
-- **Important**: non-Hugo-module projects should be aware of the [Docsy
-  NPM install side-effect]. Also, for guidance on Hugo-reported "failed to load modules"
-  error, see [Docsy as an NPM package].
+- **Important**: non-Hugo-module projects should be aware of the [Docsy NPM
+  install side-effect]. Also, for guidance on Hugo-reported "failed to load
+  modules" error, see [Docsy as an NPM package].
 - **Page feedback**, or [User feedback]:
   - In support of projects configuring analytics outside of Docsy, feedback
     functionality is enabled regardless of whether
@@ -342,12 +342,13 @@ CHANGES** are documented below.
   as text.
 - **Display logo by default**. Most projects show their logo in the navbar. In
   support of this majority, Docsy now displays a logo by default. For details on
-  how to hide the logo (or your brand name), see [Styling your project logo and name].
+  how to hide the logo (or your brand name), see [Styling your project logo and
+  name].
 - **Upgraded Bootstrap** to v4.6.2 from v4.6.1, resulting in some style changes
   (such as an adjustment in the size of `small`). For details, see [v4.6.2
   release notes].
-- **[Upgraded FontAwesome]** to v6 from v5. While many icons were renamed, the v5
-  names still work. For details about icon renames and more, see [What's
+- **[Upgraded FontAwesome]** to v6 from v5. While many icons were renamed, the
+  v5 names still work. For details about icon renames and more, see [What's
   changed].
 - **Search-box**: the HTML structure and class names have changed, due to the
   Font Awesome upgrade, for both online and offline search. This may affect your
@@ -455,9 +456,10 @@ For the full list of changes, see the [0.2.0] release notes.
 
 **New**:
 
-- Add official Docsy support for [Hugo modules]. Many thanks to the dedicated and
-  patient efforts of [@deining], who researched, experimented, and implemented this
-  feature. Thanks to [@deining] and [@LisaFC] for the doc updates.
+- Add official Docsy support for [Hugo modules]. Many thanks to the dedicated
+  and patient efforts of [@deining], who researched, experimented, and
+  implemented this feature. Thanks to [@deining] and [@LisaFC] for the doc
+  updates.
 
   For details, see
   [Migrate to Hugo Modules](https://www.docsy.dev/docs/updating/convert-site-to-module/).

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "^0.139.0",
-    "netlify-cli": "^17.37.2",
+    "hugo-extended": "^0.139.4",
+    "netlify-cli": "^17.38.0",
     "npm-check-updates": "^17.1.11",
-    "prettier": "^3.3.3"
+    "prettier": "^3.4.2"
   },
   "engines": {
     "node": ">=22"

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -10,10 +10,10 @@ By default, a site using Docsy has the theme's default fonts, colors, and
 general look and feel. However, if you want your own color scheme (and you
 probably will!) you can very easily override the theme defaults with your own
 project-specific values - Hugo will look in your project files first when
-looking for information to build your site. And because [Docsy uses Bootstrap
-5] and SCSS for styling, you can override just single values (such as project colors
-and fonts) in its special SCSS project variables file, or do more serious customization
-by creating your own styles.
+looking for information to build your site. And because [Docsy uses Bootstrap 5]
+and SCSS for styling, you can override just single values (such as project
+colors and fonts) in its special SCSS project variables file, or do more serious
+customization by creating your own styles.
 
 Docsy also provides options for styling your code blocks, using either Chroma or
 Prism for highlighting.
@@ -77,8 +77,8 @@ Docsy has [Bootstrap][bs-docs] features such as gradient backgrounds
 can also be toggled in your project variables file by setting the variables to
 `false`.
 
-To add colors to or modify Bootstrap's [color maps], use **`assets/scss/_variables_project_after_bs.scss`**.
-For example:
+To add colors to or modify Bootstrap's [color maps], use
+**`assets/scss/_variables_project_after_bs.scss`**. For example:
 
 ```scss
 $custom-colors: (
@@ -101,9 +101,9 @@ Learn how to modify maps, see [Maps and loops] and [Adding theme colors].
 
 ### Light/dark color themes
 
-Docsy 0.10.0 supports light and [dark mode] color themes. To allow your website users
-to choose light/dark modes, **enable the Docsy [light/dark menu]** or create
-your own custom theme selector.
+Docsy 0.10.0 supports light and [dark mode] color themes. To allow your website
+users to choose light/dark modes, **enable the Docsy [light/dark menu]** or
+create your own custom theme selector.
 
 If your site uses [Chroma for code highlighting], there are extra steps required
 so that code-block styles are compatible with light/dark mode:
@@ -116,7 +116,8 @@ For details, see [Chroma for code highlighting].
 
 {{% alert title="Note" %}}
 
-Light/dark color themes, only affect documentation pages, and white [blocks shortcodes].
+Light/dark color themes, only affect documentation pages, and white [blocks
+shortcodes].
 
 [blocks shortcodes]: shortcodes/#shortcode-blocks
 
@@ -237,8 +238,8 @@ Docsy's default Chroma styles for [light/dark mode] are:
 - [tango] for light mode
 - [onedark] for dark mode
 
-If you would like to use other styles, save the [Hugo generated Chroma styles] to
-the appropriate file:
+If you would like to use other styles, save the [Hugo generated Chroma styles]
+to the appropriate file:
 
 - [assets/scss/td/chroma/_light.scss]
 - [assets/scss/td/chroma/_dark.scss]
@@ -335,8 +336,8 @@ files with your own.
 The default Docsy navbar (`.td-navbar`) displays your site identity, consisting
 of the following:
 
-1.  [Your logo][], which is included in the navbar as an inline SVG, styled by `.td-navbar .navbar-brand svg`.
-    For the style details, see [_nav.scss][].
+1.  [Your logo][], which is included in the navbar as an inline SVG, styled by
+    `.td-navbar .navbar-brand svg`. For the style details, see [_nav.scss][].
 
     To ensure your logo displays correctly, you may want to resize it and ensure
     that it doesn't have height and width attributes so that its size is fully
@@ -367,9 +368,10 @@ switch your site's documentation page display between a default "light" mode,
 and a "dark" mode where the text is displayed in a light color on a dark
 background.
 
-To enable the display of a light/[dark mode] menu in the navbar, set `params.ui.showLightDarkModeMenu`
-to `true` in your project's configuration file. The dropdown menu appears at the
-right, immediately before the [search box], if present.
+To enable the display of a light/[dark mode] menu in the navbar, set
+`params.ui.showLightDarkModeMenu` to `true` in your project's configuration
+file. The dropdown menu appears at the right, immediately before the [search
+box], if present.
 
 <!-- prettier-ignore -->
 {{< tabpane >}}
@@ -402,8 +404,8 @@ params:
 
 For pages containing a [blocks/cover][] shortcode, like most homepages, the
 navbar is translucent as long as the hero image hasn't scrolled up past the
-navbar. For an example, see the [About Docsy][] page. This initial translucent setting
-ensures that the hero image is maximally visible.
+navbar. For an example, see the [About Docsy][] page. This initial translucent
+setting ensures that the hero image is maximally visible.
 
 After the hero image has scrolled past the navbar, the navbar's (opaque)
 background color is set -- usually to the site's [primary color][].
@@ -460,7 +462,8 @@ illustrated in the following example:
 {.td-initial .my-dark-table-style}
 ```
 
-The example above uses [Markdown attribute][] syntax, and might render like this:
+The example above uses [Markdown attribute][] syntax, and might render like
+this:
 
 <!-- prettier-ignore-start -->
 | Shape    | Number of sides |

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -7,7 +7,6 @@
     "_check:links": "make --keep-going check-links",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
-    "_hugo-0_139_0_gcse-patch": "perl -i -pe 's/gcse :/gcse:/' public/search/index.html",
     "_serve": "npm run _hugo-dev -- serve --minify --disableFastRender --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "build:production": "npm run _hugo -- --minify",
@@ -18,8 +17,8 @@
     "clean": "rm -Rf public",
     "fix:format": "npm run _check:format -- --write",
     "make:public": "git init -b main public",
-    "postbuild:preview": "npm run _hugo-0_139_0_gcse-patch",
-    "postbuild:production": "npm run _hugo-0_139_0_gcse-patch",
+    "postbuild:preview": "npm run _check:links--warn",
+    "postbuild:production": "npm run _check:links--warn",
     "precheck:links:all": "npm run build",
     "precheck:links": "npm run build",
     "prepare": "cd .. && npm install",
@@ -33,5 +32,5 @@
     "postcss-cli": "^11.0.0",
     "rtlcss": "^4.3.0"
   },
-  "cSpell:ignore": "- docsy gcse htmltest pkgs postbuild precheck rtlcss -"
+  "cSpell:ignore": "- docsy htmltest pkgs postbuild precheck rtlcss -"
 }


### PR DESCRIPTION
- Fixes and closes #2134 by reverting #2135
- Upgrades NPM packages. Note that the new Hugo version introduces changes to `<img>` and other elements. Prettier formatting is adjusted too. Changes to the CHANGELOG and look-and-feel files are only due to Prettier adjusted formatting.

**Preview and tests**:

- https://deploy-preview-2143--docsydocs.netlify.app/
- https://deploy-preview-2143--docsydocs.netlify.app/search/?q=breadcrumb

