### PR TITLE
Blog list layout: display the page title and content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,12 @@ For the full list of changes, see the [0.x.y] release notes.
 
 **Other changes**:
 
+- Blog section index page content and title used to be ignored. They are now
+  displayed ([#1787]). You can recover the old behavior use the following style
+  override: `.td-section.td-blog .td-content { display: none; }`.
+
 [0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+[#1787]: https://github.com/google/docsy/issues/1787
 
 ## 0.11.0
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,10 @@
 {{ define "main" -}}
 
+<div class="td-content">
+<h1>{{ .Title }}</h1>
+{{ .Content }}
+</div>
+
 {{ if (and .Parent .Parent.IsHome) -}}
   {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) -}}
 {{ else -}}

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -371,6 +371,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:04:24.736233-05:00"
   },
+  "https://github.com/google/docsy/issues/1787": {
+    "StatusCode": 206,
+    "LastSeen": "2025-01-07T17:47:01.735556-05:00"
+  },
   "https://github.com/google/docsy/issues/1812": {
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:03:52.305697-05:00"


### PR DESCRIPTION
- Fixes #1787
- Renders the content of blog-section index pages.
- Renders the title of blog-section index pages as a level-1 heading, making the `main` content of the Blog section consistent with other sections such as `docs`.

**Preview**: https://deploy-preview-2157--docsydocs.netlify.app/blog/

### Screenshot

> <img width="1050" alt="image" src="https://github.com/user-attachments/assets/a77fa4d9-03e5-431b-8976-5e5a059190b4" />

> <img width="374" alt="image" src="https://github.com/user-attachments/assets/56e6fdb5-443c-4cb6-bd9b-1aa80e7f0699" />
