### PR TITLE
Hide index-page single breadcrumb

### DIFF
--- a/assets/scss/_breadcrumb.scss
+++ b/assets/scss/_breadcrumb.scss
@@ -2,7 +2,11 @@
 
 .td-breadcrumbs {
   @media print {
-    display: none !important;
+    display: none;
+  }
+
+  &__single {
+    display: none;
   }
 
   .breadcrumb {


### PR DESCRIPTION
- Hides breadcrumb list when there is only one breadcrumb, as this seems to be the preferred display option
- Fixes #857 in part

### Screenshots

Before:

> <img width="829" alt="image" src="https://github.com/user-attachments/assets/20e4c56f-6050-4295-9eb4-7d5d1e42ad30" />

After:

> <img width="829" alt="image" src="https://github.com/user-attachments/assets/aff60bf8-de67-442f-964b-99407963c128" />

