### PR TITLE
[CI] Upgrade NPM packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "devDependencies": {
     "cpy-cli": "^5.0.0",
     "hugo-extended": "^0.141.0",
-    "netlify-cli": "^18.0.0",
-    "npm-check-updates": "^17.1.13",
+    "netlify-cli": "^18.0.1",
+    "npm-check-updates": "^17.1.14",
     "prettier": "^3.4.2"
   },
   "engines": {


### PR DESCRIPTION
- Repurposing this PR, as I hadn't seen #2177.
- ~Fixes #2176~
- ~https://github.com/gohugoio/hugo/releases/tag/v0.141.0~
- ~Switches to using [try](https://gohugo.io/functions/go-template/try/) in `layouts/partials/scripts/mermaid.html` (it won't build otherwise).~
- ~Generated site files are the same, except for the removal of trailing whitespace in some highlighted code (and the Hugo version). For an example of the highlighted code changes, see below.~ See #2177
