### PR TITLE
Render-heading: process class attributes

### DIFF
--- a/layouts/_default/_markup/td-render-heading.html
+++ b/layouts/_default/_markup/td-render-heading.html
@@ -1,4 +1,6 @@
-<h{{ .Level }} id="{{- .Anchor | safeURL -}}">
+<h{{ .Level }} id="{{ .Anchor | safeURL }}"
+  {{- with .Attributes.class }} class="{{ . }}" {{- end -}}
+>
   {{- .Text | safeHTML -}}
   {{ template "_default/_markup/_td-heading-self-link.html" . -}}
 </h{{ .Level }}>

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -314,6 +314,7 @@ params:
 {{< /tabpane >}}
 
 ## Heading self links
+{.test-class}
 
 Docsy supports build-time generation of heading self links using Hugo's
 `render-heading.html` [hook].


### PR DESCRIPTION
- Fixes #2162
- **Preview**: https://deploy-preview-2165--docsydocs.netlify.app/docs/adding-content/navigation/#heading-self-links, noticed how the heading element contains `class="test-class"`:
  ```html
  <h2 id="heading-self-links" class="test-class">Heading self links<a class="td-heading-self-link" href="#heading-self-links" aria-label="Heading self-link"></a></h2>
  ```

/cc @boevski