### PR TITLE
Replace 404'd link to cross reference docs with API reference for relref

### DIFF
--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -278,7 +278,7 @@ External parsers may not be suitable for use with all deployment options, as you
 
 Hugo lets you specify links using normal Markdown syntax, though remember that you need to specify links relative to your site's root URL, and that relative URLs are left unchanged by Hugo in your site's generated HTML.
 
-Alternatively you can use Hugo's helper [`ref` and `relref` shortcodes](https://gohugo.io/content-management/cross-references/) for creating internal links that resolve to the correct URL. However, be aware this means your links will not appear as links at all if a user views your page outside your generated site, for example using the rendered Markdown feature in GitHub's web UI.
+Alternatively you can use Hugo's helper [`ref` and `relref` shortcodes](https://gohugo.io/functions/relref/) for creating internal links that resolve to the correct URL. However, be aware this means your links will not appear as links at all if a user views your page outside your generated site, for example using the rendered Markdown feature in GitHub's web UI.
 
 You can find (or add!) tips and gotchas for working with Hugo links in [Hugo Tips](/docs/best-practices/site-guidance).
 


### PR DESCRIPTION
The old link (https://gohugo.io/content-management/cross-references/) points to a page that no longer exists. I replaced the 404 link with a new link that points to the nearest best docs page replacement.