### PR TITLE
Rename Docsy's render-heading hook and helper partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,16 @@ Useful links:
 
 For the full list of changes, see the [0.x.y] release notes.
 
-**Potential breaking change**:
+**Breaking changes**:
+
+- Renames the default Docsy heading render hook and heading self-link partials.
+  This is a breaking change only if your project uses this feature. For details,
+  see [Heading self links][] ([#2223]).
+
+**Potential breaking changes**:
 
 - Removes shortcode `figure`, hugo's built-in shortcode `figure` can/will be
-  used instead
+  used instead.
 
 **New**:
 
@@ -53,9 +59,12 @@ For the full list of changes, see the [0.x.y] release notes.
 [#1788]: https://github.com/google/docsy/issues/1788
 [#2160]: https://github.com/google/docsy/pull/2160
 [#2192]: https://github.com/google/docsy/pull/2192
+[#2223]: https://github.com/google/docsy/pull/2223
 [Breadcrumb navigation]:
   https://www.docsy.dev/docs/adding-content/navigation/#breadcrumb-navigation
 [content type]: https://gohugo.io/quick-reference/glossary/#content-type
+[Heading self links]:
+  https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links
 [td-content-after-header.html]:
   https://github.com/google/docsy/blob/main/layouts/_default/td-content-after-header.html
 
@@ -137,7 +146,8 @@ this release are listed next.
   form `--KIND`. The new suffix is `__KIND`. For details, see [Disabling links].
 
 - **Heading self-link** support has been reimplemented and projects must now
-  explicitly enable the feature. For details, see [Heading self links].
+  explicitly enable the feature. For details, see [Heading self
+  links][0.9.0:hsl].
 
 **Footer changes**: refactoring, for easier customization, and simplification.
 For details concerning all footer changes, see [#1818].
@@ -165,7 +175,7 @@ For details concerning all footer changes, see [#1818].
 [Footer layout]: https://www.docsy.dev/blog/2024/0.9.0/#footer-layout
 [Footer copyright]: https://www.docsy.dev/blog/2024/0.9.0/#footer-copyright
 [Footer streamlined]: https://www.docsy.dev/blog/2024/0.9.0/#footer-streamlined
-[Heading self links]: https://www.docsy.dev/blog/2024/0.9.0/#heading-self-links
+[0.9.0:hsl]: https://www.docsy.dev/blog/2024/0.9.0/#heading-self-links
 [look and feel]: https://www.docsy.dev/blog/2024/0.9.0/#look-and-feel
 [mermaid]:
   https://www.docsy.dev/docs/adding-content/diagrams-and-formulae/#diagrams-with-mermaid

--- a/layouts/partials/td/render-heading.html
+++ b/layouts/partials/td/render-heading.html
@@ -4,9 +4,9 @@
   {{ end -}}
 >
   {{- .Text | safeHTML -}}
-  {{ template "_default/_markup/_td-heading-self-link.html" . -}}
+  {{ partial "td/heading-self-link.html" . -}}
 </h{{ .Level }}>
 
-{{- define "_default/_markup/_td-heading-self-link.html" -}}
+{{- define "partials/td/heading-self-link.html" -}}
 <a class="td-heading-self-link" href="#{{ .Anchor | safeURL }}" aria-label="Heading self-link"></a>
 {{- end -}}

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -345,11 +345,11 @@ cascade:
 Docsy supports build-time generation of heading self links using Hugo's
 `render-heading.html` [hook].
 
-To enable this feature in
-your project, define `layouts/_default/_markup/render-heading.html` as:
+To enable this feature in your project, define
+`layouts/_default/_markup/render-heading.html` as:
 
 ```go-html-template
-{{ template "_default/_markup/td-render-heading.html" . }}
+{{ partial "td/render-heading.html" . }}
 ```
 
 The heading self-link anchor class is `.td-heading-self-link`, which you can
@@ -360,12 +360,11 @@ customize for your project. By default, the heading self-link style has these de
   visible on hover or focus.
 
 Your projects can also reuse (in your own custom heading render hook) or
-override the heading self-link template
-`_default/_markup/_td-heading-self-link.html`, which is defined in
-[layouts/_default/_markup/td-render-heading.html].
+override the heading self-link partial `td/heading-self-link.html`, which is
+defined in [layouts/partials/td/render-heading.html].
 
 [configuration file]:
   https://gohugo.io/getting-started/configuration/#configuration-file
-[layouts/_default/_markup/td-render-heading.html]:
-  https://github.com/google/docsy/tree/main/layouts/_default/_markup/td-render-heading.html
+[layouts/partials/td/render-heading.html]:
+  https://github.com/google/docsy/tree/main/layouts/partials/td/render-heading.html
 [hook]: https://gohugo.io/templates/render-hooks/

--- a/userguide/layouts/_default/_markup/render-heading.html
+++ b/userguide/layouts/_default/_markup/render-heading.html
@@ -1,4 +1,4 @@
-{{ template "_default/_markup/td-render-heading.html" . -}}
+{{ partial "td/render-heading.html" . -}}
 
 {{/* By default, the markdown processor emits a heading on its own line, so we
 don't trim whitespace from the end of this template. */}}

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -575,6 +575,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-02-10T11:24:51.123801-05:00"
   },
+  "https://github.com/google/docsy/pull/2223": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-24T08:05:34.239565-04:00"
+  },
   "https://github.com/google/docsy/pulls": {
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:03:15.642661-05:00"
@@ -1050,6 +1054,10 @@
   "https://www.docsy.dev/docs/adding-content/navigation/#breadcrumb-navigation": {
     "StatusCode": 206,
     "LastSeen": "2025-01-08T13:26:58.452656-05:00"
+  },
+  "https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links": {
+    "StatusCode": 206,
+    "LastSeen": "2025-04-23T19:48:15.989167-04:00"
   },
   "https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options": {
     "StatusCode": 206,


### PR DESCRIPTION
- **Changes due to new template system introduced in [Hugo v0.146.0](https://github.com/gohugoio/hugo/releases/tag/v0.146.0)**
- Fixes #2214
- Renames the Docsy render-heading partial and it's heading self-link helper
- Updates the User Guide accordingly
- There are no changes to the generated UG pages, other than the specific doc updates -- which tells us that the renames were a clean refactoring
- Updates the CHANGELOG
- Does NOT update the Hugo version yet because doing so surfaces other issues, which I'll document separately