### PR TITLE
Drop `_internal` prefix from template paths

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -21,9 +21,9 @@
   {{ end -}}
 </title>
 <meta name="description" content="{{ partial "page-description.html" . }}">
-{{ template "_internal/opengraph.html" . -}}
-{{ template "_internal/schema.html" . -}}
-{{ template "_internal/twitter_cards.html" . -}}
+{{ template "opengraph.html" . -}}
+{{ template "schema.html" . -}}
+{{ template "twitter_cards.html" . -}}
 {{ partialCached "head-css.html" . "head-css-cache-key" -}}
 <script
   src="https://code.jquery.com/jquery-3.7.1.min.js"
@@ -46,7 +46,7 @@
 
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
-  {{ template "_internal/google_analytics.html" . -}}
+  {{ template "google_analytics.html" . -}}
 {{ end -}}
 
 {{ define "algolia/head" -}}

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -1,3 +1,4 @@
+{{/* cSpell:ignore docsearch opengraph outputformat */ -}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 {{ range .AlternativeOutputFormats -}}
@@ -21,9 +22,9 @@
   {{ end -}}
 </title>
 <meta name="description" content="{{ partial "page-description.html" . }}">
-{{ template "opengraph.html" . -}}
-{{ template "schema.html" . -}}
-{{ template "twitter_cards.html" . -}}
+{{ partial "opengraph.html" . -}}
+{{ partial "schema.html" . -}}
+{{ partial "twitter_cards.html" . -}}
 {{ partialCached "head-css.html" . "head-css-cache-key" -}}
 <script
   src="https://code.jquery.com/jquery-3.7.1.min.js"
@@ -46,7 +47,7 @@
 
 {{/* To comply with GDPR, cookie consent scripts places in head-end must execute before Google Analytics is enabled */ -}}
 {{ if hugo.IsProduction -}}
-  {{ template "google_analytics.html" . -}}
+  {{ partial "google_analytics.html" . -}}
 {{ end -}}
 
 {{ define "algolia/head" -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -39,7 +39,7 @@
   {{ end -}}
 </div>
 <div class="td-blog-posts__pagination">
-  {{ template "_internal/pagination.html" . -}}
+  {{ template "pagination.html" . -}}
 </div>
 {{- end -}}
 {{ end -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -39,7 +39,7 @@
   {{ end -}}
 </div>
 <div class="td-blog-posts__pagination">
-  {{ template "pagination.html" . -}}
+  {{ partial "pagination.html" . -}}
 </div>
 {{- end -}}
 {{ end -}}

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -10,7 +10,7 @@ weight: 8
 ## Adding Analytics
 
 The Docsy theme builds upon [Hugo's support for Google Analytics][hugo-ga],
-which Hugo provides through [internal templates][]. Once you set up analytics as
+which Hugo provides through [embedded templates][]. Once you set up analytics as
 described below, usage information for your site (such as page views) is sent to
 your [Google Analytics][] account.
 
@@ -301,12 +301,12 @@ partial. For details, see
 [Customizing templates](lookandfeel/#customizing-templates).
 
 [Configure Google Analytics]:
-  https://gohugo.io/templates/internal/#configure-google-analytics
+  https://gohugo.io/templates/embedded/#configure-google-analytics
 [ga4-intro]: https://support.google.com/analytics/answer/1042508
 [Google Analytics]: https://analytics.google.com/analytics/web/
 [gtag.js]: https://support.google.com/analytics/answer/10220869
-[hugo-ga]: https://gohugo.io/templates/internal/#google-analytics
-[internal templates]: https://gohugo.io/templates/internal/
+[hugo-ga]: https://gohugo.io/templates/embedded/#google-analytics
+[embedded templates]: https://gohugo.io/templates/embedded/
 [page-description.html]:
   https://github.com/google/docsy/blob/main/layouts/_partials/page-description.html
 [site `params`]: https://gohugo.io/variables/site/#the-siteparams-variable

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -2043,7 +2043,7 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:44.15864-04:00"
   },
-  "https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash+c+csharp+cpp+go+java+markdown+python+scss+sql+toml+yaml&plugins=toolbar+copy-to-clipboard": {
+  "https://prismjs.com/download.html#themes=prism\u0026languages=markup+css+clike+javascript+bash+c+csharp+cpp+go+java+markdown+python+scss+sql+toml+yaml\u0026plugins=toolbar+copy-to-clipboard": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:43.950837-04:00"
   },

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -1847,6 +1847,18 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:37.548164-04:00"
   },
+  "https://gohugo.io/templates/embedded/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-16T10:33:25.556387-04:00"
+  },
+  "https://gohugo.io/templates/embedded/#configure-google-analytics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-16T10:33:25.984266-04:00"
+  },
+  "https://gohugo.io/templates/embedded/#google-analytics": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-16T10:33:25.360519-04:00"
+  },
   "https://gohugo.io/templates/internal/": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:34.993115-04:00"
@@ -2031,7 +2043,7 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:44.15864-04:00"
   },
-  "https://prismjs.com/download.html#themes=prism\u0026languages=markup+css+clike+javascript+bash+c+csharp+cpp+go+java+markdown+python+scss+sql+toml+yaml\u0026plugins=toolbar+copy-to-clipboard": {
+  "https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash+c+csharp+cpp+go+java+markdown+python+scss+sql+toml+yaml&plugins=toolbar+copy-to-clipboard": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:43.950837-04:00"
   },


### PR DESCRIPTION
- Contributes to #2243
- Drops `_internal` prefix from template paths
- Adjusts UG accordingly
- Note: tests were passing when doing a development build, but then failed in production. Needed to use `partial "abc"` rather than `template "abc"` to get checks to pass in production