### PR TITLE
Update pkgs: Hugo to 0.147.0, etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "^0.145.0",
-    "netlify-cli": "^19.0.2",
-    "npm-check-updates": "^17.1.15",
+    "hugo-extended": "^0.147.0",
+    "netlify-cli": "^20.1.1",
+    "npm-check-updates": "^18.0.1",
     "prettier": "^3.5.3"
   },
   "engines": {


### PR DESCRIPTION
- Fixes #2224
- Upgrades NPM packages, Hugo 0.147.0

UG diff:

```diff
$ (cd userguide/public && git diff)             
diff --git a/index.html b/index.html
index 8445bec..8169628 100644
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html itemscope itemtype="http://schema.org/WebPage" lang="en" class="no-js">
   <head>
-       <meta name="generator" content="Hugo 0.145.0">
+       <meta name="generator" content="Hugo 0.147.0">
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="robots" content="noindex, nofollow">
diff --git a/robots.txt b/robots.txt
index 4f9540b..7d329b1 100644
--- a/robots.txt
+++ b/robots.txt
@@ -1 +1 @@
-User-agent: *
\ No newline at end of file
+User-agent: *
```