### PR TITLE
Heading render hook: support all attributes

### DIFF
--- a/layouts/_default/_markup/td-render-heading.html
+++ b/layouts/_default/_markup/td-render-heading.html
@@ -1,5 +1,7 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}"
-  {{- with .Attributes.class }} class="{{ . }}" {{- end -}}
+<h{{ .Level }}
+  {{- range $key, $value := .Attributes -}}
+    {{ printf " %s=%q" $key (string $value) | safeHTMLAttr -}}
+  {{ end -}}
 >
   {{- .Text | safeHTML -}}
   {{ template "_default/_markup/_td-heading-self-link.html" . -}}

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -341,7 +341,6 @@ cascade:
 ```
 
 ## Heading self links
-{.test-class}
 
 Docsy supports build-time generation of heading self links using Hugo's
 `render-heading.html` [hook].


### PR DESCRIPTION
- Fixes #2205

The only change to the generated UG pages is due to the removed `.test-class`:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "dateModified|modified_time|data-proofer" -- ':(exclude)*.xml') | grep -v _print | grep ^diff
diff --git a/docs/adding-content/navigation/index.html b/docs/adding-content/navigation/index.html
```