### PR TITLE
fix(#2137): Adjust search box sizing for longer placeholder text

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -4,4 +4,13 @@ Nothing defined here. The Hugo project that uses this theme can override Bootstr
 
 assets/scss/_styles_project.scss
 
+
 */
+
+@use 'search';
+
+.td-search {
+  &__input {
+    field-sizing: content;
+  }
+}


### PR DESCRIPTION

Fixes the issue where search box placeholder text gets cut off in some languages.

