### PR TITLE
[UG] Run Prettier over all pages under `adding-content`

### DIFF
--- a/tools/prettier-ignore-helper.pl
+++ b/tools/prettier-ignore-helper.pl
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl -w
+
+use strict;
+use warnings;
+
+foreach my $file (@ARGV) {
+    open my $in,  '<', $file or die "Cannot open $file: $!";
+    my @lines = <$in>;
+    close $in;
+
+    open my $out, '>', $file or die "Cannot write to $file: $!";
+
+    my $inside_tabpane = 0;
+    my $inside_ignore = 0;
+
+    while (@lines) {
+        my $line = shift @lines;
+
+        if ($line =~ /<!--\s*prettier-ignore-start\s*-->/) {
+            $inside_ignore = 1;
+        } elsif ($line =~ /<!--\s*prettier-ignore-end\s*-->/) {
+            $inside_ignore = 0;
+        } elsif ($line =~ /^\s*\{\{<\s*tabpane\s*>\}\}\s*$/) {
+            if (!$inside_ignore) {
+                print $out "<!-- prettier-ignore-start -->\n";
+                $inside_ignore = 1;
+            }
+            $inside_tabpane = 1;
+        } elsif ($inside_tabpane && $line =~ /^\s*\{\{<\s*\/tabpane\s*>\}\}\s*$/) {
+            print $out $line;
+            # If not already inside ignore, insert ignore-end
+            if ($inside_ignore) {
+                print $out "<!-- prettier-ignore-end -->\n";
+                $inside_ignore = 0;
+            }
+            $inside_tabpane = 0;
+            next;
+        }
+
+        print $out $line;
+    }
+
+    close $out;
+}
+
+print "Processed ", scalar(@ARGV), " files.\n";

--- a/tools/prettier-ignore-helper.pl
+++ b/tools/prettier-ignore-helper.pl
@@ -31,7 +31,7 @@ foreach my $file (@ARGV) {
         }
 
         # Detect non-indented tabpane opening
