### PR TITLE
[feat] Add base support of td-content-after-header hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ For the full list of changes, see the [0.x.y] release notes.
     [Breadcrumb navigation].
   - **Blog** pages now also have breadcrumbs by default ([#1788]).
   - Index-page single-element breadcrumb lists are hidden by default ([#2160]).
+- Support for a [td-content-after-header.html] page-content render hook, which
+  can be [content type] specific ([#2192]).
 
 **Other changes**:
 
@@ -50,8 +52,10 @@ For the full list of changes, see the [0.x.y] release notes.
 [#1787]: https://github.com/google/docsy/issues/1787
 [#1788]: https://github.com/google/docsy/issues/1788
 [#2160]: https://github.com/google/docsy/pull/2160
+[#2192]: https://github.com/google/docsy/pull/2192
 [Breadcrumb navigation]:
   https://www.docsy.dev/docs/adding-content/navigation/#breadcrumb-navigation
+[content type]: https://gohugo.io/quick-reference/glossary/#content-type
 
 ## 0.11.0
 

--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -7,6 +7,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
+	{{ .Render "td-content-after-header" }}
 	{{ .Content }}
 	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -11,6 +11,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
+	{{ .Render "td-content-after-header" }}
 	{{ .Content }}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,8 +8,9 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
+	{{ .Render "td-content-after-header" }}
 	{{ .Content }}
-  {{ partial "section-index.html" . -}}
+	{{ partial "section-index.html" . -}}
 	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -571,6 +571,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-01-08T13:26:59.610341-05:00"
   },
+  "https://github.com/google/docsy/pull/2192": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-10T11:24:51.123801-05:00"
+  },
   "https://github.com/google/docsy/pulls": {
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:03:15.642661-05:00"
@@ -806,6 +810,10 @@
   "https://gohugo.io/methods/site/copyright/": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:04:23.921846-05:00"
+  },
+  "https://gohugo.io/quick-reference/glossary/#content-type": {
+    "StatusCode": 206,
+    "LastSeen": "2025-02-10T11:24:50.719553-05:00"
   },
   "https://gohugo.io/templates/render-hooks/": {
     "StatusCode": 206,


### PR DESCRIPTION
> [!IMPORTANT]
> This preliminary core feature implementation is **experimental**.

---

- Adds a "render hook" for page content right after the `td-content` `<header>`, and so just before the page `.Content`.
- Adds nothing more so that projects can experiment with use of site/page params etc. Docsy isn't ready yet to commit to richer solutions for #1773 and the like.
- The base hook template is empty. 
- Processes the template using [.Render](https://gohugo.io/methods/page/render/), which means that template lookup is based on [content type](https://gohugo.io/quick-reference/glossary/#content-type).
