### PR TITLE
Move new content-after-header hook into partials folder, add UG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,12 @@ For the full list of changes, see the [0.x.y] release notes.
 - **[Breadcrumb navigation]** support has been enhanced and adjusted:
   - You can now disable breadcrumbs for an entire project, or individual pages
     or sections by setting `ui.breadcrumb_disable` to true. For details, see
-    [Breadcrumb navigation].
+    [Breadcrumb navigation][].
   - **Blog** pages now also have breadcrumbs by default ([#1788]).
   - Index-page single-element breadcrumb lists are hidden by default ([#2160]).
 - Support for a [td/content-after-header.html] page-content render hook, which
-  can be [content type][] specific ([#2192]).
+  can be [content type][] specific ([#2192]). For details, see the [User
+  Guide][before-page-content].
 
 **Other changes**:
 
@@ -63,6 +64,8 @@ For the full list of changes, see the [0.x.y] release notes.
 [#2192]: https://github.com/google/docsy/pull/2192
 [#2223]: https://github.com/google/docsy/pull/2223
 [#2243]: https://github.com/google/docsy/pull/2243
+[before-page-content]:
+  https://www.docsy.dev/docs/adding-content/lookandfeel/#before-page-content
 [Breadcrumb navigation]:
   https://www.docsy.dev/docs/adding-content/navigation/#breadcrumb-navigation
 [content type]: https://gohugo.io/quick-reference/glossary/#content-type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ For the full list of changes, see the [0.x.y] release notes.
     [Breadcrumb navigation].
   - **Blog** pages now also have breadcrumbs by default ([#1788]).
   - Index-page single-element breadcrumb lists are hidden by default ([#2160]).
-- Support for a [td-content-after-header.html] page-content render hook, which
-  can be [content type] specific ([#2192]).
+- Support for a [td/content-after-header.html] page-content render hook, which
+  can be [content type][] specific ([#2192]).
 
 **Other changes**:
 
@@ -68,8 +68,8 @@ For the full list of changes, see the [0.x.y] release notes.
 [content type]: https://gohugo.io/quick-reference/glossary/#content-type
 [Heading self links]:
   https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links
-[td-content-after-header.html]:
-  https://github.com/google/docsy/blob/main/layouts/td-content-after-header.html
+[td/content-after-header.html]:
+  https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html
 
 ## 0.11.0
 

--- a/layouts/blog/content.html
+++ b/layouts/blog/content.html
@@ -11,7 +11,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ partial "td/content-after-header" . -}}
 	{{ .Content }}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/layouts/content.html
+++ b/layouts/content.html
@@ -7,7 +7,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ partial "td/content-after-header" . -}}
 	{{ .Content }}
 	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,7 +8,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ partial "td/content-after-header" . -}}
 	{{ .Content }}
 	{{ partial "section-index.html" . -}}
 	{{ partial "feedback.html" . -}}

--- a/userguide/.htmltest.yml
+++ b/userguide/.htmltest.yml
@@ -23,5 +23,4 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://badges.netlify.com/api
   - ^https://code.jquery.com
   # TEMPORARY until we're done with https://github.com/google/docsy/issues/2243
-  - ^https://github.com/google/docsy/blob/main/layouts/td-content-after-header.html
-  - ^https://github.com/google/docsy/blob/main/layouts/baseof.html
+  - ^https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -507,6 +507,16 @@ Both [head.html] and [scripts.html] are included from [baseof.html], Docsy's
 [scripts.html]:
   https://github.com/google/docsy/blob/main/layouts/_partials/head.html
 
+### Adding a banner before page content (EXPERIMENTAL) {#before-page-content}
+
+To have a banner, or other similar content, appear at the top of the pages in a
+section, add the content to the [td/content-after-header.html] partial. It will
+appear inside the `div.td-content`, after `</header>`, just before `.Content` is
+rendered.
+
+[td/content-after-header.html]:
+  https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html
+
 ## Adding custom class to the body element
 
 By default, Docsy adds the `td-{{ .Kind }}` class, where the kind is the kind of

--- a/userguide/package.json
+++ b/userguide/package.json
@@ -8,6 +8,7 @@
     "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit -m \"Site at $HASH\"",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
+    "_refcache:prune": "jq 'with_entries(select(.value.StatusCode < 400))' static/refcache.json > tmp/refcache.json && mv tmp/refcache.json static/refcache.json",
     "_serve": "npm run _hugo-dev -- serve --minify --disableFastRender --renderToMemory",
     "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "build:production": "npm run _hugo -- --minify",
@@ -33,5 +34,5 @@
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },
-  "cSpell:ignore": "- docsy htmltest pkgs postbuild precheck rtlcss -"
+  "cSpell:ignore": "- docsy htmltest pkgs postbuild precheck refcache rtlcss -"
 }

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -727,6 +727,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:38.127906-04:00"
   },
+  "https://github.com/google/docsy/blob/main/layouts/baseof.html": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-22T12:25:13.516369-04:00"
+  },
   "https://github.com/google/docsy/blob/main/layouts/blog/baseof.html": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:42.383402-04:00"

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -2307,6 +2307,10 @@
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:06:01.765051-05:00"
   },
+  "https://www.docsy.dev/docs/adding-content/lookandfeel/#before-page-content": {
+    "StatusCode": 206,
+    "LastSeen": "2025-05-22T13:24:36.066951-04:00"
+  },
   "https://www.docsy.dev/docs/adding-content/lookandfeel/#code-highlighting-with-chroma": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:07:28.264639-05:00"


### PR DESCRIPTION
- Cleanup done as a part of #2243 
- Moves `layouts/td-content-after-header.html` into the `_partials` folder since the hook is actually a partial just like the other hooks.
- Developer note: why place the file under `_partials/td` and not `_partials/td/hooks`? Because everything under `td` is a hook atm. Note that use of `td` is in support of #1654
- Adds an entry to the UG for this new feature, marking it as experimental. /cc @LisaFC 
  **Preview**: https://deploy-preview-2256--docsydocs.netlify.app/docs/adding-content/lookandfeel/#before-page-content