### PR TITLE
Drop style attribute using undef CSS var

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -123,7 +123,6 @@
 
   @include media-breakpoint-up(md) {
     padding-top: 4rem;
-    background-color: var(--bs-body-tertiary-bg);
     padding-right: 1rem;
     border-right: 1px solid var(--bs-border-color);
   }


### PR DESCRIPTION
- Fixes #2178
- Drops style attribute `background-color: var(--bs-body-tertiary-bg)` because `--bs-body-tertiary-bg` doesn't exist