### PR TITLE
Blog list layout refactoring

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -16,7 +16,9 @@
     <li class="td-blog-posts-list__item">
       <div class="td-blog-posts-list__body">
         <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
-        <p class="mb-2 mb-md-3"><small class="text-body-secondary">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+        <p class="mb-2 mb-md-3"><small class="text-body-secondary">
+          {{- .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle -}}
+        </small></p>
         <header class="article-meta">
           {{- partial "taxonomy_terms_article_wrapper.html" . -}}
           {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,40 +1,39 @@
-{{ define "main" }}
+{{ define "main" -}}
+
 {{ if (and .Parent .Parent.IsHome) -}}
   {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) -}}
 {{ else -}}
   {{$.Scratch.Set "blog-pages" .Pages -}}
 {{ end -}}
 
+{{- if .Pages -}}
 <div class="td-blog-posts">
-  {{ if .Pages -}}
-    {{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
-    {{ range $pag.PageGroups -}}
-    <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
-    <ul class="td-blog-posts-list">
-      {{ range .Pages -}}
-      <li class="td-blog-posts-list__item">
-        <div class="td-blog-posts-list__body">
-          <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
-          <p class="mb-2 mb-md-3"><small class="text-body-secondary">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
-          <header class="article-meta">
-            {{ partial "taxonomy_terms_article_wrapper.html" . -}}
-            {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
-              {{ partial "reading-time.html" . -}}
-            {{ end -}}
-          </header>
-          {{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
-          <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
-          <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
-        </div>
-      </li>
-      {{ end -}}
-    </ul>
+  {{ $pager := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" ) -}}
+  {{ range $pager.PageGroups -}}
+  <div class="h2">{{ T "post_posts_in" }} {{ .Key }}</div>
+  <ul class="td-blog-posts-list">
+    {{ range .Pages -}}
+    <li class="td-blog-posts-list__item">
+      <div class="td-blog-posts-list__body">
+        <h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+        <p class="mb-2 mb-md-3"><small class="text-body-secondary">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+        <header class="article-meta">
+          {{- partial "taxonomy_terms_article_wrapper.html" . -}}
+          {{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) -}}
+            {{- partial "reading-time.html" . -}}
+          {{ end -}}
+        </header>
+        {{- partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-start me-3 pt-1 d-none d-md-block") -}}
+        <p class="pt-0 mt-0">{{ .Plain | safeHTML | truncate 250 }}</p>
+        <p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
+      </div>
+    </li>
     {{ end -}}
-  {{ end }}
-</div>
-<div class="td-blog-posts__pagination">
-  {{ if .Pages -}}
-    {{ template "_internal/pagination.html" . -}}
+  </ul>
   {{ end -}}
 </div>
+<div class="td-blog-posts__pagination">
+  {{ template "_internal/pagination.html" . -}}
+</div>
+{{- end -}}
 {{ end -}}


### PR DESCRIPTION
- Mainly refactors `layouts/blog/list.html` by replacing the two consecutive `{{- if .Pages -}}` by a single `if`, suppressing the `<div>` when there are no pages, rather than showing empty `div`s.
- In preparation for #1787
- There are at most whitespace changes in the generated UG pages:
  ```console
  $ pwd
  /.../docsy/userguide
  $ (cd public && git diff -bw --ignore-blank-lines)
  $
  ```