### PR TITLE
Bump dependency Font-Awesome to latest version 6.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 // AUTO-GENERATED using `npm run get:hugo-modules`
 
 require (
-	github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f h1:3/aWi2Aq8yQsulhJo1lS3NJ3ytCyXNHorms/GoZHn78=
-github.com/FortAwesome/Font-Awesome v0.0.0-20241120164804-3447c58c6b3f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3 h1:/iluJkJiyTAdnqrw3Yi9rH2HNHhrrtCmj8VJe7I6o3w=
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "update:pkgs": "npx npm-check-updates -u && npm run cd:docs update:pkgs"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "6.7.1",
+    "@fortawesome/fontawesome-free": "6.7.2",
     "bootstrap": "5.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR bumps dependency `Font-Awesome` to latest released version 6.7.2.