### PR TITLE
Update Hugo to 0.142.0, and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "^0.141.0",
-    "netlify-cli": "^18.0.1",
+    "hugo-extended": "^0.142.0",
+    "netlify-cli": "^18.0.2",
     "npm-check-updates": "^17.1.14",
     "prettier": "^3.4.2"
   },


### PR DESCRIPTION
The hash for background images changes in the generated site files. There are no other significant changes to the generated pages.