-        if (!$inside_ignore && $line =~ /^\s*\{\{<\s*tabpane\s*>\}\}\s*$/ && $line !~ /^\s{1,}\{\{<\s*tabpane\s*>\}\}\s*$/) {
+        if (!$inside_ignore && $line =~ /^\s*\{\{<\s*tabpane.*?>\}\}\s*$/ && $line !~ /^\s{1,}\{\{<\s*tabpane.*?>\}\}\s*$/) {
             # Only process if NOT indented (no leading spaces/tabs)
             if ($i == 0 || $lines[$i-1] !~ /<!--\s*prettier-ignore-start\s*-->/) {
                 print $out "<!-- prettier-ignore-start -->\n";
@@ -58,8 +58,8 @@ foreach my $file (@ARGV) {
         # Detect indented tabpane opening/closing not in an ignore region and warn
         if (!$inside_ignore &&
             (
-                ($line =~ /^\s+\{\{<\s*tabpane\s*>\}\}\s*$/) ||
-                ($line =~ /^\s+\{\{<\s*\/tabpane\s*>\}\}\s*$/)
+                ($line =~ /^\s+\{\{<\s*tabpane.*?>\}\}\s*$/) ||
+                ($line =~ /^\s+\{\{<\s*\/tabpane.*?>\}\}\s*$/)
             )
         ) {
             print STDERR "$file:", $i+1, ": WARNING: Indented tabpane shortcode found, usually because it is in a list. Add prettier-ignore directive manually before the start of the list.\n";

--- a/userguide/.prettierignore
+++ b/userguide/.prettierignore
@@ -11,9 +11,9 @@
 
 !/content/en/docs/adding-content
 /content/en/docs/adding-content/*
-!/content/en/docs/adding-content/search.md
-
+!/content/en/docs/adding-content/content.md
 !/content/en/docs/adding-content/lookandfeel.md
+!/content/en/docs/adding-content/search.md
 !/content/en/docs/adding-content/taxonomy.md
 
 !/static

--- a/userguide/.prettierignore
+++ b/userguide/.prettierignore
@@ -10,14 +10,5 @@
 !/content/en/docs
 /content/en/docs/*
 !/content/en/docs/_index.md
-
 !/content/en/docs/adding-content
-/content/en/docs/adding-content/*
-
-!/content/en/docs/adding-content/content.md
-!/content/en/docs/adding-content/lookandfeel.md
-!/content/en/docs/adding-content/navigation.md
-!/content/en/docs/adding-content/search.md
-!/content/en/docs/adding-content/taxonomy.md
-
 !/static

--- a/userguide/.prettierignore
+++ b/userguide/.prettierignore
@@ -1,3 +1,5 @@
+# cSpell:ignore lookandfeel
+
 .*
 /*
 !/content
@@ -11,8 +13,10 @@
 
 !/content/en/docs/adding-content
 /content/en/docs/adding-content/*
+
 !/content/en/docs/adding-content/content.md
 !/content/en/docs/adding-content/lookandfeel.md
+!/content/en/docs/adding-content/navigation.md
 !/content/en/docs/adding-content/search.md
 !/content/en/docs/adding-content/taxonomy.md
 

--- a/userguide/content/en/docs/adding-content/_index.md
+++ b/userguide/content/en/docs/adding-content/_index.md
@@ -1,7 +1,5 @@
 ---
-title: "Content and Customization"
-linkTitle: "Content and Customization"
+title: Content and Customization
 weight: 3
-description: >
-  How to add content to and customize your Docsy site.
+description: How to add content to and customize your Docsy site.
 ---

--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -420,6 +420,7 @@ weight: 20
 
 To add author and date information to blog posts, add them to the page frontmatter:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -731,6 +732,7 @@ sitemap:
 
 To override any of these values for a given page, specify it in page frontmatter:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}

--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -5,33 +5,75 @@ description: >
   Add different types of content to your Docsy site.
 ---
 
-So you've got a new Hugo website with Docsy, now it's time to add some content! This page tells you how to use the theme to add and structure your site content.
+So you've got a new Hugo website with Docsy, now it's time to add some content!
+This page tells you how to use the theme to add and structure your site content.
 
 ## Content root directory
 
-You add content for your site under the **content root directory** of your Hugo site project - either `content/` or a [language-specific](/docs/language/) root like `content/en/`. The main exception here is static files that you don't want built into your site: you can find out more about where you add these below in [Adding static content](#adding-static-content). The files in your content root directory are typically grouped in subdirectories corresponding to your site's sections and templates, which we'll look at in [Content sections and templates](#content-sections-and-templates).
+You add content for your site under the **content root directory** of your Hugo
+site project - either `content/` or a [language-specific](/docs/language/) root
+like `content/en/`. The main exception here is static files that you don't want
+built into your site: you can find out more about where you add these below in
+[Adding static content](#adding-static-content). The files in your content root
+directory are typically grouped in subdirectories corresponding to your site's
+sections and templates, which we'll look at in
+[Content sections and templates](#content-sections-and-templates).
 
-You can find out more about Hugo directory structure in [Directory Structure Explained](https://gohugo.io/getting-started/directory-structure/#directory-structure-explained).
+You can find out more about Hugo directory structure in
+[Directory Structure Explained](https://gohugo.io/getting-started/directory-structure/#directory-structure-explained).
 
 ## Content sections and templates
 
-Hugo builds your site pages using the content files you provide plus any templates provided by your site's theme. These templates (or *"layouts"* in Hugo terminology) include things like your page's headers, footers, navigation, and links to stylesheets: essentially, everything except your page's specific content. The templates in turn can be made up of *partials*: little reusable snippets of HTML for page elements like headers, search boxes, and more.
+Hugo builds your site pages using the content files you provide plus any
+templates provided by your site's theme. These templates (or _"layouts"_ in Hugo
+terminology) include things like your page's headers, footers, navigation, and
+links to stylesheets: essentially, everything except your page's specific
+content. The templates in turn can be made up of _partials_: little reusable
+snippets of HTML for page elements like headers, search boxes, and more.
 
-Because most technical documentation sites have different sections for different types of content, the Docsy theme comes with the [following templates](https://github.com/google/docsy/tree/main/layouts) for top-level site sections that you might need:
+Because most technical documentation sites have different sections for different
+types of content, the Docsy theme comes with the
+[following templates](https://github.com/google/docsy/tree/main/layouts) for
+top-level site sections that you might need:
 
-* [`docs`](https://github.com/google/docsy/tree/main/layouts/docs) is for pages in your site's Documentation section.
-* [`blog`](https://github.com/google/docsy/tree/main/layouts/blog) is for pages in your site's Blog.
-* [`community`](https://github.com/google/docsy/tree/main/layouts/community) is for your site's Community page.
+- [`docs`](https://github.com/google/docsy/tree/main/layouts/docs) is for pages
+  in your site's Documentation section.
+- [`blog`](https://github.com/google/docsy/tree/main/layouts/blog) is for pages
+  in your site's Blog.
+- [`community`](https://github.com/google/docsy/tree/main/layouts/community) is
+  for your site's Community page.
 
-It also provides a [default "landing page" type of template](https://github.com/google/docsy/tree/main/layouts/_default) with the site header and footer, but no left nav, that you can use for any other section. In this site and our example site it's used for the site [home page](/) and the [About](/about/) page.
+It also provides a
+[default "landing page" type of template](https://github.com/google/docsy/tree/main/layouts/_default)
+with the site header and footer, but no left nav, that you can use for any other
+section. In this site and our example site it's used for the site [home page](/)
+and the [About](/about/) page.
 
-Each top-level **section** in your site corresponds to a **directory** in your site content root. Hugo automatically applies the appropriate **template** for that section, depending on which folder the content is in. For example, this page is in the `docs` subdirectory of the site's content root directory `content/en/`, so Hugo automatically applies the `docs` template. You can override this by explicitly specifying a template or content type for a particular page.
+Each top-level **section** in your site corresponds to a **directory** in your
+site content root. Hugo automatically applies the appropriate **template** for
+that section, depending on which folder the content is in. For example, this
+page is in the `docs` subdirectory of the site's content root directory
+`content/en/`, so Hugo automatically applies the `docs` template. You can
+override this by explicitly specifying a template or content type for a
+particular page.
 
-If you've copied the example site, you already have appropriately named top-level section directories for using Docsy's templates, each with an index page ( `_index.md` or `index.html`) page for users to land on. These top-level sections also appear in the example site's [top-level menu](/docs/adding-content/navigation/#top-level-menu).
+If you've copied the example site, you already have appropriately named
+top-level section directories for using Docsy's templates, each with an index
+page ( `_index.md` or `index.html`) page for users to land on. These top-level
+sections also appear in the example site's
+[top-level menu](/docs/adding-content/navigation/#top-level-menu).
 
 ### Custom sections
 
-If you've copied the example site and *don't* want to use one of the provided content sections, just delete the appropriate content subdirectory. Similarly, if you want to add a top-level section, just add a new subdirectory, though you'll need to specify the layout or content type explicitly in the [frontmatter](#page-frontmatter) of each page if you want to use any existing Docsy template other than the default one. For example, if you create a new directory `content/en/amazing` and want one or more pages in that custom section to use Docsy's `docs` template, you add `type: docs` to the frontmatter of each page:
+If you've copied the example site and _don't_ want to use one of the provided
+content sections, just delete the appropriate content subdirectory. Similarly,
+if you want to add a top-level section, just add a new subdirectory, though
+you'll need to specify the layout or content type explicitly in the
+[frontmatter](#page-frontmatter) of each page if you want to use any existing
+Docsy template other than the default one. For example, if you create a new
+directory `content/en/amazing` and want one or more pages in that custom section
+to use Docsy's `docs` template, you add `type: docs` to the frontmatter of each
+page:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -66,19 +108,33 @@ description: >
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-Alternatively, create your own page template for your new section in your project's `layouts` directory based on one of the existing templates.
+Alternatively, create your own page template for your new section in your
+project's `layouts` directory based on one of the existing templates.
 
-You can find out much more about how Hugo page layouts work in [Hugo Templates](https://gohugo.io/templates/). The rest of this page tells you about how to add content and use each of Docsy's templates.
+You can find out much more about how Hugo page layouts work in
+[Hugo Templates](https://gohugo.io/templates/). The rest of this page tells you
+about how to add content and use each of Docsy's templates.
 
 ### Alternative site structure
 
-As noted above, by default your site has a home page (using the `_default` layout), a docs section under `/docs/`, a blog section under `/blog/` and a community section under `/community/`.   [The type](https://gohugo.io/content-management/types/) of each section (which determines the layout it uses) matches its directory name.
+As noted above, by default your site has a home page (using the `_default`
+layout), a docs section under `/docs/`, a blog section under `/blog/` and a
+community section under `/community/`.
+[The type](https://gohugo.io/content-management/types/) of each section (which
+determines the layout it uses) matches its directory name.
 
-In some cases, you may want to have a different directory structure, but still make use of Docsy's layouts. A common example is for a "docs site", where most of the pages (including the home page) use the docs layout, or perhaps you'd rather have a `/news/` directory treated with the blog layout.
+In some cases, you may want to have a different directory structure, but still
+make use of Docsy's layouts. A common example is for a "docs site", where most
+of the pages (including the home page) use the docs layout, or perhaps you'd
+rather have a `/news/` directory treated with the blog layout.
 
-Since Hugo 0.76, this has become practical without copying layouts to your site, or having to specify `type: blog` on every single page by making use of [target specific cascading front matter](https://gohugo.io/content-management/front-matter/#target-specific-pages).
+Since Hugo 0.76, this has become practical without copying layouts to your site,
+or having to specify `type: blog` on every single page by making use of
+[target specific cascading front matter](https://gohugo.io/content-management/front-matter/#target-specific-pages).
 
-For example, for the `/news/` section, you can specify the following front matter in the index page which will change the type of the section and everything below it to "blog":
+For example, for the `/news/` section, you can specify the following front
+matter in the index page which will change the type of the section and
+everything below it to "blog":
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -126,8 +182,9 @@ cascade:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-
-If you want to create a "docs" site, specifying something like the following in the top level `_index.md` will set all top level sections to be treated as "docs", except for "news":
+If you want to create a "docs" site, specifying something like the following in
+the top level `_index.md` will set all top level sections to be treated as
+"docs", except for "news":
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -187,13 +244,22 @@ cascade:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-Note the addition of `toc_root` here.  Setting that to true for a section causes it to be treated as a separate part of the site, with its own left hand navigation menu.
+Note the addition of `toc_root` here. Setting that to true for a section causes
+it to be treated as a separate part of the site, with its own left hand
+navigation menu.
 
-An example docs-based site that uses this technique can be found at the [mostly docs](https://github.com/gwatts/mostlydocs/) repo.
+An example docs-based site that uses this technique can be found at the
+[mostly docs](https://github.com/gwatts/mostlydocs/) repo.
 
 ## Page frontmatter
 
-Each page file in a Hugo site has metadata frontmatter that tells Hugo about the page. You specify page frontmatter in TOML, YAML, or JSON (our example site and this site use YAML). Use the frontmatter to specify the page title, description, creation date, link title, template, menu weighting, and even any resources such as images used by the page. You can see a complete list of possible page frontmatter in [Front Matter](https://gohugo.io/content-management/front-matter/).
+Each page file in a Hugo site has metadata frontmatter that tells Hugo about the
+page. You specify page frontmatter in TOML, YAML, or JSON (our example site and
+this site use YAML). Use the frontmatter to specify the page title, description,
+creation date, link title, template, menu weighting, and even any resources such
+as images used by the page. You can see a complete list of possible page
+frontmatter in
+[Front Matter](https://gohugo.io/content-management/front-matter/).
 
 For example, here's the frontmatter for this page:
 
@@ -230,19 +296,32 @@ description: >
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-The minimum frontmatter you need to provide is a title: everything else is up to you! However, if you leave out the page weight, your [navigation](/docs/adding-content/navigation) may get a little disorganized. You may also want to include `description` since Docsy uses that to generate the meta `description` tag used by search engines. See [Search Engine Optimization (SEO) meta tags]({{< ref "feedback#search-engine-optimization-meta-tags" >}}) for details.
-
+The minimum frontmatter you need to provide is a title: everything else is up to
+you! However, if you leave out the page weight, your
+[navigation](/docs/adding-content/navigation) may get a little disorganized. You
+may also want to include `description` since Docsy uses that to generate the
+meta `description` tag used by search engines. See [Search Engine Optimization
+(SEO) meta tags]({{< ref "feedback#search-engine-optimization-meta-tags" >}})
+for details.
 
 ## Page contents and markup
 
-By default you create pages in a Docsy site as simple [Markdown or HTML files](https://gohugo.io/content-management/formats/) with [page frontmatter](#page-frontmatter), as described above.
-As of version 0.100, [Goldmark](https://github.com/yuin/goldmark/) is the only Markdown parser supported by Hugo.
+By default you create pages in a Docsy site as simple
+[Markdown or HTML files](https://gohugo.io/content-management/formats/) with
+[page frontmatter](#page-frontmatter), as described above. As of version 0.100,
+[Goldmark](https://github.com/yuin/goldmark/) is the only Markdown parser
+supported by Hugo.
 
 <div class="alert alert-primary" role="alert">
 
 <h4 class="alert-heading">Tip</h4>
 
-If you've been using versions of Hugo before 0.60 that use [`BlackFriday`](https://github.com/russross/blackfriday) as its Markdown parser, you may need to make some small changes to your site to work with the current `Goldmark` Markdown parser. In particular, if you cloned an earlier version of our example site, add the following to your `hugo.toml`/`hugo.yaml`/`hugo.json` to allow Goldmark to render raw HTML as well as Markdown:
+If you've been using versions of Hugo before 0.60 that use
+[`BlackFriday`](https://github.com/russross/blackfriday) as its Markdown parser,
+you may need to make some small changes to your site to work with the current
+`Goldmark` Markdown parser. In particular, if you cloned an earlier version of
+our example site, add the following to your `hugo.toml`/`hugo.yaml`/`hugo.json`
+to allow Goldmark to render raw HTML as well as Markdown:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -275,59 +354,127 @@ markup:
 
 </div>
 
-In addition to your marked-up text, you can also use Hugo and Docsy's [shortcodes](/docs/adding-content/shortcodes): reusable chunks of HTML that you can use to quickly build your pages. Find out more about shortcodes in [Docsy Shortcodes](/docs/adding-content/shortcodes).
+In addition to your marked-up text, you can also use Hugo and Docsy's
+[shortcodes](/docs/adding-content/shortcodes): reusable chunks of HTML that you
+can use to quickly build your pages. Find out more about shortcodes in
+[Docsy Shortcodes](/docs/adding-content/shortcodes).
 
-{{% alert title="Note" color="info" %}}
-Hugo also supports adding content using other markups using [external parsers as helpers](https://gohugo.io/content-management/formats/#additional-formats-through-external-helpers). For example, you can add content in RST using `rst2html` as an external parser (though be aware this does not support all flavors of RST, such as Sphinx RST). Similarly, you can use `asciidoctor` to parse Asciidoc files, or `pandoc` for other formats.
+{{% alert title="Note" color="info" %}} Hugo also supports adding content using
+other markups using
+[external parsers as helpers](https://gohugo.io/content-management/formats/#additional-formats-through-external-helpers).
+For example, you can add content in RST using `rst2html` as an external parser
+(though be aware this does not support all flavors of RST, such as Sphinx RST).
+Similarly, you can use `asciidoctor` to parse Asciidoc files, or `pandoc` for
+other formats.
 
-External parsers may not be suitable for use with all deployment options, as you'll need to install the external parser and run Hugo yourself to generate your site (so, for example, you won't be able to use [Netlify's continuous deployment feature](/docs/deployment/#deployment-with-netlify)). In addition, adding an external parser may cause performance issues building larger sites.
-{{% /alert %}}
+External parsers may not be suitable for use with all deployment options, as
+you'll need to install the external parser and run Hugo yourself to generate
+your site (so, for example, you won't be able to use
+[Netlify's continuous deployment feature](/docs/deployment/#deployment-with-netlify)).
+In addition, adding an external parser may cause performance issues building
+larger sites. {{% /alert %}}
 
 ### Working with links
 
-Hugo lets you specify links using normal Markdown syntax, though remember that you need to specify links relative to your site's root URL, and that relative URLs are left unchanged by Hugo in your site's generated HTML.
+Hugo lets you specify links using normal Markdown syntax, though remember that
+you need to specify links relative to your site's root URL, and that relative
+URLs are left unchanged by Hugo in your site's generated HTML.
 
-Alternatively you can use Hugo's helper [`ref` and `relref` shortcodes](https://gohugo.io/functions/relref/) for creating internal links that resolve to the correct URL. However, be aware this means your links will not appear as links at all if a user views your page outside your generated site, for example using the rendered Markdown feature in GitHub's web UI.
+Alternatively you can use Hugo's helper
+[`ref` and `relref` shortcodes](https://gohugo.io/functions/relref/) for
+creating internal links that resolve to the correct URL. However, be aware this
+means your links will not appear as links at all if a user views your page
+outside your generated site, for example using the rendered Markdown feature in
+GitHub's web UI.
 
-You can find (or add!) tips and gotchas for working with Hugo links in [Hugo Tips](/docs/best-practices/site-guidance).
+You can find (or add!) tips and gotchas for working with Hugo links in
+[Hugo Tips](/docs/best-practices/site-guidance).
 
 ### Content style
 
-We don't mandate any particular style for your page contents. However, if you'd like some guidance on how to write and format clear, concise technical documentation, we recommend the [Google Developer Documentation Style Guide](https://developers.google.com/style/), particularly the [Style Guide Highlights](https://developers.google.com/style/highlights).
+We don't mandate any particular style for your page contents. However, if you'd
+like some guidance on how to write and format clear, concise technical
+documentation, we recommend the
+[Google Developer Documentation Style Guide](https://developers.google.com/style/),
+particularly the
+[Style Guide Highlights](https://developers.google.com/style/highlights).
 
 ## Page bundles
 
-You can create site pages as standalone files in their section or subsection directory, or as folders where the content is in the folder's index page. Creating a folder for your page lets you [bundle](https://gohugo.io/content-management/page-bundles/) images and other resources together with the content.
+You can create site pages as standalone files in their section or subsection
+directory, or as folders where the content is in the folder's index page.
+Creating a folder for your page lets you
+[bundle](https://gohugo.io/content-management/page-bundles/) images and other
+resources together with the content.
 
-You can see examples of both approaches in this and our example site. For example, the source for this page is just a standalone file `/content/en/docs/adding-content.md`. However the source for [Docsy Shortcodes](/docs/adding-content/shortcodes/) in this site lives in `/content/en/docs/adding-content/shortcodes/index.md`, with the image resource used by the page in the same `/shortcodes/` directory. In Hugo terminology, this is called a *leaf bundle* because it's a folder containing all the data for a single site page without any child pages (and uses `index.md` without an underscore).
+You can see examples of both approaches in this and our example site. For
+example, the source for this page is just a standalone file
+`/content/en/docs/adding-content.md`. However the source for
+[Docsy Shortcodes](/docs/adding-content/shortcodes/) in this site lives in
+`/content/en/docs/adding-content/shortcodes/index.md`, with the image resource
+used by the page in the same `/shortcodes/` directory. In Hugo terminology, this
+is called a _leaf bundle_ because it's a folder containing all the data for a
+single site page without any child pages (and uses `index.md` without an
+underscore).
 
-You can find out much more about managing resources with Hugo bundles in [Page Bundles](https://gohugo.io/content-management/page-bundles/).
+You can find out much more about managing resources with Hugo bundles in
+[Page Bundles](https://gohugo.io/content-management/page-bundles/).
 
 ## Adding docs and blog posts
 
-The template you'll probably use most often is the [`docs` template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html) (as used in this page) or the very similar [`blog` template](https://github.com/google/docsy/blob/main/layouts/blog/baseof.html). Both these templates include:
+The template you'll probably use most often is the
+[`docs` template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html)
+(as used in this page) or the very similar
+[`blog` template](https://github.com/google/docsy/blob/main/layouts/blog/baseof.html).
+Both these templates include:
 
-* a left nav
-* GitHub links (populated from your site config) for readers to edit the page or create issues
-* a page menu
+- a left nav
+- GitHub links (populated from your site config) for readers to edit the page or
+  create issues
+- a page menu
 
-as well as the common header and footer used by all your site's pages. Which template is applied depends on whether you've added the content to the `blog` or `docs` content directory. You can find out more about how the nav and page menu are created in [Navigation and Search](/docs/adding-content/navigation/).
+as well as the common header and footer used by all your site's pages. Which
+template is applied depends on whether you've added the content to the `blog` or
+`docs` content directory. You can find out more about how the nav and page menu
+are created in [Navigation and Search](/docs/adding-content/navigation/).
 
 ### Organizing your documentation
 
-While Docsy's top-level sections let you create site sections for different types of content, you may also want to organize your docs content within your `docs` section. For example, this site's `docs` section directory has multiple subdirectories for **Getting Started**, **Content and Customization**, and so on. Each subdirectory has an `_index.md` (it could also be an `_index.html`), which acts as a section index page and tells Hugo that the relevant directory is a subsection of your docs.
+While Docsy's top-level sections let you create site sections for different
+types of content, you may also want to organize your docs content within your
+`docs` section. For example, this site's `docs` section directory has multiple
+subdirectories for **Getting Started**, **Content and Customization**, and so
+on. Each subdirectory has an `_index.md` (it could also be an `_index.html`),
+which acts as a section index page and tells Hugo that the relevant directory is
+a subsection of your docs.
 
-Docsy's `docs` layout gives you a left nav pane with an autogenerated nested menu based on your `docs` file structure. Each standalone page or subsection `_index.md` or `_index.html`  page in the `docs/` directory gets a top level menu item, using the link name and `weight` metadata from the page or index.
+Docsy's `docs` layout gives you a left nav pane with an autogenerated nested
+menu based on your `docs` file structure. Each standalone page or subsection
+`_index.md` or `_index.html` page in the `docs/` directory gets a top level menu
+item, using the link name and `weight` metadata from the page or index.
 
-To add docs to a subsection, just add your page files to the relevant subdirectory. Any pages that you add to a subsection in addition to the subsection index page will appear in a submenu (look to the left to see one in action!), again ordered by page `weight`. Find out more about adding Docsy's navigation metadata in [Navigation and Search](/docs/adding-content/navigation/)
+To add docs to a subsection, just add your page files to the relevant
+subdirectory. Any pages that you add to a subsection in addition to the
+subsection index page will appear in a submenu (look to the left to see one in
+action!), again ordered by page `weight`. Find out more about adding Docsy's
+navigation metadata in [Navigation and Search](/docs/adding-content/navigation/)
 
-If you've copied the example site, you'll already have some suggested subdirectories in your `docs` directory, with guidance for what types of content to put in them and some example Markdown pages. You can find out more about organizing your content with Docsy in [Organizing Your Content](/docs/best-practices/organizing-content/).
+If you've copied the example site, you'll already have some suggested
+subdirectories in your `docs` directory, with guidance for what types of content
+to put in them and some example Markdown pages. You can find out more about
+organizing your content with Docsy in
+[Organizing Your Content](/docs/best-practices/organizing-content/).
 
 #### Docs section landing pages
 
-By default a docs section landing page (the `_index.md` or `_index.html` in the section directory) uses a layout that adds a formatted list of links to the pages in the section, with their frontmatter descriptions. The [Content and Customization](/docs/adding-content/) landing page in this site is a good example.
+By default a docs section landing page (the `_index.md` or `_index.html` in the
+section directory) uses a layout that adds a formatted list of links to the
+pages in the section, with their frontmatter descriptions. The
+[Content and Customization](/docs/adding-content/) landing page in this site is
+a good example.
 
-To display a simple bulleted list of links to the section's pages instead, specify `simple_list: true` in the landing page's frontmatter:
+To display a simple bulleted list of links to the section's pages instead,
+specify `simple_list: true` in the landing page's frontmatter:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -356,7 +503,8 @@ weight: 20
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To display no links at all, specify `no_list: true` in the landing page's frontmatter:
+To display no links at all, specify `no_list: true` in the landing page's
+frontmatter:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -387,9 +535,18 @@ weight: 20
 
 ### Organizing your blog posts
 
-Docsy's `blog` layout also gives you a left nav menu (like the `docs` layout), and a list-type index page for your blog that's applied to `/blog/_index.md` and automatically displays snippets of all your recent posts in reverse chronological order.
+Docsy's `blog` layout also gives you a left nav menu (like the `docs` layout),
+and a list-type index page for your blog that's applied to `/blog/_index.md` and
+automatically displays snippets of all your recent posts in reverse
+chronological order.
 
-To create different blog categories to organize your posts, create subfolders in `blog/`. For instance, in our [example site](https://github.com/google/docsy-example/tree/main/content/en/blog) we have `news` and `releases`. Each category needs to have its own `_index.md` or `_index.html` landing page file specifying the category title for it to appear properly in the left nav and top-level blog landing page. Here's the index page for `releases`:
+To create different blog categories to organize your posts, create subfolders in
+`blog/`. For instance, in our
+[example site](https://github.com/google/docsy-example/tree/main/content/en/blog)
+we have `news` and `releases`. Each category needs to have its own `_index.md`
+or `_index.html` landing page file specifying the category title for it to
+appear properly in the left nav and top-level blog landing page. Here's the
+index page for `releases`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -418,7 +575,8 @@ weight: 20
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To add author and date information to blog posts, add them to the page frontmatter:
+To add author and date information to blog posts, add them to the page
+frontmatter:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -474,28 +632,49 @@ resources:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If you've copied the example site and you don't want a blog section, or want to link to an external blog instead, just delete the `blog` subdirectory.
-
+If you've copied the example site and you don't want a blog section, or want to
+link to an external blog instead, just delete the `blog` subdirectory.
 
 ## Working with top-level landing pages.
 
-Docsy's [default page template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html) has no left nav and is useful for creating a home page for your site or other "landing" type pages.
+Docsy's
+[default page template](https://github.com/google/docsy/blob/main/layouts/docs/baseof.html)
+has no left nav and is useful for creating a home page for your site or other
+"landing" type pages.
 
 ### Customizing the example site pages
 
-If you've copied the example site, you already have a simple site landing page in `content/en/_index.html`. This is made up of Docsy's provided Hugo shortcode [page blocks](/docs/adding-content/shortcodes/#shortcode-blocks).
+If you've copied the example site, you already have a simple site landing page
+in `content/en/_index.html`. This is made up of Docsy's provided Hugo shortcode
+[page blocks](/docs/adding-content/shortcodes/#shortcode-blocks).
 
-To customize the large landing image, which is in a [cover](/docs/adding-content/shortcodes/#blockscover) block, replace the `content/en/featured-background.jpg` file in your project with your own image (it can be called whatever you like as long as it has `background` in the file name). You can remove or add as many blocks as you like, as well as adding your own custom content.
+To customize the large landing image, which is in a
+[cover](/docs/adding-content/shortcodes/#blockscover) block, replace the
+`content/en/featured-background.jpg` file in your project with your own image
+(it can be called whatever you like as long as it has `background` in the file
+name). You can remove or add as many blocks as you like, as well as adding your
+own custom content.
 
-The example site also has an About page in `content/en/about/_index.html` using the same Docsy template. Again, this is made up of [page blocks](/docs/adding-content/shortcodes/#shortcode-blocks), including another background image in `content/en/about/featured-background.jpg`. As with the site landing page, you can replace the image, remove or add blocks, or just add your own content.
+The example site also has an About page in `content/en/about/_index.html` using
+the same Docsy template. Again, this is made up of
+[page blocks](/docs/adding-content/shortcodes/#shortcode-blocks), including
+another background image in `content/en/about/featured-background.jpg`. As with
+the site landing page, you can replace the image, remove or add blocks, or just
+add your own content.
 
 ### Building your own landing pages
 
-If you've just used the theme, you can still use all Docsy's provided [page blocks](/docs/adding-content/shortcodes/#shortcode-blocks) (or any other content you want) to build your own landing pages in the same file locations.
+If you've just used the theme, you can still use all Docsy's provided
+[page blocks](/docs/adding-content/shortcodes/#shortcode-blocks) (or any other
+content you want) to build your own landing pages in the same file locations.
 
 ## Adding a community page
 
-The `community` landing page template has boilerplate content that's automatically filled in with the project name and community links specified in `hugo.toml`/`hugo.yaml`/`hugo.json`, providing your users with quick links to resources that help them get involved in your project. The same links are also added by default to your site footer.
+The `community` landing page template has boilerplate content that's
+automatically filled in with the project name and community links specified in
+`hugo.toml`/`hugo.yaml`/`hugo.json`, providing your users with quick links to
+resources that help them get involved in your project. The same links are also
+added by default to your site footer.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -616,7 +795,10 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If you're creating your own site and want to add a page using this template, add a `/community/_index.md` file in your content root directory. If you've copied the example site and *don't* want a community page, just delete the `/content/en/community/` directory in your project repo.
+If you're creating your own site and want to add a page using this template, add
+a `/community/_index.md` file in your content root directory. If you've copied
+the example site and _don't_ want a community page, just delete the
+`/content/en/community/` directory in your project repo.
 
 By default, Docsy layouts assume that your project's contributing page is found
 at `<baseURL>/docs/contribution-guidelines`. To specify another URL, add it to
@@ -630,16 +812,26 @@ params:
 
 ## Adding static content
 
-You may want to serve some non-Hugo-built content along with your site: for example, if you have generated reference docs using Doxygen, Javadoc, or other doc generation tools.
+You may want to serve some non-Hugo-built content along with your site: for
+example, if you have generated reference docs using Doxygen, Javadoc, or other
+doc generation tools.
 
-To add static content to be served "as-is", just add the content as a folder and/or files in your site's `static` directory. When your site is deployed, content in this directory is served at the site root path. So, for example, if you have added content at `/static/reference/cpp/`, users can access that content at `http://{server-url}/reference/cpp/` and you can link to pages in this directory from other pages at `/reference/cpp/{file name}`.
+To add static content to be served "as-is", just add the content as a folder
+and/or files in your site's `static` directory. When your site is deployed,
+content in this directory is served at the site root path. So, for example, if
+you have added content at `/static/reference/cpp/`, users can access that
+content at `http://{server-url}/reference/cpp/` and you can link to pages in
+this directory from other pages at `/reference/cpp/{file name}`.
 
-You can also use this directory for other files used by your project, including image files. You can find out more about serving static files, including configuring multiple directories for static content, in [Static Files](https://gohugo.io/content-management/static-files/).
+You can also use this directory for other files used by your project, including
+image files. You can find out more about serving static files, including
+configuring multiple directories for static content, in
+[Static Files](https://gohugo.io/content-management/static-files/).
 
 ## RSS feeds
 
-Hugo will, by default, create an RSS feed for the home page and any section.
-To disable all RSS feeds, add the following to your
+Hugo will, by default, create an RSS feed for the home page and any section. To
+disable all RSS feeds, add the following to your
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
@@ -661,12 +853,18 @@ disableKinds: [RSS]
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-
 <div class="alert alert-info" role="alert">
 
 <h4 class="alert-heading">Note</h4>
 
-If you have enabled our [print feature](/docs/adding-content/print/) or otherwise specified section-level output formats in `hugo.toml`/`hugo.yaml`/`hugo.json`, make sure that `"RSS"` is listed as an output format, otherwise you won't get section-level RSS feeds (and your blog section won't get a nice orange RSS button). Your `hugo.toml`/`hugo.yaml`/`hugo.json` specification overrides the Hugo default [output formats](https://gohugo.io/templates/output-formats/) for sections, which are HTML and RSS.
+If you have enabled our [print feature](/docs/adding-content/print/) or
+otherwise specified section-level output formats in
+`hugo.toml`/`hugo.yaml`/`hugo.json`, make sure that `"RSS"` is listed as an
+output format, otherwise you won't get section-level RSS feeds (and your blog
+section won't get a nice orange RSS button). Your
+`hugo.toml`/`hugo.yaml`/`hugo.json` specification overrides the Hugo default
+[output formats](https://gohugo.io/templates/output-formats/) for sections,
+which are HTML and RSS.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -699,9 +897,12 @@ outputs:
 
 ## Sitemap
 
-Hugo creates a `sitemap.xml` file for your generated site by default: for example, [here's the sitemap](/sitemap.xml) for this site.
+Hugo creates a `sitemap.xml` file for your generated site by default: for
+example, [here's the sitemap](/sitemap.xml) for this site.
 
-You can configure the frequency with which your sitemap is updated, your sitemap filename, and the default page priority in your `hugo.toml`/`hugo.yaml`/`hugo.json`:
+You can configure the frequency with which your sitemap is updated, your sitemap
+filename, and the default page priority in your
+`hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -730,7 +931,8 @@ sitemap:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To override any of these values for a given page, specify it in page frontmatter:
+To override any of these values for a given page, specify it in page
+frontmatter:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -772,4 +974,5 @@ sitemap:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To learn more about configuring sitemaps, see [Sitemap Template](https://gohugo.io/templates/sitemap-template/).
+To learn more about configuring sitemaps, see
+[Sitemap Template](https://gohugo.io/templates/sitemap-template/).

--- a/userguide/content/en/docs/adding-content/content.md
+++ b/userguide/content/en/docs/adding-content/content.md
@@ -1,6 +1,5 @@
 ---
-title: "Adding Content"
-linkTitle: "Adding Content"
+title: Adding Content
 weight: 1
 description: >
   Add different types of content to your Docsy site.
@@ -34,6 +33,7 @@ If you've copied the example site, you already have appropriately named top-leve
 
 If you've copied the example site and *don't* want to use one of the provided content sections, just delete the appropriate content subdirectory. Similarly, if you want to add a top-level section, just add a new subdirectory, though you'll need to specify the layout or content type explicitly in the [frontmatter](#page-frontmatter) of each page if you want to use any existing Docsy template other than the default one. For example, if you create a new directory `content/en/amazing` and want one or more pages in that custom section to use Docsy's `docs` template, you add `type: docs` to the frontmatter of each page:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -64,6 +64,7 @@ description: >
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Alternatively, create your own page template for your new section in your project's `layouts` directory based on one of the existing templates.
 
@@ -79,6 +80,7 @@ Since Hugo 0.76, this has become practical without copying layouts to your site,
 
 For example, for the `/news/` section, you can specify the following front matter in the index page which will change the type of the section and everything below it to "blog":
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -122,10 +124,12 @@ cascade:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 
 If you want to create a "docs" site, specifying something like the following in the top level `_index.md` will set all top level sections to be treated as "docs", except for "news":
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -181,6 +185,7 @@ cascade:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Note the addition of `toc_root` here.  Setting that to true for a section causes it to be treated as a separate part of the site, with its own left hand navigation menu.
 
@@ -192,6 +197,7 @@ Each page file in a Hugo site has metadata frontmatter that tells Hugo about the
 
 For example, here's the frontmatter for this page:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -222,6 +228,7 @@ description: >
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 The minimum frontmatter you need to provide is a title: everything else is up to you! However, if you leave out the page weight, your [navigation](/docs/adding-content/navigation) may get a little disorganized. You may also want to include `description` since Docsy uses that to generate the meta `description` tag used by search engines. See [Search Engine Optimization (SEO) meta tags]({{< ref "feedback#search-engine-optimization-meta-tags" >}}) for details.
 
@@ -237,6 +244,7 @@ As of version 0.100, [Goldmark](https://github.com/yuin/goldmark/) is the only M
 
 If you've been using versions of Hugo before 0.60 that use [`BlackFriday`](https://github.com/russross/blackfriday) as its Markdown parser, you may need to make some small changes to your site to work with the current `Goldmark` Markdown parser. In particular, if you cloned an earlier version of our example site, add the following to your `hugo.toml`/`hugo.yaml`/`hugo.json` to allow Goldmark to render raw HTML as well as Markdown:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -263,6 +271,7 @@ markup:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 </div>
 
@@ -320,6 +329,7 @@ By default a docs section landing page (the `_index.md` or `_index.html` in the 
 
 To display a simple bulleted list of links to the section's pages instead, specify `simple_list: true` in the landing page's frontmatter:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -344,9 +354,11 @@ weight: 20
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To display no links at all, specify `no_list: true` in the landing page's frontmatter:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -371,6 +383,7 @@ weight: 20
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Organizing your blog posts
 
@@ -378,6 +391,7 @@ Docsy's `blog` layout also gives you a left nav menu (like the `docs` layout), a
 
 To create different blog categories to organize your posts, create subfolders in `blog/`. For instance, in our [example site](https://github.com/google/docsy-example/tree/main/content/en/blog) we have `news` and `releases`. Each category needs to have its own `_index.md` or `_index.html` landing page file specifying the category title for it to appear properly in the left nav and top-level blog landing page. Here's the index page for `releases`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -402,6 +416,7 @@ weight: 20
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To add author and date information to blog posts, add them to the page frontmatter:
 
@@ -456,6 +471,7 @@ resources:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If you've copied the example site and you don't want a blog section, or want to link to an external blog instead, just delete the `blog` subdirectory.
 
@@ -480,6 +496,7 @@ If you've just used the theme, you can still use all Docsy's provided [page bloc
 
 The `community` landing page template has boilerplate content that's automatically filled in with the project name and community links specified in `hugo.toml`/`hugo.yaml`/`hugo.json`, providing your users with quick links to resources that help them get involved in your project. The same links are also added by default to your site footer.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -596,6 +613,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If you're creating your own site and want to add a page using this template, add a `/community/_index.md` file in your content root directory. If you've copied the example site and *don't* want a community page, just delete the `/content/en/community/` directory in your project repo.
 
@@ -623,6 +641,7 @@ Hugo will, by default, create an RSS feed for the home page and any section.
 To disable all RSS feeds, add the following to your
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -639,6 +658,7 @@ disableKinds: [RSS]
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 
 <div class="alert alert-info" role="alert">
@@ -647,6 +667,7 @@ disableKinds: [RSS]
 
 If you have enabled our [print feature](/docs/adding-content/print/) or otherwise specified section-level output formats in `hugo.toml`/`hugo.yaml`/`hugo.json`, make sure that `"RSS"` is listed as an output format, otherwise you won't get section-level RSS feeds (and your blog section won't get a nice orange RSS button). Your `hugo.toml`/`hugo.yaml`/`hugo.json` specification overrides the Hugo default [output formats](https://gohugo.io/templates/output-formats/) for sections, which are HTML and RSS.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -672,6 +693,7 @@ outputs:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 </div>
 
 ## Sitemap
@@ -680,6 +702,7 @@ Hugo creates a `sitemap.xml` file for your generated site by default: for exampl
 
 You can configure the frequency with which your sitemap is updated, your sitemap filename, and the default page priority in your `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -704,6 +727,7 @@ sitemap:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To override any of these values for a given page, specify it in page frontmatter:
 
@@ -744,5 +768,6 @@ sitemap:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To learn more about configuring sitemaps, see [Sitemap Template](https://gohugo.io/templates/sitemap-template/).

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -67,6 +67,7 @@ As soon as you use a `math` code block on your page, support of \\(\KaTeX\\) is 
 
 If you want to use inline formulae and don't have a `math` code block present in your page which triggers auto activation, you need to manually activate \\(\KaTeX\\) support. The easiest way to do so is to add a `math` attribute to the frontmatter of your page and set it to `true`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Page front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -85,9 +86,11 @@ math: true
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If you use formulae in most of your pages, you can also enable sitewide \\(\KaTeX\\) support inside the Docsy theme. To do so update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -109,9 +112,11 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Additionally, you can customize various \\(\KaTeX\\) options inside `hugo.toml`/`hugo.yaml`/`hugo.json`, if needed:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -221,6 +226,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 For a complete list of options and their detailed description, have a look at the documentation of \\({\KaTeX}\\)'s [Rendering API options](https://katex.org/docs/autorender.html#api) and of \\({\KaTeX}\\)'s [configuration options](https://katex.org/docs/options.html).
 
@@ -283,6 +289,7 @@ As soon as you use a `chem` code block on your page, rendering support for chemi
 
 If you want to use chemical formulae inline and don't have a `chem` code block present in your page which triggers auto activation, you need to manually activate rendering support for chemical formulae. The easiest way to do so is to add a `chem` attribute to the frontmatter of your page and set it to `true`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Page front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -301,9 +308,11 @@ chem: true
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If you use formulae in most of your pages, you can also enable sitewide rendering support for chemical formulae inside the Docsy theme. To do so, enable `mhchem` inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Site configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -333,6 +342,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Diagrams with Mermaid
 
@@ -384,6 +394,7 @@ Support of Mermaid diagrams is automatically enabled as soon as you use a `merma
 
 By default, docsy pulls in the latest officially released version of Mermaid at build time. If that doesn't fit your needs, you can specify the wanted mermaid version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -405,9 +416,11 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If needed, you can define custom settings for your diagrams, such as themes, padding in your `hugo.toml`/`hugo.yaml`/`hugo.json`.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -437,6 +450,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 See the [Mermaid documentation](https://mermaid-js.github.io/mermaid/#/Setup?id=mermaidapi-configuration-defaults) for a list of defaults that can be overridden.
 
@@ -492,6 +506,7 @@ Foo -> Foo7: To queue
 
 To enable/disable PlantUML, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -513,9 +528,11 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Other optional settings are:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -558,6 +575,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## MindMap support with MarkMap
 
@@ -625,6 +643,7 @@ Automatically renders to:
 
 To enable/disable MarkMap, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -646,6 +665,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Diagrams with Diagrams.net
 
@@ -666,6 +686,7 @@ As the diagram data is transported via the browser, the diagrams.net server does
 
 To enable detection of diagrams, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -687,9 +708,11 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 You can also [deploy and use your own server](https://github.com/jgraph/docker-drawio/blob/master/README.md) for editing diagrams, in which case update the configuration to point to that server:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -711,3 +734,4 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -6,13 +6,29 @@ math: true
 chem: true
 ---
 
-Docsy has built-in support for a number of diagram creation and typesetting tools you can use to add rich content to your site, including \\(\KaTeX\\), Mermaid, Diagrams.net, PlantUML, and MarkMap.
+Docsy has built-in support for a number of diagram creation and typesetting
+tools you can use to add rich content to your site, including \\(\KaTeX\\),
+Mermaid, Diagrams.net, PlantUML, and MarkMap.
 
 ## \\(\LaTeX\\) support with \\(\KaTeX\\)
 
-[\\(\LaTeX\\)](https://www.latex-project.org/) is a high-quality typesetting system for the production of technical and scientific documentation. Due to its excellent math typesetting capabilities, \\(\TeX\\) became the de facto standard for the communication and publication of scientific documents, especially if these documents contain a lot of mathematical formulae. Designed and mostly written by Donald Knuth, the initial version was released in 1978. Dating back that far, \\(\LaTeX\\) has `pdf` as its primary output target and is not particularly well suited for producing HTML output for the Web. Fortunately, with [\\(\KaTeX\\)](https://katex.org/) there exists a fast and easy-to-use JavaScript library for \\(\TeX\\) math rendering on the web, which was integrated into the Docsy theme.
+[\\(\LaTeX\\)](https://www.latex-project.org/) is a high-quality typesetting
+system for the production of technical and scientific documentation. Due to its
+excellent math typesetting capabilities, \\(\TeX\\) became the de facto standard
+for the communication and publication of scientific documents, especially if
+these documents contain a lot of mathematical formulae. Designed and mostly
+written by Donald Knuth, the initial version was released in 1978. Dating back
+that far, \\(\LaTeX\\) has `pdf` as its primary output target and is not
+particularly well suited for producing HTML output for the Web. Fortunately,
+with [\\(\KaTeX\\)](https://katex.org/) there exists a fast and easy-to-use
+JavaScript library for \\(\TeX\\) math rendering on the web, which was
+integrated into the Docsy theme.
 
-With \\(\KaTeX\\) support [enabled](#activating-and-configuring-katex-support) in Docsy, you can include complex mathematical formulae into your web page, either inline or centred on its own line. Since \\(\KaTeX\\) relies on server side rendering, it produces the same output regardless of your browser or your environment. Formulae can be shown either inline or in display mode:
+With \\(\KaTeX\\) support [enabled](#activating-and-configuring-katex-support)
+in Docsy, you can include complex mathematical formulae into your web page,
+either inline or centred on its own line. Since \\(\KaTeX\\) relies on server
+side rendering, it produces the same output regardless of your browser or your
+environment. Formulae can be shown either inline or in display mode:
 
 ### Inline formulae
 
@@ -22,50 +38,64 @@ The following code sample produces a text line with three inline formulae:
 When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c= 0\\) and they are \\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\\).
 ```
 
-When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c= 0\\) and they are \\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\\).
+When \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c= 0\\) and they
+are \\(x = {-b \pm \sqrt{b^2-4ac} \over 2a}\\).
 
 ### Formulae in display mode
 
-The following code sample produces an introductory text line followed by a formula numbered as `(1)` residing on its own line:
+The following code sample produces an introductory text line followed by a
+formula numbered as `(1)` residing on its own line:
 
 ````markdown
 The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
+
 ```math
 \tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 ````
 
-The formula itself is written inside a [GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math). The above code fragment renders to:
+The formula itself is written inside a
+[GLFM math block](https://docs.gitlab.com/ee/user/markdown.html#math). The above
+code fragment renders to:
 
 The probability of getting \\(k\\) heads when flipping \\(n\\) coins is:
+
 ```math
 \tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 
-{{% alert title="Warning" color="warning" %}}
-`math` code blocks are only supported as of hugo version 0.93.
+{{% alert title="Warning" color="warning" %}} `math` code blocks are only
+supported as of hugo version 0.93.
 
-In case of hugo version 0.92 or lower, use this code snippet to display the formula:
+In case of hugo version 0.92 or lower, use this code snippet to display the
+formula:
+
 ```tex
 $$
 \tag*{(1)} P(E) = {n \choose k} p^k (1-p)^{n-k}
 $$
 ```
+
 {{% /alert %}}
 
-{{% alert title="Tip" %}}
-This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth information about typesetting mathematical formulae using the \\(\LaTeX\\) typesetting system.
-{{% /alert %}}
+{{% alert title="Tip" %}} This
+[wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth
+information about typesetting mathematical formulae using the \\(\LaTeX\\)
+typesetting system. {{% /alert %}}
 
 ### Activating and configuring \\(\KaTeX\\) support
 
 #### Auto activation
 
-As soon as you use a `math` code block on your page, support of \\(\KaTeX\\) is automatically enabled.
+As soon as you use a `math` code block on your page, support of \\(\KaTeX\\) is
+automatically enabled.
 
 #### Manual activation (no `math` code block present or hugo 0.92 or lower)
 
-If you want to use inline formulae and don't have a `math` code block present in your page which triggers auto activation, you need to manually activate \\(\KaTeX\\) support. The easiest way to do so is to add a `math` attribute to the frontmatter of your page and set it to `true`:
+If you want to use inline formulae and don't have a `math` code block present in
+your page which triggers auto activation, you need to manually activate
+\\(\KaTeX\\) support. The easiest way to do so is to add a `math` attribute to
+the frontmatter of your page and set it to `true`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -88,7 +118,9 @@ math: true
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If you use formulae in most of your pages, you can also enable sitewide \\(\KaTeX\\) support inside the Docsy theme. To do so update `hugo.toml`/`hugo.yaml`/`hugo.json`:
+If you use formulae in most of your pages, you can also enable sitewide
+\\(\KaTeX\\) support inside the Docsy theme. To do so update
+`hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -114,7 +146,8 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-Additionally, you can customize various \\(\KaTeX\\) options inside `hugo.toml`/`hugo.yaml`/`hugo.json`, if needed:
+Additionally, you can customize various \\(\KaTeX\\) options inside
+`hugo.toml`/`hugo.yaml`/`hugo.json`, if needed:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -228,19 +261,32 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-For a complete list of options and their detailed description, have a look at the documentation of \\({\KaTeX}\\)'s [Rendering API options](https://katex.org/docs/autorender.html#api) and of \\({\KaTeX}\\)'s [configuration options](https://katex.org/docs/options.html).
+For a complete list of options and their detailed description, have a look at
+the documentation of \\({\KaTeX}\\)'s
+[Rendering API options](https://katex.org/docs/autorender.html#api) and of
+\\({\KaTeX}\\)'s [configuration options](https://katex.org/docs/options.html).
 
 ### Display of Chemical Equations and Physical Units
 
-[mhchem](https://www.ctan.org/pkg/mhchem) is a \\(\LaTeX\\) package for typesetting chemical molecular formulae and equations. Fortunately, \\(\KaTeX\\) provides the `mhchem` [extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes the `mhchem` package accessible when authoring content for the web. With `mhchem` extension [enabled](#activating-rendering-support-for-chemical-formulae), you can easily include chemical equations into your page. An equation can be shown either inline or can reside on its own line. The following code sample produces a text line including a chemical equation:
+[mhchem](https://www.ctan.org/pkg/mhchem) is a \\(\LaTeX\\) package for
+typesetting chemical molecular formulae and equations. Fortunately, \\(\KaTeX\\)
+provides the `mhchem`
+[extension](https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem) that makes
+the `mhchem` package accessible when authoring content for the web. With
+`mhchem` extension
+[enabled](#activating-rendering-support-for-chemical-formulae), you can easily
+include chemical equations into your page. An equation can be shown either
+inline or can reside on its own line. The following code sample produces a text
+line including a chemical equation:
 
 ```mhchem
 *Precipitation of barium sulfate:* \\(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\\)
 ```
 
-*Precipitation of barium sulfate:* \\(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\\)
+_Precipitation of barium sulfate:_ \\(\ce{SO4^2- + Ba^2+ -> BaSO4 v}\\)
 
-More complex equations need to be displayed on their own line. Use a code block adorned with `chem` in order to achieve this:
+More complex equations need to be displayed on their own line. Use a code block
+adorned with `chem` in order to achieve this:
 
 ````markdown
 ```chem
@@ -252,42 +298,55 @@ More complex equations need to be displayed on their own line. Use a code block 
 \tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
 ```
 
-{{% alert title="Warning" color="warning" %}}
-`chem` code blocks are only supported as of hugo version 0.93.
+{{% alert title="Warning" color="warning" %}} `chem` code blocks are only
+supported as of hugo version 0.93.
 
-In case of hugo version 0.92 or lower, use this code snippet to display the formula:
+In case of hugo version 0.92 or lower, use this code snippet to display the
+formula:
+
 ```tex
 $$
 \tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
 $$
 ```
+
 {{% /alert %}}
 
-{{% alert title="Note" %}}
-The [manual](https://mhchem.github.io/MathJax-mhchem/) for mchem’s input syntax provides in-depth information about typesetting chemical formulae and physical units using the `mhchem` tool.
-{{% /alert %}}
+{{% alert title="Note" %}} The
+[manual](https://mhchem.github.io/MathJax-mhchem/) for mchem’s input syntax
+provides in-depth information about typesetting chemical formulae and physical
+units using the `mhchem` tool. {{% /alert %}}
 
-Use of `mhchem` is not limited to the authoring of chemical equations, using the included `\pu` command, pretty looking physical units can be written with ease, too. The following code sample produces two text lines with four numbers plus their corresponding physical units:
+Use of `mhchem` is not limited to the authoring of chemical equations, using the
+included `\pu` command, pretty looking physical units can be written with ease,
+too. The following code sample produces two text lines with four numbers plus
+their corresponding physical units:
 
 ```mhchem
 * Scientific number notation: \\(\pu{1.2e3 kJ}\\) or \\(\pu{1.2E3 kJ}\\) \\
 * Divisions: \\(\pu{123 kJ/mol}\\) or \\(\pu{123 kJ//mol}\\)
 ```
 
-* Scientific number notation: \\(\pu{1.2e3 kJ}\\) or \\(\pu{1.2E3 kJ}\\)
-* Divisions: \\(\pu{123 kJ/mol}\\) or \\(\pu{123 kJ//mol}\\)
+- Scientific number notation: \\(\pu{1.2e3 kJ}\\) or \\(\pu{1.2E3 kJ}\\)
+- Divisions: \\(\pu{123 kJ/mol}\\) or \\(\pu{123 kJ//mol}\\)
 
-For a complete list of options when authoring physical units, have a look at the [section](https://mhchem.github.io/MathJax-mhchem/#pu) on physical units in the `mhchem` documentation.
+For a complete list of options when authoring physical units, have a look at the
+[section](https://mhchem.github.io/MathJax-mhchem/#pu) on physical units in the
+`mhchem` documentation.
 
 #### Activating rendering support for chemical formulae
 
 ##### Auto activation
 
-As soon as you use a `chem` code block on your page, rendering support for chemical equations is automatically enabled.
+As soon as you use a `chem` code block on your page, rendering support for
+chemical equations is automatically enabled.
 
 ##### Manual activation (no `chem` code block present or hugo 0.92 or lower)
 
-If you want to use chemical formulae inline and don't have a `chem` code block present in your page which triggers auto activation, you need to manually activate rendering support for chemical formulae. The easiest way to do so is to add a `chem` attribute to the frontmatter of your page and set it to `true`:
+If you want to use chemical formulae inline and don't have a `chem` code block
+present in your page which triggers auto activation, you need to manually
+activate rendering support for chemical formulae. The easiest way to do so is to
+add a `chem` attribute to the frontmatter of your page and set it to `true`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -310,7 +369,9 @@ chem: true
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If you use formulae in most of your pages, you can also enable sitewide rendering support for chemical formulae inside the Docsy theme. To do so, enable `mhchem` inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
+If you use formulae in most of your pages, you can also enable sitewide
+rendering support for chemical formulae inside the Docsy theme. To do so, enable
+`mhchem` inside your `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -346,11 +407,18 @@ params:
 
 ## Diagrams with Mermaid
 
-[Mermaid](https://mermaid-js.github.io) is a Javascript library for rendering simple text definitions to useful diagrams in the browser.  It can generate a variety of different diagram types, including flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, user journey diagrams, Gantt charts and pie charts.
+[Mermaid](https://mermaid-js.github.io) is a Javascript library for rendering
+simple text definitions to useful diagrams in the browser. It can generate a
+variety of different diagram types, including flowcharts, sequence diagrams,
+class diagrams, state diagrams, ER diagrams, user journey diagrams, Gantt charts
+and pie charts.
 
-With Mermaid support enabled in Docsy, you can include the text definition of a Mermaid diagram inside a code block, and it will automatically be rendered by the browser as soon as the page loads.
+With Mermaid support enabled in Docsy, you can include the text definition of a
+Mermaid diagram inside a code block, and it will automatically be rendered by
+the browser as soon as the page loads.
 
-The great advantage of this is anyone who can edit the page can now edit the diagram - no more hunting for the original tools and version to make a new edit.
+The great advantage of this is anyone who can edit the page can now edit the
+diagram - no more hunting for the original tools and version to make a new edit.
 
 For example, the following defines a sequence diagram:
 
@@ -390,9 +458,12 @@ sequenceDiagram
     Docsy user->>Docsy user: Being happy
 ```
 
-Support of Mermaid diagrams is automatically enabled as soon as you use a `mermaid` code block on your page.
+Support of Mermaid diagrams is automatically enabled as soon as you use a
+`mermaid` code block on your page.
 
-By default, docsy pulls in the latest officially released version of Mermaid at build time. If that doesn't fit your needs, you can specify the wanted mermaid version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+By default, docsy pulls in the latest officially released version of Mermaid at
+build time. If that doesn't fit your needs, you can specify the wanted mermaid
+version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -418,7 +489,8 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If needed, you can define custom settings for your diagrams, such as themes, padding in your `hugo.toml`/`hugo.yaml`/`hugo.json`.
+If needed, you can define custom settings for your diagrams, such as themes,
+padding in your `hugo.toml`/`hugo.yaml`/`hugo.json`.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -452,15 +524,26 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-See the [Mermaid documentation](https://mermaid-js.github.io/mermaid/#/Setup?id=mermaidapi-configuration-defaults) for a list of defaults that can be overridden.
+See the
+[Mermaid documentation](https://mermaid-js.github.io/mermaid/#/Setup?id=mermaidapi-configuration-defaults)
+for a list of defaults that can be overridden.
 
-Settings can also be overridden on a per-diagram basis by making use of a [frontmatter config](http://mermaid.js.org/config/theming.html#customizing-themes-with-themevariables) block at the start of the diagram definition.
+Settings can also be overridden on a per-diagram basis by making use of a
+[frontmatter config](http://mermaid.js.org/config/theming.html#customizing-themes-with-themevariables)
+block at the start of the diagram definition.
 
 ## UML Diagrams with PlantUML
 
-[PlantUML](https://plantuml.com/en/) is an alternative to Mermaid that lets you quickly create UML diagrams, including sequence diagrams, use case diagrams, and state diagrams. Unlike Mermaid diagrams, which are entirely rendered in the browser, PlantUML uses a PlantUML server to create diagrams. You can use the provided default demo server (not recommended for production use), or run a server yourself. PlantUML offers a wider range of image types than Mermaid, so may be a better choice for some use cases.
+[PlantUML](https://plantuml.com/en/) is an alternative to Mermaid that lets you
+quickly create UML diagrams, including sequence diagrams, use case diagrams, and
+state diagrams. Unlike Mermaid diagrams, which are entirely rendered in the
+browser, PlantUML uses a PlantUML server to create diagrams. You can use the
+provided default demo server (not recommended for production use), or run a
+server yourself. PlantUML offers a wider range of image types than Mermaid, so
+may be a better choice for some use cases.
 
-Diagrams are defined using a simple and intuitive language. ([see PlantUML Language Reference Guide](https://plantuml.com/en/guide)).
+Diagrams are defined using a simple and intuitive language.
+([see PlantUML Language Reference Guide](https://plantuml.com/en/guide)).
 
 The following example shows a use case diagram:
 
@@ -579,7 +662,8 @@ params:
 
 ## MindMap support with MarkMap
 
-[MarkMap](https://markmap.js.org/) is a Javascript library for rendering simple text definitions to MindMap in the browser.
+[MarkMap](https://markmap.js.org/) is a Javascript library for rendering simple
+text definitions to MindMap in the browser.
 
 For example, the following defines a simple MindMap:
 
@@ -614,7 +698,7 @@ For example, the following defines a simple MindMap:
 
 Automatically renders to:
 
-```markmap
+````markmap
 # markmap
 
 ## Links
@@ -639,7 +723,7 @@ Automatically renders to:
     console.log('code block');
     ```
 - Katex - $x = {-b \pm \sqrt{b^2-4ac} \over 2a}$
-```
+````
 
 To enable/disable MarkMap, update `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
@@ -669,18 +753,27 @@ params:
 
 ## Diagrams with Diagrams.net
 
-[Diagrams.net](https://diagrams.net/) (aka `draw.io`) provides a free and open source diagram editor that can generate a wider range of diagrams than Mermaid or PlantUML using a web or desktop editor.
+[Diagrams.net](https://diagrams.net/) (aka `draw.io`) provides a free and open
+source diagram editor that can generate a wider range of diagrams than Mermaid
+or PlantUML using a web or desktop editor.
 
-SVG and PNG files exported with the tool contain the source code of the original diagram by default, which allows the diagrams.net site to import those images again for edit in the future. With `draw.io` enabled, Docsy will detect this and automatically add an `Edit` button over any image that can be edited using the online site.
+SVG and PNG files exported with the tool contain the source code of the original
+diagram by default, which allows the diagrams.net site to import those images
+again for edit in the future. With `draw.io` enabled, Docsy will detect this and
+automatically add an `Edit` button over any image that can be edited using the
+online site.
 
-Hover over the image below and click edit to instantly start working with it.  Clicking the `Save` button will cause the edited diagram to be exported using the same filename and filetype, and downloaded to your browser.
+Hover over the image below and click edit to instantly start working with it.
+Clicking the `Save` button will cause the edited diagram to be exported using
+the same filename and filetype, and downloaded to your browser.
 
-{{%alert title="Note"  color="primary" %}}
-If you're creating a new diagram, be sure to `File -> Export` in either `svg` or `png` format (`svg` is usually the best choice) and ensure the `Include a copy of my diagram` is selected so it can be edited again later.
-{{%/alert%}}
+{{%alert title="Note"  color="primary" %}} If you're creating a new diagram, be
+sure to `File -> Export` in either `svg` or `png` format (`svg` is usually the
+best choice) and ensure the `Include a copy of my diagram` is selected so it can
+be edited again later. {{%/alert%}}
 
-As the diagram data is transported via the browser, the diagrams.net server does not need to access the content on your Docsy server directly at all.
-
+As the diagram data is transported via the browser, the diagrams.net server does
+not need to access the content on your Docsy server directly at all.
 
 {{< figure src="docsy-diagrams.svg" caption="Mouse over the above image and click the `Edit` button!">}}
 
@@ -710,7 +803,10 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-You can also [deploy and use your own server](https://github.com/jgraph/docker-drawio/blob/master/README.md) for editing diagrams, in which case update the configuration to point to that server:
+You can also
+[deploy and use your own server](https://github.com/jgraph/docker-drawio/blob/master/README.md)
+for editing diagrams, in which case update the configuration to point to that
+server:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -122,6 +122,7 @@ case where analytics is configured outside of Docsy.
 
 {{% /alert %}}
 
+<!-- prettier-ignore-start -->
 1.  Open your project's Hugo configuration file.
 2.  Set the response text that users see after clicking **Yes** or **No**.
 
@@ -162,6 +163,7 @@ params:
 
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 3.  Save the edits to your configuration file.
 
@@ -202,6 +204,7 @@ visualize individual data points (per page) along with average values.
 Add the parameter `hide_feedback` to the page's front matter and set it to
 `true`.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -220,12 +223,14 @@ hide_feedback: true
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Disable feedback on all pages
 
 Set `params.ui.feedback.enable` to `false` in
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -250,6 +255,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Add a contact form with Fabform
 
@@ -281,8 +287,7 @@ using the `description` meta tag to tell search engines what your page is about.
 For each generated page, Docsy will set the content of the meta `description` by
 using the first of the following that is defined:
 
-- The page `description` [frontmatter field]({{< ref
-"content#page-frontmatter" >}})
+- The page `description` [frontmatter field](content/#page-frontmatter)
 - For non-index pages, the page [summary][], as computed by Hugo
 - The site description taken from the [site `params`][]
 
@@ -290,8 +295,7 @@ For the template code used to perform this computation, see
 [layouts/partials/page-description.html][].
 
 Add more meta tags as needed to your project's copy of the `head-end.html`
-partial. For details, see [Customizing templates]({{< ref "lookandfeel#customizing-templates"
->}}).
+partial. For details, see [Customizing templates](lookandfeel/#customizing-templates).
 
 [Configure Google Analytics]: https://gohugo.io/templates/internal/#configure-google-analytics
 [ga4-intro]: https://support.google.com/analytics/answer/1042508

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -23,8 +23,8 @@ started** section of [Introducing Google Analytics 4 (GA4)][ga4-intro].
 
 {{% alert title="Tip" %}}
 
-  Your project's **analytics ID** is a string that starts with `G-` (a GA4
-  measurement ID) or `UA-` (a universal analytics property ID).
+Your project's **analytics ID** is a string that starts with `G-` (a GA4
+measurement ID) or `UA-` (a universal analytics property ID).
 
 {{% /alert %}}
 
@@ -34,30 +34,33 @@ Enable Google Analytics by adding your project's analytics ID to the site
 configuration file. For details, see [Configure Google Analytics][].
 
 {{% alert title="Deprecation note and warning" color="warning" %}}
+
   <!-- Remove this warning once the Hugo docs have been updated to include it. -->
 
-  While you can configure your project's analytics ID by setting either the
-  top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,
-  **`googleAnalytics` was [deprecated in Hugo 0.120.0][v0.120.0]** and
-  will be removed in a future release.
+While you can configure your project's analytics ID by setting either the
+top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,
+**`googleAnalytics` was [deprecated in Hugo 0.120.0][v0.120.0]** and will be
+removed in a future release.
 
-  **Do not define both parameters,** otherwise this can result in [unexpected
-  behavior][]. For details, see [Is services.googleAnalytics.id an alias for
-  googleAnalytics][alias-discussion].
+**Do not define both parameters,** otherwise this can result in [unexpected
+behavior][]. For details, see [Is services.googleAnalytics.id an alias for
+googleAnalytics][alias-discussion].
 
-  [alias-discussion]: https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469
-  [unexpected behavior]: https://github.com/google/docsy/issues/921
-  [v0.120.0]: https://github.com/gohugoio/hugo/releases/tag/v0.120.0
+[alias-discussion]:
+  https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469
+[unexpected behavior]: https://github.com/google/docsy/issues/921
+[v0.120.0]: https://github.com/gohugoio/hugo/releases/tag/v0.120.0
 
 {{% /alert %}}
 
 {{% alert title="Production-only feature!" color="primary" %}}
 
-  Analytics are enabled _only_ for **production** builds (called "environments"
-  in Hugo terminology). For information about Hugo environments and how to set
-  them, see the following [discussion][].
+Analytics are enabled _only_ for **production** builds (called "environments" in
+Hugo terminology). For information about Hugo environments and how to set them,
+see the following [discussion][].
 
-  [discussion]: https://discourse.gohugo.io/t/what-does-setting-hugo-env-to-production-do/24669/2
+[discussion]:
+  https://discourse.gohugo.io/t/what-does-setting-hugo-env-to-production-do/24669/2
 
 {{% /alert %}}
 
@@ -177,8 +180,8 @@ Page feedback is reported to Google Analytics through [events].
 
 {{% alert title="Version note" color=warning %}}
 
-As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful` events,
-rather than `click` events.
+As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful`
+events, rather than `click` events.
 
 [0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
 
@@ -266,9 +269,9 @@ form that collects the user's email address to your site source:
 
 ```html
 <form action="https://fabform.io/f/{form-id}" method="post">
- <label for="email">Your Email</label>
- <input name="email" type="email">
- <button type="submit">Submit</button>
+  <label for="email">Your Email</label>
+  <input name="email" type="email" />
+  <button type="submit">Submit</button>
 </form>
 ```
 
@@ -295,16 +298,20 @@ For the template code used to perform this computation, see
 [layouts/partials/page-description.html][].
 
 Add more meta tags as needed to your project's copy of the `head-end.html`
-partial. For details, see [Customizing templates](lookandfeel/#customizing-templates).
+partial. For details, see
+[Customizing templates](lookandfeel/#customizing-templates).
 
-[Configure Google Analytics]: https://gohugo.io/templates/internal/#configure-google-analytics
+[Configure Google Analytics]:
+  https://gohugo.io/templates/internal/#configure-google-analytics
 [ga4-intro]: https://support.google.com/analytics/answer/1042508
 [Google Analytics]: https://analytics.google.com/analytics/web/
 [gtag.js]: https://support.google.com/analytics/answer/10220869
 [hugo-ga]: https://gohugo.io/templates/internal/#google-analytics
 [internal templates]: https://gohugo.io/templates/internal/
-[layouts/partials/page-description.html]: https://github.com/google/docsy/blob/main/layouts/partials/page-description.html
+[layouts/partials/page-description.html]:
+  https://github.com/google/docsy/blob/main/layouts/partials/page-description.html
 [site `params`]: https://gohugo.io/variables/site/#the-siteparams-variable
 [summary]: https://gohugo.io/content-management/summaries/
 [configure]: #setup-1
-[configuration file]: https://gohugo.io/getting-started/configuration/#configuration-file
+[configuration file]:
+  https://gohugo.io/getting-started/configuration/#configuration-file

--- a/userguide/content/en/docs/adding-content/iconsimages.md
+++ b/userguide/content/en/docs/adding-content/iconsimages.md
@@ -11,8 +11,8 @@ By default, Docsy shows a site logo at the start of the navbar, that is, at the
 extreme left. Place your project's SVG logo in `assets/icons/logo.svg`. This
 overrides the default Docsy logo in the theme.
 
-If you don't want a logo to appear in the navbar, then set site parameter `navbar_logo`
-to `false` in your project's config:
+If you don't want a logo to appear in the navbar, then set site parameter
+`navbar_logo` to `false` in your project's config:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -42,29 +42,54 @@ params:
 For information about styling your logo, see [Styling your project logo and
 name][].
 
-[Styling your project logo and name]: /docs/adding-content/lookandfeel/#styling-your-project-logo-and-name
+[Styling your project logo and name]:
+  /docs/adding-content/lookandfeel/#styling-your-project-logo-and-name
 
 ## Use icons
 
-Docsy includes the free FontAwesome icons by default, including logos for sites like GitHub and Stack Overflow. You can view all available icons in the [FontAwesome documentation](https://fontawesome.com/icons/), including the FontAwesome version when the icon was added and whether it is available for free tier users. Check Docsy's [`package.json`](https://github.com/google/docsy/blob/main/package.json) and release notes for Docsy's currently included version of FontAwesome.
+Docsy includes the free FontAwesome icons by default, including logos for sites
+like GitHub and Stack Overflow. You can view all available icons in the
+[FontAwesome documentation](https://fontawesome.com/icons/), including the
+FontAwesome version when the icon was added and whether it is available for free
+tier users. Check Docsy's
+[`package.json`](https://github.com/google/docsy/blob/main/package.json) and
+release notes for Docsy's currently included version of FontAwesome.
 
-You can add FontAwesome icons to your [top-level menu](/docs/adding-content/navigation/#adding-icons-to-the-top-level-menu), [section menu](/docs/adding-content/navigation/#add-icons-to-the-section-menu), or anywhere in your text.
+You can add FontAwesome icons to your
+[top-level menu](/docs/adding-content/navigation/#adding-icons-to-the-top-level-menu),
+[section menu](/docs/adding-content/navigation/#add-icons-to-the-section-menu),
+or anywhere in your text.
 
 ## Add your favicons
 
-The easiest way to do this is to create a set of favicons via http://cthedot.de/icongen (which lets you create a huge range of icon sizes and options from a single image) and/or [https://favicon.io](https://favicon.io), and put them in your site project's `static/favicons` directory. This will override the default favicons from the theme.
+The easiest way to do this is to create a set of favicons via
+http://cthedot.de/icongen (which lets you create a huge range of icon sizes and
+options from a single image) and/or [https://favicon.io](https://favicon.io),
+and put them in your site project's `static/favicons` directory. This will
+override the default favicons from the theme.
 
-Note that https://favicon.io  doesn't create as wide a range of sizes as Icongen but *does* let you quickly create favicons from text: if you want to create text favicons you can use this site to generate them, then use Icongen to create more sizes (if necessary) from your generated `.png` file.
+Note that https://favicon.io doesn't create as wide a range of sizes as Icongen
+but _does_ let you quickly create favicons from text: if you want to create text
+favicons you can use this site to generate them, then use Icongen to create more
+sizes (if necessary) from your generated `.png` file.
 
-If you have special favicon requirements, you can create your own `layouts/partials/favicons.html` with your links.
+If you have special favicon requirements, you can create your own
+`layouts/partials/favicons.html` with your links.
 
 ## Add images
 
 ### Landing pages
 
-Docsy's [`blocks/cover` shortcode](/docs/adding-content/shortcodes/#blockscover) make it easy to add large cover images to your landing pages. The shortcode looks for an image with the word "background" in the name inside the landing page's [Page Bundle](https://gohugo.io/content-management/page-bundles/) - so, for example, if you've copied the example site, the landing page image in `content/en/_index.html` is `content/en/featured-background.jpg`.
+Docsy's [`blocks/cover` shortcode](/docs/adding-content/shortcodes/#blockscover)
+make it easy to add large cover images to your landing pages. The shortcode
+looks for an image with the word "background" in the name inside the landing
+page's [Page Bundle](https://gohugo.io/content-management/page-bundles/) - so,
+for example, if you've copied the example site, the landing page image in
+`content/en/_index.html` is `content/en/featured-background.jpg`.
 
-You specify the preferred display height of a cover block container (and hence its image) using the block's `height` parameter.  For a full viewport height, use `full`:
+You specify the preferred display height of a cover block container (and hence
+its image) using the block's `height` parameter. For a full viewport height, use
+`full`:
 
 ```html
 {{</* blocks/cover title="Welcome to the Docsy Example Project!" image_anchor="top" height="full" */>}}
@@ -72,7 +97,8 @@ You specify the preferred display height of a cover block container (and hence i
 {{</* /blocks/cover */>}}
 ```
 
-For a shorter image, as in the example site's About page, use one of `min`, `med`, `max` or `auto` (the actual height of the image):
+For a shorter image, as in the example site's About page, use one of `min`,
+`med`, `max` or `auto` (the actual height of the image):
 
 ```html
 {{</* blocks/cover title="About the Docsy Example" image_anchor="bottom" height="min" */>}}
@@ -82,9 +108,18 @@ For a shorter image, as in the example site's About page, use one of `min`, `med
 
 ### Other pages
 
-To add inline images to other pages, use the [`imgproc` shortcode](/docs/adding-content/shortcodes/#imgproc). Alternatively, if you prefer, just use regular Markdown or HTML images and add your image files to your project's `static` directory. You can find out more about using this directory in [Adding static content](/docs/adding-content/content/#adding-static-content).
+To add inline images to other pages, use the
+[`imgproc` shortcode](/docs/adding-content/shortcodes/#imgproc). Alternatively,
+if you prefer, just use regular Markdown or HTML images and add your image files
+to your project's `static` directory. You can find out more about using this
+directory in
+[Adding static content](/docs/adding-content/content/#adding-static-content).
 
 ## Images used on this site
 
-Images used as background images in this site are in the [public domain](https://commons.wikimedia.org/wiki/User:Bep/gallery#Wed_Aug_01_16:16:51_CEST_2018) and can be used freely. The porridge image in the example site is by <a href="https://pixabay.com/users/iha31-560629/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=531209">iha31</a> from <a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=531209">Pixabay</a>.
-
+Images used as background images in this site are in the
+[public domain](https://commons.wikimedia.org/wiki/User:Bep/gallery#Wed_Aug_01_16:16:51_CEST_2018)
+and can be used freely. The porridge image in the example site is by
+<a href="https://pixabay.com/users/iha31-560629/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=531209">iha31</a>
+from
+<a href="https://pixabay.com/?utm_source=link-attribution&amp;utm_medium=referral&amp;utm_campaign=image&amp;utm_content=531209">Pixabay</a>.

--- a/userguide/content/en/docs/adding-content/iconsimages.md
+++ b/userguide/content/en/docs/adding-content/iconsimages.md
@@ -14,6 +14,7 @@ overrides the default Docsy logo in the theme.
 If you don't want a logo to appear in the navbar, then set site parameter `navbar_logo`
 to `false` in your project's config:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -36,6 +37,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 For information about styling your logo, see [Styling your project logo and
 name][].

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -199,7 +199,7 @@ using Chroma, see [Syntax Highlighting].
 Hugo's default Chroma style is [monokai]. To use another style, such as [tango],
 add the following to your project configuration:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -222,6 +222,7 @@ markup:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 For the complete list of available styles, see [Chroma Style Gallery].
 
@@ -270,7 +271,7 @@ button in the top right-hand corner. To disable this functionality, set
 Optionally, you can enable Prism syntax highlighting in your
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -289,6 +290,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 When this option is enabled your site uses
 [Prism](https://prismjs.com/index.html) instead of Chroma for code block
@@ -373,7 +375,7 @@ To enable the display of a light/[dark mode] menu in the navbar, set
 file. The dropdown menu appears at the right, immediately before the [search
 box], if present.
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -396,6 +398,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 [dark mode]: https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode
 [search box]: /docs/adding-content/search/

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -5,13 +5,24 @@ weight: 3
 description: Customize site navigation for your Docsy site.
 ---
 
-Docsy provides multiple built-in navigation features for your sites, including site menus, section menus, and page menus. This page shows you how they work and how to configure and customize them to meet your needs.
+Docsy provides multiple built-in navigation features for your sites, including
+site menus, section menus, and page menus. This page shows you how they work and
+how to configure and customize them to meet your needs.
 
 ## Top-level menu
 
-The top level menu (the one that appears in the top navigation bar for the entire site) uses your site's [`main` menu](https://gohugo.io/content-management/menus/). All Hugo sites have a `main` menu array of menu entries, accessible via the `.Site.Menus` site variable and populatable via page front matter or your site's `hugo.toml`/`hugo.yaml`/`hugo.json`.
+The top level menu (the one that appears in the top navigation bar for the
+entire site) uses your site's
+[`main` menu](https://gohugo.io/content-management/menus/). All Hugo sites have
+a `main` menu array of menu entries, accessible via the `.Site.Menus` site
+variable and populatable via page front matter or your site's
+`hugo.toml`/`hugo.yaml`/`hugo.json`.
 
-To add a page or section to this menu, add it to the site's `main` menu in either `hugo.toml`/`hugo.yaml`/`hugo.json` or in the destination page's front matter (in `_index.md` or `_index.html` for a section, as that's the section landing page). For example, here's how we added the Documentation section landing page to the main menu in this site:
+To add a page or section to this menu, add it to the site's `main` menu in
+either `hugo.toml`/`hugo.yaml`/`hugo.json` or in the destination page's front
+matter (in `_index.md` or `_index.html` for a section, as that's the section
+landing page). For example, here's how we added the Documentation section
+landing page to the main menu in this site:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -51,9 +62,12 @@ menu:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-The menu is ordered from left to right by page `weight`. So, for example, a section index or page with `weight: 30` would appear after the Documentation section in the menu, while one with `weight: 10` would appear before it.
+The menu is ordered from left to right by page `weight`. So, for example, a
+section index or page with `weight: 30` would appear after the Documentation
+section in the menu, while one with `weight: 10` would appear before it.
 
-If you want to add a link to an external site to this menu, add it in `hugo.toml`/`hugo.yaml`/`hugo.json`, specifying the `weight`.
+If you want to add a link to an external site to this menu, add it in
+`hugo.toml`/`hugo.yaml`/`hugo.json`, specifying the `weight`.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -89,7 +103,13 @@ menu:
 
 ### Adding icons to the top-level menu
 
-As described in the [Hugo docs](https://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu), you can add icons to the top-level menu by using the pre and/or post parameter for main menu items defined in your site's `hugo.toml`/`hugo.yaml`/`hugo.json` or via page front matter. For example, the following configuration adds the GitHub icon to the GitHub menu item, and a **New!** alert to indicate that this is a new addition to the menu.
+As described in the
+[Hugo docs](https://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu),
+you can add icons to the top-level menu by using the pre and/or post parameter
+for main menu items defined in your site's `hugo.toml`/`hugo.yaml`/`hugo.json`
+or via page front matter. For example, the following configuration adds the
+GitHub icon to the GitHub menu item, and a **New!** alert to indicate that this
+is a new addition to the menu.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -129,7 +149,9 @@ menu:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-You can find a complete list of icons to use in the [FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy includes the free FontAwesome icons by default.
+You can find a complete list of icons to use in the
+[FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy
+includes the free FontAwesome icons by default.
 
 ### Adding a version drop-down
 
@@ -141,14 +163,23 @@ You can find out more in the guide to
 
 ### Adding a language drop-down
 
-If you configure more than one language in `hugo.toml`, the Docsy theme adds a language selector drop down to the top-level menu. Selecting a language takes the user to the translated version of the current page, or the home page for the given language.
+If you configure more than one language in `hugo.toml`, the Docsy theme adds a
+language selector drop down to the top-level menu. Selecting a language takes
+the user to the translated version of the current page, or the home page for the
+given language.
 
 You can find out more in [Multi-language support](/docs/language/).
 
 ## Section menu
 
-The section menu, as shown in the left side of the `docs` section, is automatically built from the `content` tree. Like the top-level menu, it is ordered by page or section index `weight` (or by page creation `date` if `weight` is not set), with the page or index's `Title`, or `linkTitle` if different, as its link title in the menu. If a section subfolder has pages other than `_index.md` or `_index.html`, those pages will appear as a submenu, again ordered by `weight`. For example, here's the metadata for this page showing its `weight` and `title`:
-
+The section menu, as shown in the left side of the `docs` section, is
+automatically built from the `content` tree. Like the top-level menu, it is
+ordered by page or section index `weight` (or by page creation `date` if
+`weight` is not set), with the page or index's `Title`, or `linkTitle` if
+different, as its link title in the menu. If a section subfolder has pages other
+than `_index.md` or `_index.html`, those pages will appear as a submenu, again
+ordered by `weight`. For example, here's the metadata for this page showing its
+`weight` and `title`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -186,9 +217,14 @@ description: >
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To hide a page or section from the left navigation menu, set `toc_hide: true` in the front matter.
+To hide a page or section from the left navigation menu, set `toc_hide: true` in
+the front matter.
 
-To hide a page from the section summary on a [docs section landing page]({{< ref "content#docs-section-landing-pages" >}}), set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summary` to `true` in the front matter.
+To hide a page from the section summary on a [docs section landing
+page]({{< ref "content#docs-section-landing-pages" >}}), set
+`hide_summary: true` in the front matter. If you want to hide a page from both
+the TOC menu and the section summary list, you need to set both `toc_hide` and
+`hide_summary` to `true` in the front matter.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -228,17 +264,33 @@ description: >
 
 ### Section menu options
 
-By default, the section menu shows the current section fully expanded all the way down. This may make the left nav too long and difficult to scan for bigger sites. Try setting site parameter `ui.sidebar_menu_compact = true` in `hugo.toml`.
+By default, the section menu shows the current section fully expanded all the
+way down. This may make the left nav too long and difficult to scan for bigger
+sites. Try setting site parameter `ui.sidebar_menu_compact = true` in
+`hugo.toml`.
 
-With the compact menu (`.ui.sidebar_menu_compact = true`), only the current page's ancestors, siblings and direct descendants are shown. You can use the optional parameter `.ui.ul_show` to set a desired menu depth to always be visible. For example, with `.ui.ul_show = 1` the first menu level is always displayed.
+With the compact menu (`.ui.sidebar_menu_compact = true`), only the current
+page's ancestors, siblings and direct descendants are shown. You can use the
+optional parameter `.ui.ul_show` to set a desired menu depth to always be
+visible. For example, with `.ui.ul_show = 1` the first menu level is always
+displayed.
 
-The number of sidebar entries shown per section can be configured using the `.ui.sidebar_menu_truncate` parameter (default: 100).
+The number of sidebar entries shown per section can be configured using the
+`.ui.sidebar_menu_truncate` parameter (default: 100).
 
-As well as the completely expanded and compact menu options, you can also create a foldable menu by setting the site parameter `ui.sidebar_menu_foldable = true` in `hugo.toml`. The foldable menu lets users expand and collapse menu sections by toggling arrow icons beside the section parents in the menu.
+As well as the completely expanded and compact menu options, you can also create
+a foldable menu by setting the site parameter `ui.sidebar_menu_foldable = true`
+in `hugo.toml`. The foldable menu lets users expand and collapse menu sections
+by toggling arrow icons beside the section parents in the menu.
 
-On large sites (default: > 2000 pages) the section menu is not generated for each page, but cached for the whole section. The HTML classes for marking the active menu item (and menu path) are then set using JS. You can adjust the limit for activating the cached section menu with the optional parameter `.ui.sidebar_cache_limit`.
+On large sites (default: > 2000 pages) the section menu is not generated for
+each page, but cached for the whole section. The HTML classes for marking the
+active menu item (and menu path) are then set using JS. You can adjust the limit
+for activating the cached section menu with the optional parameter
+`.ui.sidebar_cache_limit`.
 
-The tabbed pane below lists the menu section options you can define in your project [configuration file].
+The tabbed pane below lists the menu section options you can define in your
+project [configuration file].
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -272,26 +324,57 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-
 ### Add icons to the section menu
 
-You can add icons to the section menu in the sidebar by setting the `icon` parameter in the page front matter (e.g. `icon: fa-solid fa-screwdriver-wrench`).
+You can add icons to the section menu in the sidebar by setting the `icon`
+parameter in the page front matter (e.g.
+`icon: fa-solid fa-screwdriver-wrench`).
 
-You can find a complete list of icons to use in the [FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy includes the free FontAwesome icons by default.
+You can find a complete list of icons to use in the
+[FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy
+includes the free FontAwesome icons by default.
 
-Out of the box, if you want to use icons, you should define icons for all items on the same menu level in order to ensure an appropriate look. If the icons are used in a different way, individual CSS adjustments are likely necessary.
+Out of the box, if you want to use icons, you should define icons for all items
+on the same menu level in order to ensure an appropriate look. If the icons are
+used in a different way, individual CSS adjustments are likely necessary.
 
 ### Add manual links to the section menu
 
-By default the section menu is entirely generated from your section's pages. If you want to add a manual link to this menu, such as a link to an external site or a page in a different section of your site, you can do this by creating a *placeholder page file* in the doc hierarchy with the appropriate weight and some special parameters in its metadata (frontmatter) to specify the link details.
+By default the section menu is entirely generated from your section's pages. If
+you want to add a manual link to this menu, such as a link to an external site
+or a page in a different section of your site, you can do this by creating a
+_placeholder page file_ in the doc hierarchy with the appropriate weight and
+some special parameters in its metadata (frontmatter) to specify the link
+details.
 
-To create a placeholder page, create a page file as usual in the directory where you want the link to show up in the menu, and add a `manualLink` parameter to its metadata. If a page has `manualLink` in its metadata, Docsy generates a link for it in the section menu for this page and in the section index (the list of the child pages of a section on a landing page - see [description in the Docsy docs](/docs/adding-content/content/#docs-section-landing-pages)), but the link destination is replaced by the value of `manualLink`. The link text is the `title` (or `linkTitle` if set) of your placeholder page. You can optionally also set the `title` attribute of the link with the parameter `manualLinkTitle` and a link target with `manualLinkTarget` - for example if you want an external link to open in a new tab you can set the link target to `_blank`. Docsy automatically adds `rel=noopener` to links that open new tabs as a security best practice.
+To create a placeholder page, create a page file as usual in the directory where
+you want the link to show up in the menu, and add a `manualLink` parameter to
+its metadata. If a page has `manualLink` in its metadata, Docsy generates a link
+for it in the section menu for this page and in the section index (the list of
+the child pages of a section on a landing page - see
+[description in the Docsy docs](/docs/adding-content/content/#docs-section-landing-pages)),
+but the link destination is replaced by the value of `manualLink`. The link text
+is the `title` (or `linkTitle` if set) of your placeholder page. You can
+optionally also set the `title` attribute of the link with the parameter
+`manualLinkTitle` and a link target with `manualLinkTarget` - for example if you
+want an external link to open in a new tab you can set the link target to
+`_blank`. Docsy automatically adds `rel=noopener` to links that open new tabs as
+a security best practice.
 
- You can also use `manualLink` to add an additional cross reference to another existing page of your site. For internal links you can choose to use the parameter `manualLinkRelref` instead of `manualLink` to use the built-in Hugo function [relref](https://gohugo.io/functions/relref/ "External link to official Hugo Docs"). If `relref` can't find a unique page in your site, Hugo throws a error message.
+You can also use `manualLink` to add an additional cross reference to another
+existing page of your site. For internal links you can choose to use the
+parameter `manualLinkRelref` instead of `manualLink` to use the built-in Hugo
+function
+[relref](https://gohugo.io/functions/relref/ 'External link to official Hugo Docs').
+If `relref` can't find a unique page in your site, Hugo throws a error message.
 
- {{% alert title="Note" %}}
- Although all generated menu and landing page links based on your placeholder file are set according to the parameters `manualLink` or `manualLinkRelref`, Hugo still generates a regular HTML site page for the file, albeit one with no generated links to it. To avoid confusion if users accidentally land on a generated placeholder page, we recommend specifying the URL for the external link in the normal content and / or page description of the page.
- {{% /alert %}}
+{{% alert title="Note" %}} Although all generated menu and landing page links
+based on your placeholder file are set according to the parameters `manualLink`
+or `manualLinkRelref`, Hugo still generates a regular HTML site page for the
+file, albeit one with no generated links to it. To avoid confusion if users
+accidentally land on a generated placeholder page, we recommend specifying the
+URL for the external link in the normal content and / or page description of the
+page. {{% /alert %}}
 
 ## Breadcrumb navigation
 
@@ -367,7 +450,8 @@ To enable this feature in your project, define
 ```
 
 The heading self-link anchor class is `.td-heading-self-link`, which you can
-customize for your project. By default, the heading self-link style has these defaults:
+customize for your project. By default, the heading self-link style has these
+defaults:
 
 - The self-link symbol is `#`.
 - The symbol is always visible on mobile and touch devices, otherwise it is only

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -13,6 +13,7 @@ The top level menu (the one that appears in the top navigation bar for the entir
 
 To add a page or section to this menu, add it to the site's `main` menu in either `hugo.toml`/`hugo.yaml`/`hugo.json` or in the destination page's front matter (in `_index.md` or `_index.html` for a section, as that's the section landing page). For example, here's how we added the Documentation section landing page to the main menu in this site:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -48,11 +49,13 @@ menu:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 The menu is ordered from left to right by page `weight`. So, for example, a section index or page with `weight: 30` would appear after the Documentation section in the menu, while one with `weight: 10` would appear before it.
 
 If you want to add a link to an external site to this menu, add it in `hugo.toml`/`hugo.yaml`/`hugo.json`, specifying the `weight`.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -82,11 +85,13 @@ menu:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Adding icons to the top-level menu
 
 As described in the [Hugo docs](https://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu), you can add icons to the top-level menu by using the pre and/or post parameter for main menu items defined in your site's `hugo.toml`/`hugo.yaml`/`hugo.json` or via page front matter. For example, the following configuration adds the GitHub icon to the GitHub menu item, and a **New!** alert to indicate that this is a new addition to the menu.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -122,6 +127,7 @@ menu:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 You can find a complete list of icons to use in the [FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy includes the free FontAwesome icons by default.
 
@@ -144,6 +150,7 @@ You can find out more in [Multi-language support](/docs/language/).
 The section menu, as shown in the left side of the `docs` section, is automatically built from the `content` tree. Like the top-level menu, it is ordered by page or section index `weight` (or by page creation `date` if `weight` is not set), with the page or index's `Title`, or `linkTitle` if different, as its link title in the menu. If a section subfolder has pages other than `_index.md` or `_index.html`, those pages will appear as a submenu, again ordered by `weight`. For example, here's the metadata for this page showing its `weight` and `title`:
 
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -177,11 +184,13 @@ description: >
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To hide a page or section from the left navigation menu, set `toc_hide: true` in the front matter.
 
 To hide a page from the section summary on a [docs section landing page]({{< ref "content#docs-section-landing-pages" >}}), set `hide_summary: true` in the front matter. If you want to hide a page from both the TOC menu and the section summary list, you need to set both `toc_hide` and `hide_summary` to `true` in the front matter.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -215,6 +224,7 @@ description: >
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Section menu options
 
@@ -230,6 +240,7 @@ On large sites (default: > 2000 pages) the section menu is not generated for eac
 
 The tabbed pane below lists the menu section options you can define in your project [configuration file].
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}{{< tab header="hugo.toml" lang="toml" >}}
 [params.ui]
@@ -259,6 +270,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 
 ### Add icons to the section menu
@@ -305,6 +317,7 @@ entire project, by setting `ui.breadcrumb_disable` to true in your project
 [configuration file]. Similarly, you can disabled taxonomy breadcrumbs by
 setting `ui.taxonomy_breadcrumb_disable` to true:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}{{< tab header="hugo.toml" lang="toml" >}}
 [params.ui]
@@ -328,6 +341,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 To disable breadcrumbs in a specific page or section set `ui.breadcrumb_disable`
 to true in the page or section-index front matter. Here is an example of the

--- a/userguide/content/en/docs/adding-content/print.md
+++ b/userguide/content/en/docs/adding-content/print.md
@@ -1,16 +1,22 @@
 ---
-title: "Print Support"
-linkTitle: "Print Support"
-weight:  7
+title: 'Print Support'
+linkTitle: 'Print Support'
+weight: 7
 description: >
-     Making it easier to print entire sections of documentation.
+  Making it easier to print entire sections of documentation.
 ---
 
-Individual documentation pages print well from most browsers as the layouts have been styled to omit navigational chrome from the printed output.
+Individual documentation pages print well from most browsers as the layouts have
+been styled to omit navigational chrome from the printed output.
 
-On some sites, it can be useful to enable a "print entire section" feature (as seen in this user guide).  Selecting this option renders the entire current top-level section (such as Content and Customization for this page) with all of its child pages and sections in a format suited to printing, complete with a table of contents for the section.
+On some sites, it can be useful to enable a "print entire section" feature (as
+seen in this user guide). Selecting this option renders the entire current
+top-level section (such as Content and Customization for this page) with all of
+its child pages and sections in a format suited to printing, complete with a
+table of contents for the section.
 
-To enable this feature, add the "print" output format in your site's `hugo.toml`/`hugo.yaml`/`hugo.json` file for the "section" type:
+To enable this feature, add the "print" output format in your site's
+`hugo.toml`/`hugo.yaml`/`hugo.json` file for the "section" type:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -40,13 +46,16 @@ outputs:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-The site should then show a "Print entire section" link in the right hand navigation.
+The site should then show a "Print entire section" link in the right hand
+navigation.
 
 ## Further Customization
 
 ### Disabling the ToC
 
-To disable showing the the table of contents in the printable view, set the `disable_toc` param to `true`, either in the page front matter, or in `hugo.toml`/`hugo.yaml`/`hugo.json`:
+To disable showing the the table of contents in the printable view, set the
+`disable_toc` param to `true`, either in the page front matter, or in
+`hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
@@ -101,12 +110,14 @@ params:
 
 ## Layout hooks
 
-A number of layout partials and hooks are defined that can be used to customize the printed format.  These can be found in `layouts/partials/print`.
+A number of layout partials and hooks are defined that can be used to customize
+the printed format. These can be found in `layouts/partials/print`.
 
-Hooks can be defined on a per-type basis.  For example, you may want to customize the layouts of heading for "blog" pages vs "docs". This can be achieved by creating `layouts/partials/print/page-heading-<type>.html` - eg. `page-heading-blog.html`.  It defaults to using the page title and description as a heading.
+Hooks can be defined on a per-type basis. For example, you may want to customize
+the layouts of heading for "blog" pages vs "docs". This can be achieved by
+creating `layouts/partials/print/page-heading-<type>.html` - eg.
+`page-heading-blog.html`. It defaults to using the page title and description as
+a heading.
 
-Similarly, the formatting for each page can be customized by creating `layouts/partials/print/content-<type>.html`.
-
-
-
-
+Similarly, the formatting for each page can be customized by creating
+`layouts/partials/print/content-<type>.html`.

--- a/userguide/content/en/docs/adding-content/print.md
+++ b/userguide/content/en/docs/adding-content/print.md
@@ -12,6 +12,7 @@ On some sites, it can be useful to enable a "print entire section" feature (as s
 
 To enable this feature, add the "print" output format in your site's `hugo.toml`/`hugo.yaml`/`hugo.json` file for the "section" type:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -37,6 +38,7 @@ outputs:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 The site should then show a "Print entire section" link in the right hand navigation.
 
@@ -46,6 +48,7 @@ The site should then show a "Print entire section" link in the right hand naviga
 
 To disable showing the the table of contents in the printable view, set the `disable_toc` param to `true`, either in the page front matter, or in `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab toml >}}
@@ -70,7 +73,9 @@ disable_toc: true
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Config file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -92,6 +97,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Layout hooks
 

--- a/userguide/content/en/docs/adding-content/repository-links.md
+++ b/userguide/content/en/docs/adding-content/repository-links.md
@@ -2,28 +2,51 @@
 title: Repository Links and other page information
 linkTitle: Repo links and page info
 weight: 9
-description: Help your users interact with page source and view page-source information.
+description:
+  Help your users interact with page source and view page-source information.
 ---
 
-The Docsy [docs and blog layouts](/docs/adding-content/content/#adding-docs-and-blog-posts) include links for readers to edit the page or create issues for your docs or project via your site's source repository. The current generated links for each docs or blog page are:
+The Docsy
+[docs and blog layouts](/docs/adding-content/content/#adding-docs-and-blog-posts)
+include links for readers to edit the page or create issues for your docs or
+project via your site's source repository. The current generated links for each
+docs or blog page are:
 
-* **View page source**: Brings the user to the page source in your docs repo.
-* **Edit this page**: Brings the user to an editable version of the page content in their fork (if available) of your docs repo. If the user doesn't have a current fork of your docs repo, they are invited to create one before making their edit. The user can then create a pull request for your docs.
-* **Create child page**: Brings the user to a create new file form in their fork of your docs repo.  The new file will be located as a child of the page they clicked the link on.  The form will be pre-populated with a template the user can edit to create their page.  You can change this by adding `assets/stubs/new-page-template.md` to your own project.
-* **Create documentation issue**: Brings the user to a new issue form in your docs repo with the name of the current page as the issue's title.
-* **Create project issue** (optional): Brings the user to a new issue form in your project repo. This can be useful if you have separate project and docs repos and your users want to file issues against the project feature being discussed rather than your docs.
+- **View page source**: Brings the user to the page source in your docs repo.
+- **Edit this page**: Brings the user to an editable version of the page content
+  in their fork (if available) of your docs repo. If the user doesn't have a
+  current fork of your docs repo, they are invited to create one before making
+  their edit. The user can then create a pull request for your docs.
+- **Create child page**: Brings the user to a create new file form in their fork
+  of your docs repo. The new file will be located as a child of the page they
+  clicked the link on. The form will be pre-populated with a template the user
+  can edit to create their page. You can change this by adding
+  `assets/stubs/new-page-template.md` to your own project.
+- **Create documentation issue**: Brings the user to a new issue form in your
+  docs repo with the name of the current page as the issue's title.
+- **Create project issue** (optional): Brings the user to a new issue form in
+  your project repo. This can be useful if you have separate project and docs
+  repos and your users want to file issues against the project feature being
+  discussed rather than your docs.
 
 This page shows you how to configure these links.
 
-Currently, Docsy supports only GitHub repository links "out of the box". Since GitLab can handle the same link scheme, it should work as well. If you are using another repository such as Bitbucket and would like generated repository links, feel free to [add a feature request or update our theme](/docs/contribution-guidelines/).
+Currently, Docsy supports only GitHub repository links "out of the box". Since
+GitLab can handle the same link scheme, it should work as well. If you are using
+another repository such as Bitbucket and would like generated repository links,
+feel free to
+[add a feature request or update our theme](/docs/contribution-guidelines/).
 
 ## Link configuration
 
-There are four site variables you can configure in `hugo.toml`/`hugo.yaml`/`hugo.json` to set up links, as well as one in your page metadata.
+There are four site variables you can configure in
+`hugo.toml`/`hugo.yaml`/`hugo.json` to set up links, as well as one in your page
+metadata.
 
 ### `github_repo`
 
-The URL for your site's source repository. This is used to generate the **Edit this page**, **Create child page**, and **Create documentation issue** links.
+The URL for your site's source repository. This is used to generate the **Edit
+this page**, **Create child page**, and **Create documentation issue** links.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -48,7 +71,9 @@ params:
 
 ### `github_subdir` (optional)
 
-Specify a value here if your content directory is not in your repo's root directory. For example, this site is in the `userguide` subdirectory of its repo. Setting this value means that your edit links will go to the right page.
+Specify a value here if your content directory is not in your repo's root
+directory. For example, this site is in the `userguide` subdirectory of its
+repo. Setting this value means that your edit links will go to the right page.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -73,7 +98,9 @@ params:
 
 ### `github_project_repo` (optional)
 
-Specify a value here if you have a separate project repo and you'd like your users to be able to create issues against your project from the relevant docs. The **Create project issue** link appears only if this is set.
+Specify a value here if you have a separate project repo and you'd like your
+users to be able to create issues against your project from the relevant docs.
+The **Create project issue** link appears only if this is set.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -98,7 +125,8 @@ params:
 
 ### `github_branch` (optional)
 
-Specify a value here if you have would like to reference a different branch for the other github settings like **Edit this page** or **Create project issue**.
+Specify a value here if you have would like to reference a different branch for
+the other github settings like **Edit this page** or **Create project issue**.
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -182,11 +210,10 @@ then also set `github_project_repo`, something like this:
 
 ```yaml
 ---
-...
+---
 cascade:
   github_repo: &repo https://github.com/some-username/another-repo/
   github_project_repo: *repo
-...
 ---
 ```
 
@@ -222,9 +249,10 @@ cascade:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-{{% alert title="Tip" %}}
-Please note that the YAML code fragment makes use of [Yaml anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/). Use of Yaml anchors is optional, but it helps keep the settings [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
-{{% /alert %}}
+{{% alert title="Tip" %}} Please note that the YAML code fragment makes use of
+[Yaml anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/).
+Use of Yaml anchors is optional, but it helps keep the settings
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). {{% /alert %}}
 
 The `path_base_for_github_subdir` setting is a regular expression, so you can
 use it even if you have a site with [multiple languages][] for example:
@@ -303,13 +331,15 @@ path_base_for_github_subdir:
 
 ### `github_url` (optional)
 
-{{% alert title="Deprecation note" color="warning" %}}
-  This setting is deprecated. Use [path_base_for_github_subdir][] instead.
+{{% alert title="Deprecation note" color="warning" %}} This setting is
+deprecated. Use [path_base_for_github_subdir][] instead.
 
-  [path_base_for_github_subdir]: #path_base_for_github_subdir-optional
+[path_base_for_github_subdir]: #path_base_for_github_subdir-optional
+
 {{% /alert %}}
 
-Specify a value for this **in your page metadata** to set a specific edit URL for this page, as in the following example:
+Specify a value for this **in your page metadata** to set a specific edit URL
+for this page, as in the following example:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -350,19 +380,21 @@ your [projects's `_styles_project.scss`][project-style-files] file to hide
 modifier -- not shown):
 
 ```scss
-.td-page-meta__child { display: none; }
+.td-page-meta__child {
+  display: none;
+}
 ```
 
 Each link kind has an associated unique class named `.td-page-meta__KIND`, as
 defined by the following table:
 
-Link kind | Class name
---- | ---
-View page source | `.td-page-meta__view`
-Edit this page | `.td-page-meta__edit`
-Create child page | `.td-page-meta__child`
-Create documentation issue | `.td-page-meta__issue`
-Create project issue | `.td-page-meta__project-issue`
+| Link kind                  | Class name                     |
+| -------------------------- | ------------------------------ |
+| View page source           | `.td-page-meta__view`          |
+| Edit this page             | `.td-page-meta__edit`          |
+| Create child page          | `.td-page-meta__child`         |
+| Create documentation issue | `.td-page-meta__issue`         |
+| Create project issue       | `.td-page-meta__project-issue` |
 
 Of course, you can also use these classes to give repository links unique styles
 for your project.
@@ -386,18 +418,23 @@ A last-modified page note looks something like this:
 > <div class="td-page-meta__lastmod"
 >      style="margin-top: 0 !important; display: block !important;">
 >
-> Last modified November 29, 2023: [Release v0.8.0 preparation (#1756) (6bb4f99)](https://github.com/google/docsy/commit/6bb4f99d1eab4976fb80d1488c81ba12b1715c05)
+> Last modified November 29, 2023:
+> [Release v0.8.0 preparation (#1756) (6bb4f99)](https://github.com/google/docsy/commit/6bb4f99d1eab4976fb80d1488c81ba12b1715c05)
+>
 > </div>
-{.border-0}
+> {.border-0}
 
 Once enabled site-wide, you can selectively hide last-modified notes in a page
 or section by declaring the following style (optionally with a `!important`
 modifier &mdash; not shown):
 
 ```scss
-.td-page-meta__lastmod { display: none; }
+.td-page-meta__lastmod {
+  display: none;
+}
 ```
 
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[multiple languages]: {{% relref "language" %}}
-[project-style-files]: {{% relref "lookandfeel#project-style-files" %}}
+
+[multiple languages]: language/
+[project-style-files]: lookandfeel/#project-style-files

--- a/userguide/content/en/docs/adding-content/repository-links.md
+++ b/userguide/content/en/docs/adding-content/repository-links.md
@@ -25,6 +25,7 @@ There are four site variables you can configure in `hugo.toml`/`hugo.yaml`/`hugo
 
 The URL for your site's source repository. This is used to generate the **Edit this page**, **Create child page**, and **Create documentation issue** links.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -43,11 +44,13 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### `github_subdir` (optional)
 
 Specify a value here if your content directory is not in your repo's root directory. For example, this site is in the `userguide` subdirectory of its repo. Setting this value means that your edit links will go to the right page.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -66,11 +69,13 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### `github_project_repo` (optional)
 
 Specify a value here if you have a separate project repo and you'd like your users to be able to create issues against your project from the relevant docs. The **Create project issue** link appears only if this is set.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -89,11 +94,13 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### `github_branch` (optional)
 
 Specify a value here if you have would like to reference a different branch for the other github settings like **Edit this page** or **Create project issue**.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -112,6 +119,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### `path_base_for_github_subdir` (optional)
 
@@ -120,6 +128,7 @@ come from another repo, such as a [git submodule][]. Add settings like these to
 the **section's index page** so that the repository links for all pages in that
 section refer to the originating repo:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -153,6 +162,7 @@ cascade:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 As an example, consider a page at the path
 `content/some-section/subpath/some-page.md` with `github_branch` globally set to
@@ -180,6 +190,7 @@ cascade:
 ---
 ```
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -209,6 +220,7 @@ cascade:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 {{% alert title="Tip" %}}
 Please note that the YAML code fragment makes use of [Yaml anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/). Use of Yaml anchors is optional, but it helps keep the settings [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
@@ -217,6 +229,7 @@ Please note that the YAML code fragment makes use of [Yaml anchor](https://suppo
 The `path_base_for_github_subdir` setting is a regular expression, so you can
 use it even if you have a site with [multiple languages][] for example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -241,11 +254,13 @@ path_base_for_github_subdir: content/\w+/some-section
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 In situations where a page originates from a file under a different name, you
 can specify `from` and `to` path-rename settings. Here's an example where an
 index file is named `README.md` in the originating repo:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -284,6 +299,7 @@ path_base_for_github_subdir:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### `github_url` (optional)
 
@@ -295,6 +311,7 @@ path_base_for_github_subdir:
 
 Specify a value for this **in your page metadata** to set a specific edit URL for this page, as in the following example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -319,6 +336,7 @@ github_url: https://github.com/some-username/another-repo/edit/main/README.md
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 This can be useful if you have page source files in multiple Git repositories,
 or require a non-GitHub URL. Pages using this value have **Edit this page**

--- a/userguide/content/en/docs/adding-content/repository-links.md
+++ b/userguide/content/en/docs/adding-content/repository-links.md
@@ -435,6 +435,5 @@ modifier &mdash; not shown):
 ```
 
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-
 [multiple languages]: language/
 [project-style-files]: lookandfeel/#project-style-files

--- a/userguide/content/en/docs/adding-content/search.md
+++ b/userguide/content/en/docs/adding-content/search.md
@@ -42,7 +42,7 @@ of the sidebar left navigation pane. If you don't want the sidebar search box,
 set the site parameter `sidebar_search_disable` to `true` in
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -64,6 +64,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ## Configure search with a Google Custom Search Engine
 
@@ -154,7 +155,6 @@ params:
 }
 {{< /tab >}}
     {{< /tabpane >}}
-
 <!-- prettier-ignore-end -->
 
 ### Disabling GCSE search
@@ -230,7 +230,6 @@ params:
 }
 {{< /tab >}}
     {{< /tabpane >}}
-
 <!-- prettier-ignore-end -->
 
 To learn more about Algolia DocSearch V3, see
@@ -309,7 +308,7 @@ need to stop the server and restart it in order to see your search results.
 You can customize the summary length by setting `offlineSearchSummaryLength` in
 `hugo.toml`/`hugo.yaml`/`hugo.json`.
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -332,13 +331,14 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Changing the maximum result count of the local search
 
 You can customize the maximum result count by setting `offlineSearchMaxResults`
 in `hugo.toml`/`hugo.yaml`/`hugo.json`.
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -360,6 +360,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Changing the width of the local search results popover
 

--- a/userguide/content/en/docs/adding-content/shortcodes/includes/config.yaml
+++ b/userguide/content/en/docs/adding-content/shortcodes/includes/config.yaml
@@ -8,4 +8,4 @@ spec:
       image: alpine
       script: |
         #!/bin/sh
-        echo "Hello World"  
+        echo "Hello World"

--- a/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
@@ -1,14 +1,10 @@
 **Installation**
 
-{{% alert title="Note" color="primary" %}}
-Check system compatibility before proceeding.
-{{% /alert %}}
+{{% alert title="Note" color="primary" %}} Check system compatibility before
+proceeding. {{% /alert %}}
 
 1.  Download the installation files.
 
-1.  Run the installation script
-    
-    `sudo sh install.sh`
+1.  Run the installation script `sudo sh install.sh`
 
 1.  Test that your installation was successfully completed.
-

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -397,6 +397,7 @@ example, the tabbed pane below shows the language-specific variants of the
 famous `Hello world!` program one usually writes first when learning a new
 programming language:
 
+<!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab "C" >}}
 #include <stdio.h>
@@ -455,6 +456,7 @@ object HelloWorld extends App {
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 The Docsy template provides two shortcodes `tabpane` and `tab` that let you
 easily create tabbed panes. To see how to use them, have a look at the following
@@ -482,6 +484,7 @@ active tabs:
 This code translates to the right aligned tabbed pane below, showing a
 `Welcome!` greeting in English, German or Swahili:
 
+<!-- prettier-ignore-start -->
 {{< tabpane text=true right=true >}}
   {{% tab header="**Languages**:" disabled=true /%}}
   {{% tab header="English" lang="en" %}}
@@ -497,6 +500,7 @@ This code translates to the right aligned tabbed pane below, showing a
   **Karibu sana!**
   {{% /tab %}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 ### Shortcode details
 

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -6,12 +6,19 @@ weight: 5
 description: >
   Use Docsy's Hugo shortcodes to quickly build site pages.
 resources:
-- src: "**spruce*.jpg"
-  params:
-    byline: "*Photo*: Bjørn Erik Pedersen / CC-BY-SA"
+  - src: '**spruce*.jpg'
+    params:
+      byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
 ---
 
-Rather than writing all your site pages from scratch, Hugo lets you define and use [shortcodes](https://gohugo.io/content-management/shortcodes/). These are reusable snippets of content that you can include in your pages, often using HTML to create effects that are difficult or impossible to do in simple Markdown. Shortcodes can also have parameters that let you, for example, add your own text to a fancy shortcode text box. As well as Hugo's [built-in shortcodes](https://gohugo.io/content-management/shortcodes/), Docsy provides some shortcodes of its own to help you build your pages.
+Rather than writing all your site pages from scratch, Hugo lets you define and
+use [shortcodes](https://gohugo.io/content-management/shortcodes/). These are
+reusable snippets of content that you can include in your pages, often using
+HTML to create effects that are difficult or impossible to do in simple
+Markdown. Shortcodes can also have parameters that let you, for example, add
+your own text to a fancy shortcode text box. As well as Hugo's
+[built-in shortcodes](https://gohugo.io/content-management/shortcodes/), Docsy
+provides some shortcodes of its own to help you build your pages.
 
 ## Shortcode delimiters
 
@@ -22,19 +29,25 @@ the shortcode body as Markdown. You can use both styles in your pages.
 
 ## Shortcode blocks
 
-The theme comes with a set of custom  **Page Block** shortcodes that can be used to compose landing pages, about pages, and similar.
+The theme comes with a set of custom **Page Block** shortcodes that can be used
+to compose landing pages, about pages, and similar.
 
 These blocks share some common parameters:
 
-height
-: A pre-defined height of the block container. One of `min`, `med`, `max`, `full`, or `auto`. Setting it to `full` will fill the Viewport Height, which can be useful for landing pages.
-
-color
-: The block will be assigned a color from the theme palette if not provided, but you can set your own if needed. You can use all of Bootstrap's color names, theme color names or a grayscale shade. Some examples would be `primary`, `white`, `dark`, `warning`, `light`, `success`, `300`, `blue`, `orange`. This will become the **background color** of the block, but text colors will adapt to get proper contrast.
+- **height**: A pre-defined height of the block container. One of `min`, `med`,
+  `max`, `full`, or `auto`. Setting it to `full` will fill the Viewport Height,
+  which can be useful for landing pages.
+- **color**: The block will be assigned a color from the theme palette if not
+  provided, but you can set your own if needed. You can use all of Bootstrap's
+  color names, theme color names or a grayscale shade. Some examples would be
+  `primary`, `white`, `dark`, `warning`, `light`, `success`, `300`, `blue`,
+  `orange`. This will become the **background color** of the block, but text
+  colors will adapt to get proper contrast.
 
 ### blocks/cover
 
-The **blocks/cover** shortcode creates a landing page type of block that fills the top of the page.
+The **blocks/cover** shortcode creates a landing page type of block that fills
+the top of the page.
 
 ```html
 {{</* blocks/cover title="Welcome!" image_anchor="center" height="full" color="primary" */>}}
@@ -53,28 +66,35 @@ The **blocks/cover** shortcode creates a landing page type of block that fills t
 {{</* /blocks/cover */>}}
 ```
 
-Note that the relevant shortcode parameters above will have sensible defaults, but is included here for completeness.
+Note that the relevant shortcode parameters above will have sensible defaults,
+but is included here for completeness.
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| title | | The main display title for the block. |
-| image_anchor | |
-| height | | See above.
-| color | | See above.
-| byline | Byline text on featured image. |
+| Parameter    | Default                        | Description                           |
+| ------------ | ------------------------------ | ------------------------------------- |
+| title        |                                | The main display title for the block. |
+| image_anchor |                                |
+| height       |                                | See above.                            |
+| color        |                                | See above.                            |
+| byline       | Byline text on featured image. |
 
+To set the background image, place an image with the word "background" in the
+name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles).
+For example, in our the example site the background image in the home page's
+cover block is
+[`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en),
+in the same directory.
 
-To set the background image, place an image with the word "background" in the name in the page's [Page Bundle](/docs/adding-content/content/#page-bundles). For example, in our the example site the background image in the home page's cover block is [`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en), in the same directory.
+{{% alert title="Tip" %}} If you also include the word **featured** in the image
+name, e.g. `my-featured-background.jpg`, it will also be used as the Twitter
+Card image when shared. {{% /alert %}}
 
-{{% alert title="Tip" %}}
-If you also include the word **featured** in the image name, e.g. `my-featured-background.jpg`, it will also be used as the Twitter Card image when shared.
-{{% /alert %}}
-
-For available icons, see [Font Awesome](https://fontawesome.com/icons?d=gallery&m=free).
+For available icons, see
+[Font Awesome](https://fontawesome.com/icons?d=gallery&m=free).
 
 ### blocks/lead
 
-The **blocks/lead** block shortcode is a simple lead/title block with centred text and an arrow down pointing to the next section.
+The **blocks/lead** block shortcode is a simple lead/title block with centred
+text and an arrow down pointing to the next section.
 
 ```go-html-template
 {{%/* blocks/lead color="dark" */%}}
@@ -85,16 +105,17 @@ Runs on **bare metal** in the **cloud**!
 ```
 
 | Parameter | Default  | Description                               |
-| --------- |--------- | ----------------------------------------- |
+| --------- | -------- | ----------------------------------------- |
 | height    | `auto`   | See [Shortcode blocks](#shortcode-blocks) |
 | color     | .Ordinal | See [Shortcode blocks](#shortcode-blocks) |
 
 ### blocks/section
 
-The **blocks/section** shortcode is meant as a general-purpose content container. It comes in two "flavors", one for general content and one with styling more suitable for wrapping a horizontal row of feature sections.
+The **blocks/section** shortcode is meant as a general-purpose content
+container. It comes in two "flavors", one for general content and one with
+styling more suitable for wrapping a horizontal row of feature sections.
 
 The example below shows a section wrapping 3 feature sections.
-
 
 ```go-html-template
 {{</* blocks/section color="dark" type="row" */>}}
@@ -111,11 +132,11 @@ For announcement of latest features etc.
 {{</* /blocks/section */>}}
 ```
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| `height` | | See above.
-| `color` | | See above.
-| `type`  | | Specify "container" (the default) if you want a general container, or "row" if the section will contain columns -- which must be immediate children.
+| Parameter | Default | Description                                                                                                                                          |
+| --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `height`  |         | See above.                                                                                                                                           |
+| `color`   |         | See above.                                                                                                                                           |
+| `type`    |         | Specify "container" (the default) if you want a general container, or "row" if the section will contain columns -- which must be immediate children. |
 
 ### blocks/feature
 
@@ -125,17 +146,17 @@ We do a [Pull Request](https://github.com/gohugoio/hugo/pulls) contributions wor
 {{%/* /blocks/feature */%}}
 ```
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| title | | The title to use.
-| url | | The URL to link to.
-| url_text | The [language parameter](/docs/language/#internationalization-bundles) value of [`ui_read_more`](https://github.com/google/docsy/blob/main/i18n/en.toml) | The link text to use.
-| icon | | The icon class to use.
-
+| Parameter | Default                                                                                                                                                  | Description            |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| title     |                                                                                                                                                          | The title to use.      |
+| url       |                                                                                                                                                          | The URL to link to.    |
+| url_text  | The [language parameter](/docs/language/#internationalization-bundles) value of [`ui_read_more`](https://github.com/google/docsy/blob/main/i18n/en.toml) | The link text to use.  |
+| icon      |                                                                                                                                                          | The icon class to use. |
 
 ### blocks/link-down
 
-The **blocks/link-down** shortcode creates a navigation link down to the next section. It's meant to be used in combination with the other blocks shortcodes.
+The **blocks/link-down** shortcode creates a navigation link down to the next
+section. It's meant to be used in combination with the other blocks shortcodes.
 
 ```go-html-template
 <div class="mx-auto mt-5">
@@ -143,15 +164,16 @@ The **blocks/link-down** shortcode creates a navigation link down to the next se
 </div>
 ```
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| color | info | See above.
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| color     | info    | See above.  |
 
 ## Shortcode helpers
 
 ### alert
 
-The **alert** shortcode creates an alert block that can be used to display notices or warnings.
+The **alert** shortcode creates an alert block that can be used to display
+notices or warnings.
 
 ```go-html-template
 {{%/* alert title="Warning" color="warning" */%}}
@@ -161,17 +183,18 @@ This is a warning.
 
 Renders to:
 
-{{% alert title="Warning" color="warning" %}}
-This is a warning.
-{{% /alert %}}
+{{% alert title="Warning" color="warning" %}} This is a warning. {{% /alert %}}
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| color | primary | One of the theme colors, eg `primary`, `info`, `warning` etc.
+| Parameter | Default | Description                                                   |
+| --------- | ------- | ------------------------------------------------------------- |
+| color     | primary | One of the theme colors, eg `primary`, `info`, `warning` etc. |
 
 ### pageinfo
 
-The **pageinfo** shortcode creates a text box that you can use to add banner information for a page: for example, letting users know that the page contains placeholder content, that the content is deprecated, or that it documents a beta feature.
+The **pageinfo** shortcode creates a text box that you can use to add banner
+information for a page: for example, letting users know that the page contains
+placeholder content, that the content is deprecated, or that it documents a beta
+feature.
 
 ```go-html-template
 {{%/* pageinfo color="info" */%}}
@@ -182,17 +205,20 @@ This is placeholder content.
 Renders to:
 
 {{% pageinfo color="info" %}}
+
 This is placeholder content
+
 {{% /pageinfo %}}
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| color | primary | One of the theme colors, eg `primary`, `info`, `warning` etc.
-
+| Parameter | Default | Description                                                   |
+| --------- | ------- | ------------------------------------------------------------- |
+| color     | primary | One of the theme colors, eg `primary`, `info`, `warning` etc. |
 
 ### imgproc
 
-The **imgproc** shortcode finds an image in the current [Page Bundle](/docs/adding-content/content/#page-bundles) and scales it given a set of processing instructions.
+The **imgproc** shortcode finds an image in the current
+[Page Bundle](/docs/adding-content/content/#page-bundles) and scales it given a
+set of processing instructions.
 
 ```go-html-template
 {{%/* imgproc spruce Fill "400x450" */%}}
@@ -200,13 +226,19 @@ Norway Spruce *Picea abies* shoot with foliage buds.
 {{%/* /imgproc */%}}
 ```
 
-Use the syntax above if the inner content and/or the `byline` parameter of your shortcode is authored in markdown. In case of HTML content, use `<>` as innermost delimiters: `{{</* imgproc >}}<b>HTML</b> content{{< /imgproc */>}}`.
+Use the syntax above if the inner content and/or the `byline` parameter of your
+shortcode is authored in markdown. In case of HTML content, use `<>` as
+innermost delimiters: `{{</* imgproc >}}<b>HTML</b> content{{< /imgproc */>}}`.
 
-{{% imgproc spruce Fill "400x450" %}}
-Norway Spruce *Picea abies* shoot with foliage buds.
-{{% /imgproc %}}
+{{% imgproc spruce Fill "400x450" %}} Norway Spruce _Picea abies_ shoot with
+foliage buds. {{% /imgproc %}}
 
-The example above has also a byline with photo attribution added. When using illustrations with a free license from [WikiMedia](https://commons.wikimedia.org/) and similar, you will in most situations need a way to attribute the author or licensor. You can add metadata to your page resources in the page front matter. The `byline` param is used by convention in this theme:
+The example above has also a byline with photo attribution added. When using
+illustrations with a free license from
+[WikiMedia](https://commons.wikimedia.org/) and similar, you will in most
+situations need a way to attribute the author or licensor. You can add metadata
+to your page resources in the page front matter. The `byline` param is used by
+convention in this theme:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -243,15 +275,20 @@ resources:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-| Parameter        | Description  |
-| ----------------: |------------|
-| 1 | The image filename or enough of it to identify it (we do Glob matching)
-| 2 | Command. One of `Fit`, `Resize`, `Fill` or `Crop`. See [Image Processing Methods](https://gohugo.io/content-management/image-processing/#image-processing-methods).
-| 3 | Processing options, e.g. `400x450 r180`. See [Image Processing Options](https://gohugo.io/content-management/image-processing/#image-processing-options).
+| Parameter | Description                                                                                                                                                         |
+| --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|         1 | The image filename or enough of it to identify it (we do Glob matching)                                                                                             |
+|         2 | Command. One of `Fit`, `Resize`, `Fill` or `Crop`. See [Image Processing Methods](https://gohugo.io/content-management/image-processing/#image-processing-methods). |
+|         3 | Processing options, e.g. `400x450 r180`. See [Image Processing Options](https://gohugo.io/content-management/image-processing/#image-processing-options).           |
 
 ### swaggerui
 
-You can place the `swaggerui` shortcode anywhere inside a page with the [`swagger` layout](https://github.com/google/docsy/tree/main/layouts/swagger); it renders [Swagger UI](https://swagger.io/tools/swagger-ui/) using any OpenAPI YAML or JSON file as source. This file can be hosted anywhere you like, for example in your site's root [`/static` folder](/docs/adding-content/content/#adding-static-content).
+You can place the `swaggerui` shortcode anywhere inside a page with the
+[`swagger` layout](https://github.com/google/docsy/tree/main/layouts/swagger);
+it renders [Swagger UI](https://swagger.io/tools/swagger-ui/) using any OpenAPI
+YAML or JSON file as source. This file can be hosted anywhere you like, for
+example in your site's root
+[`/static` folder](/docs/adding-content/content/#adding-static-content).
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -289,53 +326,76 @@ description: Reference for the Pet Store API
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-You can customize Swagger UI's look and feel by overriding Swagger's CSS in `themes/docsy/assets/scss/_swagger.scss`.
+You can customize Swagger UI's look and feel by overriding Swagger's CSS in
+`themes/docsy/assets/scss/_swagger.scss`.
 
-{{% alert title="Warning" color="warning" %}}
-This shortcode relies on JavaScript libraries hosted on unpkg. Make sure that you can access unpkg from your network when building or loading your site.
-{{% /alert %}}
+{{% alert title="Warning" color="warning" %}} This shortcode relies on
+JavaScript libraries hosted on unpkg. Make sure that you can access unpkg from
+your network when building or loading your site. {{% /alert %}}
 
 ### redoc
 
-The `redoc` shortcode uses the open-source [Redoc](https://github.com/Redocly/redoc) tool to render reference API documentation from an OpenAPI YAML or JSON file. This can be hosted anywhere you like, for example in your site's root [`/static` folder](/docs/adding-content/content/#adding-static-content), but you can use a URL as well, for example:
+The `redoc` shortcode uses the open-source
+[Redoc](https://github.com/Redocly/redoc) tool to render reference API
+documentation from an OpenAPI YAML or JSON file. This can be hosted anywhere you
+like, for example in your site's root
+[`/static` folder](/docs/adding-content/content/#adding-static-content), but you
+can use a URL as well, for example:
 
 ```yaml
 ---
-title: "Pet Store API"
+title: 'Pet Store API'
 type: docs
 weight: 1
 description: Reference for the Pet Store API
 ---
-
-{{</* redoc "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v2.0/yaml/petstore.yaml" */>}}
+{
+  {
+    </* redoc
+    "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v2.0/yaml/petstore.yaml"
+    */>,
+  },
+}
 ```
 
 ### iframe
 
-With this shortcode you can embed external content into a Docsy page as an inline frame (`iframe`) - see: https://www.w3schools.com/tags/tag_iframe.asp
+With this shortcode you can embed external content into a Docsy page as an
+inline frame (`iframe`) - see: https://www.w3schools.com/tags/tag_iframe.asp
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| src | | URL of external content
-| width | 100% | Width of iframe
-| tryautoheight | true | If true the shortcode tries to calculate the needed height for the embedded content using JavaScript, as described here: https://stackoverflow.com/a/14618068. This is only possible if the embedded content is [on the same domain](https://stackoverflow.com/questions/22086722/resize-cross-domain-iframe-height). Note that even if the embedded content is on the same domain, it depends on the structure of the content if the height can be calculated correctly.
-| style | min-height:98vh; border:none; | CSS styles for the iframe. `min-height:98vh;` is a backup if `tryautoheight` doesn't work. `border:none;` removes the border from the iframe - this is useful if you want the embedded content to look more like internal content from your page.
-| sandbox | false | You can switch the sandbox completely on by setting `sandbox = true` or allow specific functionality with the common values for the iframe parameter `sandbox` defined in the [HTML standard](https://www.w3schools.com/tags/att_iframe_sandbox.asp).
-| name | iframe-name | Specify the [name of the iframe](https://www.w3schools.com/tags/att_iframe_name.asp).
-| id | iframe-id | Sets the ID of the iframe.
-| class |  | Optional parameter to set the classes of the iframe.
-| sub | Your browser cannot display embedded frames. You can access the embedded page via the following link: | The text displayed (in addition to the embedded URL) if the user's browser can't display embedded frames.
+| Parameter     | Default                                                                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| src           |                                                                                                       | URL of external content                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| width         | 100%                                                                                                  | Width of iframe                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| tryautoheight | true                                                                                                  | If true the shortcode tries to calculate the needed height for the embedded content using JavaScript, as described here: https://stackoverflow.com/a/14618068. This is only possible if the embedded content is [on the same domain](https://stackoverflow.com/questions/22086722/resize-cross-domain-iframe-height). Note that even if the embedded content is on the same domain, it depends on the structure of the content if the height can be calculated correctly. |
+| style         | min-height:98vh; border:none;                                                                         | CSS styles for the iframe. `min-height:98vh;` is a backup if `tryautoheight` doesn't work. `border:none;` removes the border from the iframe - this is useful if you want the embedded content to look more like internal content from your page.                                                                                                                                                                                                                         |
+| sandbox       | false                                                                                                 | You can switch the sandbox completely on by setting `sandbox = true` or allow specific functionality with the common values for the iframe parameter `sandbox` defined in the [HTML standard](https://www.w3schools.com/tags/att_iframe_sandbox.asp).                                                                                                                                                                                                                     |
+| name          | iframe-name                                                                                           | Specify the [name of the iframe](https://www.w3schools.com/tags/att_iframe_name.asp).                                                                                                                                                                                                                                                                                                                                                                                     |
+| id            | iframe-id                                                                                             | Sets the ID of the iframe.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| class         |                                                                                                       | Optional parameter to set the classes of the iframe.                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| sub           | Your browser cannot display embedded frames. You can access the embedded page via the following link: | The text displayed (in addition to the embedded URL) if the user's browser can't display embedded frames.                                                                                                                                                                                                                                                                                                                                                                 |
 
-{{% alert title="Warning" color="warning" %}}
-You can only embed external content from a server when its `X-Frame-Options` is not set or if it specifically allows embedding for your site. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options for details.
+{{% alert title="Warning" color="warning" %}} You can only embed external
+content from a server when its `X-Frame-Options` is not set or if it
+specifically allows embedding for your site. See
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options for
+details.
 
-There are several tools you can use to check if a website can be embedded via iframe - e.g.: https://gf.dev/x-frame-options-test. Be aware that when this test says "Couldn’t find the X-Frame-Options header
-in the response headers." you __CAN__ embed it, but when the test says "Great! X-Frame-Options header was found in the HTTP response headers as highlighted below.", you __CANNOT__ - unless it has been explicitly enabled for your site.
-{{% /alert %}}
+There are several tools you can use to check if a website can be embedded via
+iframe - e.g.: https://gf.dev/x-frame-options-test. Be aware that when this test
+says "Couldn’t find the X-Frame-Options header in the response headers." you
+**CAN** embed it, but when the test says "Great! X-Frame-Options header was
+found in the HTTP response headers as highlighted below.", you **CANNOT** -
+unless it has been explicitly enabled for your site. {{% /alert %}}
 
 ## Tabbed panes
 
-Sometimes it's very useful to have tabbed panes when authoring content. One common use-case is to show multiple syntax highlighted code blocks that showcase the same problem, and how to solve it in different programming languages. As an example, the tabbed pane below shows the language-specific variants of the famous `Hello world!` program one usually writes first when learning a new programming language:
+Sometimes it's very useful to have tabbed panes when authoring content. One
+common use-case is to show multiple syntax highlighted code blocks that showcase
+the same problem, and how to solve it in different programming languages. As an
+example, the tabbed pane below shows the language-specific variants of the
+famous `Hello world!` program one usually writes first when learning a new
+programming language:
 
 {{< tabpane langEqualsHeader=true >}}
 {{< tab "C" >}}
@@ -396,7 +456,10 @@ object HelloWorld extends App {
 {{< /tab >}}
 {{< /tabpane >}}
 
-The Docsy template provides two shortcodes `tabpane` and `tab` that let you easily create tabbed panes. To see how to use them, have a look at the following code block, which renders to a right aligned pane with one disabled and three active tabs:
+The Docsy template provides two shortcodes `tabpane` and `tab` that let you
+easily create tabbed panes. To see how to use them, have a look at the following
+code block, which renders to a right aligned pane with one disabled and three
+active tabs:
 
 ```go-html-template
 {{</* tabpane text=true right=true */>}}
@@ -416,7 +479,8 @@ The Docsy template provides two shortcodes `tabpane` and `tab` that let you easi
 {{</* /tabpane */>}}
 ```
 
-This code translates to the right aligned tabbed pane below, showing a `Welcome!` greeting in English, German or Swahili:
+This code translates to the right aligned tabbed pane below, showing a
+`Welcome!` greeting in English, German or Swahili:
 
 {{< tabpane text=true right=true >}}
   {{% tab header="**Languages**:" disabled=true /%}}
@@ -447,12 +511,13 @@ the following named parameters, all of which are optional:
 - **`lang`**: the default code-block language to use for all contained tabs
 - **`highlight`**: parameter passed on to the code-block [highlight] function,
   as described below
-- **`langEqualsHeader`**: set to `true` when header text matches the tab language.
+- **`langEqualsHeader`**: set to `true` when header text matches the tab
+  language.
 - **`persist`**: one of `header`, `lang`, or `disabled`
 - **`persistLang`**: deprecated, use `persist` instead
 - **`right`**: set to `true` if you want right-aligned tabs
-- **`text`**: set to `true` if the content of all contained tabs are text. Default
-  is `false` and assumes the content is code.
+- **`text`**: set to `true` if the content of all contained tabs are text.
+  Default is `false` and assumes the content is code.
 
 The value of the optional parameters `lang` and `highlight` are passed on as
 second `LANG` and third `OPTIONS` arguments to Hugo's built-in [highlight]
@@ -469,16 +534,16 @@ Tab selection is persisted by default. When unspecified, `persist` defaults to
 The `tab` shortcode represent the tabs you want to show. It supports the
 following named parameters, all of which are optional:
 
-- **`header`**: defines the tab's header text. When omitted it defaults to text of
-  the form "Tab _n_". You can omit the parameter name if it is the only tab
+- **`header`**: defines the tab's header text. When omitted it defaults to text
+  of the form "Tab _n_". You can omit the parameter name if it is the only tab
   parameter:
   ```
   {{</* tab "My tab header" */>}} … {{</* /tab */>}}
   ```
 - **`lang`**: code-block language for code tabs
 - **`highlight`**: parameter passed on to the code-block [highlight] function
-- **`right`**: set to `true` in order to split tab panes into a left aligned and a
-  right aligned tab groups. Specify `right=true` in the dividing tab. By using
+- **`right`**: set to `true` in order to split tab panes into a left aligned and
+  a right aligned tab groups. Specify `right=true` in the dividing tab. By using
   `right=true` more than once, you can even render multiple tab groups.
 - **`disabled`**: set to `true` to disable a tab.
 - **`text`**: set to `true` for text tabs. By default tabs are assumed to
@@ -503,31 +568,40 @@ and _textual_ representation:
 
 ## Card panes
 
-When authoring content, it's sometimes very useful to put similar text blocks or code fragments on card like elements, which can be optionally presented side by side. Let's showcase this feature with the following sample card group which shows the first four Presidents of the United States:
+When authoring content, it's sometimes very useful to put similar text blocks or
+code fragments on card like elements, which can be optionally presented side by
+side. Let's showcase this feature with the following sample card group which
+shows the first four Presidents of the United States:
 
 {{% cardpane %}}
 {{% card header="**George Washington**" title="\*1732 &nbsp;&nbsp;&nbsp; †1799" subtitle="**President:** 1789 – 1797" footer="![SignatureGeorgeWashington](https://upload.wikimedia.org/wikipedia/commons/thumb/2/2e/George_Washington_signature.svg/320px-George_Washington_signature.svg.png 'Signature George Washington')" %}}
-![PortraitGeorgeWashington](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg/633px-Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg "Portrait George Washington")
+![PortraitGeorgeWashington](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg/633px-Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg 'Portrait George Washington')
 {{% /card %}}
 {{% card header="**John Adams**" title="\* 1735 &nbsp;&nbsp;&nbsp; † 1826" subtitle="**President:** 1797 – 1801" footer="![SignatureJohnAdams](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e8/John_Adams_Sig_2.svg/320px-John_Adams_Sig_2.svg.png 'Signature John Adams')" %}}
-![PortraitJohnAdams](https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg/633px-Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg "Portrait John Adams")
+![PortraitJohnAdams](https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg/633px-Gilbert_Stuart%2C_John_Adams%2C_c._1800-1815%2C_NGA_42933.jpg 'Portrait John Adams')
 {{% /card %}}
 {{% card header="**Thomas Jefferson**" title="\* 1743 &nbsp;&nbsp;&nbsp; † 1826" subtitle="**President:** 1801 – 1809" footer="![SignatureThomasJefferson](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Thomas_Jefferson_Signature.svg/320px-Thomas_Jefferson_Signature.svg.png 'Signature Thomas Jefferson')" %}}
-![PortraitThomasJefferson](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg/390px-Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg "Portrait Thomas Jefferson")
+![PortraitThomasJefferson](https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg/390px-Official_Presidential_portrait_of_Thomas_Jefferson_%28by_Rembrandt_Peale%2C_1800%29%28cropped%29.jpg 'Portrait Thomas Jefferson')
 {{% /card %}}
 {{% card header="**James Madison**" title="\* 1751 &nbsp;&nbsp;&nbsp; † 1836" subtitle="**President:** 1809 – 1817" footer="![SignatureJamesMadison](https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/James_Madison_sig.svg/320px-James_Madison_sig.svg.png 'Signature James Madison')" %}}
-![PortraitJamesMadison](https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/James_Madison%28cropped%29%28c%29.jpg/393px-James_Madison%28cropped%29%28c%29.jpg "Portrait James Madison")
-{{% /card %}}
-{{% /cardpane %}}
+![PortraitJamesMadison](https://upload.wikimedia.org/wikipedia/commons/thumb/2/20/James_Madison%28cropped%29%28c%29.jpg/393px-James_Madison%28cropped%29%28c%29.jpg 'Portrait James Madison')
+{{% /card %}} {{% /cardpane %}}
 
 Docsy supports creating such card panes via different shortcodes:
 
-* The `cardpane` shortcode which is the container element for the various cards to be presented.
-* The `card` shortcodes, with each shortcode representing an individual card. While cards are often presented inside a card group, a single card may stand on its own, too. A `card` shortcode can hold programming code, text, images or any other arbitrary kind of markdown or HTML markup as content. In case of programming code, cards provide automatic code-highlighting and other optional features like line numbers, highlighting of certain lines, ….
+- The `cardpane` shortcode which is the container element for the various cards
+  to be presented.
+- The `card` shortcodes, with each shortcode representing an individual card.
+  While cards are often presented inside a card group, a single card may stand
+  on its own, too. A `card` shortcode can hold programming code, text, images or
+  any other arbitrary kind of markdown or HTML markup as content. In case of
+  programming code, cards provide automatic code-highlighting and other optional
+  features like line numbers, highlighting of certain lines, ….
 
 ### Shortcode `card`: textual content
 
-Make use of the `card` shortcode to display a card. The following code sample demonstrates how to code a card element:
+Make use of the `card` shortcode to display a card. The following code sample
+demonstrates how to code a card element:
 
 ```go-html-template
 {{</* card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono"
@@ -539,35 +613,42 @@ Imagine all the people living for today…
 …
 {{</* /card */>}}
 ```
-This code translates to the left card shown below, showing the lyrics of John Lennon's famous song `Imagine`. A second explanatory card element to the right indicates and explains the individual components of a card:
+
+This code translates to the left card shown below, showing the lyrics of John
+Lennon's famous song `Imagine`. A second explanatory card element to the right
+indicates and explains the individual components of a card:
 
 {{% cardpane %}}
 {{< card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono" footer="![SignatureJohnLennon](https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Firma_de_John_Lennon.svg/320px-Firma_de_John_Lennon.svg.png 'Signature John Lennon')" >}}
-Imagine there's no heaven, It's easy if you try<br/>
-No hell below us, above us only sky<br/>
-Imagine all the people living for today…
+Imagine there's no heaven, It's easy if you try<br/> No hell below us, above us
+only sky<br/> Imagine all the people living for today…
 
-Imagine there's no countries, it isn't hard to do<br/>
-Nothing to kill or die for, and no religion too<br/>
-Imagine all the people living life in peace…
+Imagine there's no countries, it isn't hard to do<br/> Nothing to kill or die
+for, and no religion too<br/> Imagine all the people living life in peace…
 
-Imagine no possessions, I wonder if you can<br/>
-No need for greed or hunger - a brotherhood of man<br/>
-Imagine all the people sharing all the world…
+Imagine no possessions, I wonder if you can<br/> No need for greed or hunger - a
+brotherhood of man<br/> Imagine all the people sharing all the world…
 
-You may say I'm a dreamer, but I'm not the only one<br/>
-I hope someday you'll join us and the world will live as one
-{{< /card >}}
+You may say I'm a dreamer, but I'm not the only one<br/> I hope someday you'll
+join us and the world will live as one {{< /card >}}
 {{% card header="**Header**: specified via named parameter `Header`" title="**Card title**: specified via named parameter `title`" subtitle="**Card subtitle**: specified via named parameter `subtitle`" footer="**Footer**: specified via named parameter `footer`" %}}
-  **Content**: inner content of the shortcode, this may be plain text or formatted text, images, videos, … . If your content is markdown, use the percent sign `%` as outermost delimiter of your `card` shortcode, your markup should look like `{{%/* card */%}}Your **markdown** content{{%/* /card */%}}`. In case of HTML content, use square brackets `<>` as outermost delimiters: `{{</* card */>}}Your <b>HTML</b> content{{</* /card */>}}`
-{{% /card %}}
+**Content**: inner content of the shortcode, this may be plain text or formatted
+text, images, videos, … . If your content is markdown, use the percent sign `%`
+as outermost delimiter of your `card` shortcode, your markup should look like
+`{{%/* card */%}}Your **markdown** content{{%/* /card */%}}`. In case of HTML
+content, use square brackets `<>` as outermost delimiters:
+`{{</* card */>}}Your <b>HTML</b> content{{</* /card */>}}` {{% /card %}}
 {{% /cardpane %}}
 
-While the main content of the card is taken from the inner markup of the `card` shortcode, the optional elements `footer`, `header`, `title`, and `subtitle` are all specified as named parameters of the shortcode.
+While the main content of the card is taken from the inner markup of the `card`
+shortcode, the optional elements `footer`, `header`, `title`, and `subtitle` are
+all specified as named parameters of the shortcode.
 
 ### Shortcode `card`: programming code
 
-If you want to display programming code on your card, set the named parameter `code` of the card to `true`. The following sample demonstrates how to code a card element with the famous `Hello world!` application coded in C:
+If you want to display programming code on your card, set the named parameter
+`code` of the card to `true`. The following sample demonstrates how to code a
+card element with the famous `Hello world!` application coded in C:
 
 ```go-html-template
 {{</* card code=true header="**C**" lang="C" */>}}
@@ -584,23 +665,22 @@ int main(void)
 
 This code translates to the card shown below:
 
-{{< card code=true header="**C**" lang="C" highlight="" >}}
-#include <stdio.h>
+{{< card code=true header="**C**" lang="C" highlight="" >}} #include <stdio.h>
 #include <stdlib.h>
 
-int main(void)
-{
-  puts("Hello World!");
-  return EXIT_SUCCESS;
-}
-{{< /card >}}
+int main(void) { puts("Hello World!"); return EXIT_SUCCESS; } {{< /card >}}
 
-<br/>If called with parameter `code=true`, the `card` shortcode can optionally hold the named parameters `lang` and/or `highlight`. The values of these optional parameters are passed on as second `LANG` and third `OPTIONS` arguments to Hugo's built-in [`highlight`](https://gohugo.io/functions/highlight/) function which is used to render the code block presented on the card.
+<br/>If called with parameter `code=true`, the `card` shortcode can optionally
+hold the named parameters `lang` and/or `highlight`. The values of these
+optional parameters are passed on as second `LANG` and third `OPTIONS` arguments
+to Hugo's built-in [`highlight`](https://gohugo.io/functions/highlight/)
+function which is used to render the code block presented on the card.
 
 ### Card groups
 
-Displaying two ore more cards side by side can be easily achieved by putting them between the opening and closing elements of a `cardpane` shortcode.
-The general markup of a card group resembles closely the markup of a tabbed pane:
+Displaying two ore more cards side by side can be easily achieved by putting
+them between the opening and closing elements of a `cardpane` shortcode. The
+general markup of a card group resembles closely the markup of a tabbed pane:
 
 ```go-html-template
 {{</* cardpane */>}}
@@ -616,21 +696,15 @@ The general markup of a card group resembles closely the markup of a tabbed pane
 {{</* /cardpane */>}}
 ```
 
-Contrary to tabs, cards are presented side by side, however. This is especially useful it you want to compare different programming techniques (traditional vs. modern) on two cards, like demonstrated in the example above:
+Contrary to tabs, cards are presented side by side, however. This is especially
+useful it you want to compare different programming techniques (traditional vs.
+modern) on two cards, like demonstrated in the example above:
 
-{{< cardpane >}}
-{{< card code=true header="**Java 5**" >}}
-File[] hiddenFiles = new File("directory_name")
-  .listFiles(new FileFilter() {
-    public boolean accept(File file) {
-      return file.isHidden();
-    }
-  });
-{{< /card >}}
-{{< card code=true header="**Java 8, Lambda expression**" >}}
-File[] hiddenFiles = new File("directory_name")
-  .listFiles(File::isHidden);
-{{< /card >}}
+{{< cardpane >}} {{< card code=true header="**Java 5**" >}} File[] hiddenFiles =
+new File("directory_name") .listFiles(new FileFilter() { public boolean
+accept(File file) { return file.isHidden(); } }); {{< /card >}}
+{{< card code=true header="**Java 8, Lambda expression**" >}} File[] hiddenFiles
+= new File("directory_name") .listFiles(File::isHidden); {{< /card >}}
 {{< /cardpane >}}
 
 ## Include external files
@@ -684,8 +758,8 @@ The following section explains how to install the database:
 
 ---
 
-The parameter is the relative path to the file. Only relative paths
-under the parent file's working directory are supported.
+The parameter is the relative path to the file. Only relative paths under the
+parent file's working directory are supported.
 
 For files outside the current working directory you can use an absolute path
 starting with `/`. The root directory is the `/content` folder.
@@ -706,8 +780,8 @@ To create a new pipeline, follow the next steps:
 1.  Apply the file to your cluster `kubectl apply config.yaml`
 ```
 
-This code automatically reads the content of `includes/config.yaml` and inserts it
-into the document. The rendered text looks like this:
+This code automatically reads the content of `includes/config.yaml` and inserts
+it into the document. The rendered text looks like this:
 
 ---
 
@@ -721,34 +795,35 @@ To create a new pipeline, follow the next steps:
 
 ---
 
-{{% alert title="Warning" color="warning" %}}
-You must use `{{</* */>}}` delimiters for the code highlighting to work
-correctly.
-{{% /alert %}}
+{{% alert title="Warning" color="warning" %}} You must use `{{</* */>}}`
+delimiters for the code highlighting to work correctly. {{% /alert %}}
 
-The `file` parameter is the relative path to the file. Only relative paths
-under the parent file's working directory are supported.
+The `file` parameter is the relative path to the file. Only relative paths under
+the parent file's working directory are supported.
 
 For files outside the current working directory you can use an absolute path
 starting with `/`. The root directory is the `/content` folder.
 
-| Parameter        | Default    | Description  |
-| ---------------- |------------| ------------|
-| file | | Path of external file|
-| code | false | Boolean value. If `true` the contents is treated as code|
-| lang | plain text | Programming language |
+| Parameter | Default    | Description                                              |
+| --------- | ---------- | -------------------------------------------------------- |
+| file      |            | Path of external file                                    |
+| code      | false      | Boolean value. If `true` the contents is treated as code |
+| lang      | plain text | Programming language                                     |
 
 ### Error reporting
 
-If the shortcode can't find the specified file, the shortcode throws a compile error.
+If the shortcode can't find the specified file, the shortcode throws a compile
+error.
 
-In the following example, Hugo throws a compile error if it can't find `includes/deploy.yml`:
+In the following example, Hugo throws a compile error if it can't find
+`includes/deploy.yml`:
 
 ```go-html-template
 {{</* readfile file="includes/deploy.yaml" code="true" lang="yaml" */>}}
 ```
 
-Alternately, Hugo you can display a message on the rendered page instead of throwing a compile error. Add `draft="true"` as a parameter. For example:
+Alternately, Hugo you can display a message on the rendered page instead of
+throwing a compile error. Add `draft="true"` as a parameter. For example:
 
 ```go-html-template
 {{</* readfile file="includes/deploy.yaml" code="true" lang="yaml" draft="true" */>}}
@@ -756,7 +831,11 @@ Alternately, Hugo you can display a message on the rendered page instead of thro
 
 ## Conditional text
 
-The `conditional-text` shortcode allows you to show or hide parts of your content depending on the value of the `buildCondition` parameter set in your configuration file. This can be useful if you are generating different builds from the same source, for example, using a different product name. This shortcode helps you handle the minor differences between these builds.
+The `conditional-text` shortcode allows you to show or hide parts of your
+content depending on the value of the `buildCondition` parameter set in your
+configuration file. This can be useful if you are generating different builds
+from the same source, for example, using a different product name. This
+shortcode helps you handle the minor differences between these builds.
 
 ```text
 {{%/* conditional-text include-if="foo" */%}}
@@ -767,6 +846,9 @@ This text does not appear in the output if `buildCondition = "bar" is set in you
 {{%/* /conditional-text */%}}
 ```
 
-If you are using this shortcode, note that when evaluating the conditions, substring matches are matches as well. That means, if you set `include-if="foobar"`, and `buildcondition = "foo"`, you have a match!
+If you are using this shortcode, note that when evaluating the conditions,
+substring matches are matches as well. That means, if you set
+`include-if="foobar"`, and `buildcondition = "foo"`, you have a match!
 
-[shortcode delimiter]: https://gohugo.io/content-management/shortcodes/#use-shortcodes
+[shortcode delimiter]:
+  https://gohugo.io/content-management/shortcodes/#use-shortcodes

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -208,6 +208,7 @@ Norway Spruce *Picea abies* shoot with foliage buds.
 
 The example above has also a byline with photo attribution added. When using illustrations with a free license from [WikiMedia](https://commons.wikimedia.org/) and similar, you will in most situations need a way to attribute the author or licensor. You can add metadata to your page resources in the page front matter. The `byline` param is used by convention in this theme:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -240,6 +241,7 @@ resources:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 | Parameter        | Description  |
 | ----------------: |------------|
@@ -251,6 +253,7 @@ resources:
 
 You can place the `swaggerui` shortcode anywhere inside a page with the [`swagger` layout](https://github.com/google/docsy/tree/main/layouts/swagger); it renders [Swagger UI](https://swagger.io/tools/swagger-ui/) using any OpenAPI YAML or JSON file as source. This file can be hosted anywhere you like, for example in your site's root [`/static` folder](/docs/adding-content/content/#adding-static-content).
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
 {{< tab header="toml" lang="toml" >}}
@@ -284,6 +287,7 @@ description: Reference for the Pet Store API
 {{</* swaggerui src="/openapi/petstore.yaml" */>}}
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 You can customize Swagger UI's look and feel by overriding Swagger's CSS in `themes/docsy/assets/scss/_swagger.scss`.
 

--- a/userguide/content/en/docs/adding-content/versioning.md
+++ b/userguide/content/en/docs/adding-content/versioning.md
@@ -1,22 +1,22 @@
 ---
-title: "Doc Versioning"
+title: Doc Versioning
 date: 2020-02-02
 weight: 4
-description: >
-   Customize navigation and banners for multiple versions of your docs.
+description: Customize navigation and banners for multiple versions of your docs.
 ---
 
 Depending on your project's releases and versioning, you may want to let your
 users access previous versions of your documentation. How you deploy the
 previous versions is up to you. This page describes the Docsy features that you
-can use to provide navigation between the various versions of your docs and
-to display an information banner on the archived sites.
+can use to provide navigation between the various versions of your docs and to
+display an information banner on the archived sites.
 
 ## Adding a version drop-down menu
 
-If you add some `[params.versions]` in `hugo.toml`/`hugo.yaml`/`hugo.json`, the Docsy theme adds a
-version selector drop down to the top-level menu. You specify a URL and a name
-for each version you would like to add to the menu, as in the following example:
+If you add some `[params.versions]` in `hugo.toml`/`hugo.yaml`/`hugo.json`, the
+Docsy theme adds a version selector drop down to the top-level menu. You specify
+a URL and a name for each version you would like to add to the menu, as in the
+following example:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -71,7 +71,8 @@ params:
 Remember to add your current version so that users can navigate back!
 
 The default title for the version drop-down menu is **Releases**. To change the
-title, change the site parameter `version_menu` in `hugo.toml`/`hugo.yaml`/`hugo.json`:
+title, change the site parameter `version_menu` in
+`hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
@@ -94,10 +95,11 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-If you set the `version_menu_pagelinks` parameter to `true`, then links in the version drop-down menu
-point to the current page in the other version, instead of the main page.
-This can be useful if the document doesn't change much between the different versions.
-Note that if the current page doesn't exist in the other version, the link will be broken.
+If you set the `version_menu_pagelinks` parameter to `true`, then links in the
+version drop-down menu point to the current page in the other version, instead
+of the main page. This can be useful if the document doesn't change much between
+the different versions. Note that if the current page doesn't exist in the other
+version, the link will be broken.
 
 You can read more about Docsy menus in the guide to
 [navigation and search](/docs/adding-content/navigation/).
@@ -124,6 +126,7 @@ To add the banner to your doc site, make the following changes in your
 `hugo.toml`/`hugo.yaml`/`hugo.json` file:
 
 <!-- prettier-ignore-start -->
+
 1. Set the site parameter `archived_version` to `true`:
 
     {{< tabpane >}}
@@ -189,4 +192,5 @@ params:
 }
 {{< /tab >}}
     {{< /tabpane >}}
+
 <!-- prettier-ignore-end -->

--- a/userguide/content/en/docs/adding-content/versioning.md
+++ b/userguide/content/en/docs/adding-content/versioning.md
@@ -18,6 +18,7 @@ If you add some `[params.versions]` in `hugo.toml`/`hugo.yaml`/`hugo.json`, the 
 version selector drop down to the top-level menu. You specify a URL and a name
 for each version you would like to add to the menu, as in the following example:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -65,12 +66,14 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 Remember to add your current version so that users can navigate back!
 
 The default title for the version drop-down menu is **Releases**. To change the
 title, change the site parameter `version_menu` in `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
@@ -89,6 +92,7 @@ params:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
 If you set the `version_menu_pagelinks` parameter to `true`, then links in the version drop-down menu
 point to the current page in the other version, instead of the main page.
@@ -119,6 +123,7 @@ For example, see the archived docs for
 To add the banner to your doc site, make the following changes in your
 `hugo.toml`/`hugo.yaml`/`hugo.json` file:
 
+<!-- prettier-ignore-start -->
 1. Set the site parameter `archived_version` to `true`:
 
     {{< tabpane >}}
@@ -184,3 +189,4 @@ params:
 }
 {{< /tab >}}
     {{< /tabpane >}}
+<!-- prettier-ignore-end -->

--- a/userguide/content/en/docs/adding-content/versioning.md
+++ b/userguide/content/en/docs/adding-content/versioning.md
@@ -2,7 +2,8 @@
 title: Doc Versioning
 date: 2020-02-02
 weight: 4
-description: Customize navigation and banners for multiple versions of your docs.
+description: >-
+  Customize navigation and banners for multiple versions of your docs.
 ---
 
 Depending on your project's releases and versioning, you may want to let your


### PR DESCRIPTION
- Contributes to #1979
- Prettifies all pages under `adding-content` after adding appropriate `prettier-ignore` directives
- Adds a helper script that can be used to add `prettier-ignore` directives around `tabpane` elements
- No change in page content.
