### PR TITLE
i18n: Add feedback_* to i18n/ja.toml

### DIFF
--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -77,3 +77,13 @@ other = "If you want to get more involved by contributing to {{ .Site.Title }}, 
 other = "You can find out how to contribute to {{ .Site.Title }} in our"
 [community_guideline]
 other = "Contribution Guidelines"
+
+# Feedback
+[feedback_title]
+other = "フィードバック"
+[feedback_question]
+other = "このページは役に立ちましたか?"
+[feedback_positive]
+other = "役に立った"
+[feedback_negative]
+other = "役に立たなかった"


### PR DESCRIPTION
Context: while reading OpenTelemetry's document, I noticed that their feedback form's i18n is completely broken in Japanese:

<img width="673" alt="image" src="https://github.com/user-attachments/assets/fb2263d4-a8fa-4e55-9146-a434ed4052ee" />

(Screenshot of https://opentelemetry.io/ja/docs/ )

and after some research, I think it was from docsy, not opentelemetry.io's fault, then I just made this patch.
