### PR TITLE
Bump KaTeX to latest version

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -52,8 +52,8 @@
 {{ define "algolia/head" -}}
 
 {{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.6.0"
-  integrity="sha512-AyDFDkYyALC5qoao077IqAOV7UC4oKCBTp+mJfjIt306AIRoBxoEZYDo0kAx/R7RbT+3EYEky1po/F1w1eQt7g=="
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3.8.2"
+  integrity="sha512-l7pkV1dOURFyHCeH8I4fK9lCkQKuqhlsTCqRl3zktifDlB8oTUJ+mJPgYkK9kHpUut8j1iPquTv32t6hvTPv3g=="
   crossorigin="anonymous" />
 {{ end -}}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -36,23 +36,23 @@ window.markmap = {
 
 {{ if  $needKaTeX -}}
 {{/* load stylesheet and scripts for KaTeX support */ -}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"
-      integrity="sha512-r2+FkHzf1u0+SQbZOoIz2RxWOIWfdEzRuYybGjzKq18jG9zaSfEy9s3+jMqG/zPtRor/q4qaUCYQpmSjTw8M+g==" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.css"
+      integrity="sha512-6a/jH+OTfV56Vs9Mm+Kl7ZsXWJRM2+EV+JDrW7HLHaf4OU2+9eLkHKFbzpSSbfJ5b60m+7/tQAevrzu7NP7Q2g==" crossorigin="anonymous">
   {{/* The loading of KaTeX is deferred to speed up page rendering */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"
-        integrity="sha512-INps9zQ2GUEMCQD7xiZQbGUVnqnzEvlynVy6eqcTcHN4+aQiLo9/uaQqckDpdJ8Zm3M0QBs+Pktg4pz0kEklUg=="
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.js"
+        integrity="sha512-FkmlbBiAj8fgfoZ8zJ+bZQCU5pdU55irXmJzFF/mXlSvBr2x/gmyLHaRu5iSpcA5Hw6CMLCCFSjB1GmgtNL2Qg=="
         crossorigin="anonymous">
 </script>
   {{ if $needmhchem -}}
   {{/* To add support for displaying chemical equations and physical units, load the mhchem extension: */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/mhchem.min.js"
-        integrity="sha512-mxjNw/u1lIsFC09k/unscDRY3ofIYPVFbWkP8slrePcS36ht4d/OZ8rRu5yddB2uiqajhTcLD8+jupOWuYPebg=="
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/mhchem.min.js"
+        integrity="sha512-Cl4bz7Rt9ppgcBOQa4z96q3UqAzHgBzNDm66u2+lDe0ZJQu0Fgz+6jO57E+IZqzlhGzfNBY++pg7Ue+iopaLrg=="
         crossorigin="anonymous">
 </script>
   {{ end -}}
   {{/* To automatically render math in text elements, include the auto-render extension: */ -}}
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"
-       integrity="sha512-YJVxTjqttjsU3cSvaTRqsSl0wbRgZUNF+NGGCgto/MUbIvaLdXQzGTCQu4CvyJZbZctgflVB0PXw9LLmTWm5/w==" crossorigin="anonymous"
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/auto-render.min.js"
+       integrity="sha512-6bKDPShiPRjAcdeO8T6cedaVEi0pavPbzue/G/ZRiwVlurWZOSZ/vI9fr2lhk8IPXK7z51AZac+zBvZzgDJzDQ==" crossorigin="anonymous"
        {{ printf "onload='renderMathInElement(%s, %s);'" (( $.Page.Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Page.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}>
 </script>
 {{ end -}}
@@ -104,8 +104,8 @@ window.markmap = {
 {{ partial "hooks/body-end.html" . -}}
 
 {{ define "algolia/scripts" -}}
-<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.6.0"
-  integrity="sha512-FtDaTWf3IS29TLuYzTPlytjGqcXkwrzG9ivq7xXElnOZeiYTbcIy/hwXAgrrRNnI0+PfN+WFz4/+4phhJmuS8Q=="
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.8.2"
+  integrity="sha512-lsD+XVzdBI6ZquXc8gqbw0/bgrfIsMJwY/8xvmvbN+U3gZSeG7BXQoCq4zv/yCmntR2GLHtgB+bD4ESPsKIbIA=="
   crossorigin="anonymous" ></script>
 <script type="text/javascript">
 const containers = ['#docsearch-0', '#docsearch-1'];


### PR DESCRIPTION
This PR bumps KaTeX and algolia docsearch to latest released versions (0.16.19 rsp. 3.8.2).