### PR TITLE
Make content-after-header a layout fragment again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ For the full list of changes, see the [0.12.0] release notes.
     [Breadcrumb navigation][].
   - **Blog** pages now also have breadcrumbs by default ([#1788]).
   - Index-page single-element breadcrumb lists are hidden by default ([#2160]).
-- Support for a [td/content-after-header.html] page-content render hook, which
+- Support for a [_td-content-after-header.html] page-content render hook, which
   can be [content type][] specific ([#2192]). For details, see the [User
   Guide][before-page-content].
 
@@ -84,8 +84,8 @@ For the full list of changes, see the [0.12.0] release notes.
 [content type]: https://gohugo.io/quick-reference/glossary/#content-type
 [Heading self links]:
   https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links
-[td/content-after-header.html]:
-  https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html
+[_td-content-after-header.html]:
+  https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html
 
 ## 0.11.0
 

--- a/layouts/_td-content.html
+++ b/layouts/_td-content.html
@@ -7,7 +7,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ partial "td/content-after-header" . -}}
+	{{ .Render "td-content-after-header" -}}
 	{{ .Content }}
 	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/_td-content.html
+++ b/layouts/_td-content.html
@@ -7,7 +7,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ .Render "_td-content-after-header" -}}
 	{{ .Content }}
 	{{ partial "feedback.html" . -}}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}

--- a/layouts/blog/_td-content.html
+++ b/layouts/blog/_td-content.html
@@ -11,7 +11,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ partial "td/content-after-header" . -}}
+	{{ .Render "td-content-after-header" -}}
 	{{ .Content }}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/layouts/blog/_td-content.html
+++ b/layouts/blog/_td-content.html
@@ -11,7 +11,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ .Render "_td-content-after-header" -}}
 	{{ .Content }}
 	{{ if (.Site.Config.Services.Disqus.Shortname) -}}
 		<br />

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,7 +8,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ .Render "td-content-after-header" -}}
+	{{ .Render "_td-content-after-header" -}}
 	{{ .Content }}
 	{{ partial "section-index.html" . -}}
 	{{ partial "feedback.html" . -}}

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -8,7 +8,7 @@
 			{{ partial "reading-time.html" . -}}
 		{{ end -}}
 	</header>
-	{{ partial "td/content-after-header" . -}}
+	{{ .Render "td-content-after-header" -}}
 	{{ .Content }}
 	{{ partial "section-index.html" . -}}
 	{{ partial "feedback.html" . -}}

--- a/userguide/.htmltest.yml
+++ b/userguide/.htmltest.yml
@@ -23,4 +23,4 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://badges.netlify.com/api
   - ^https://code.jquery.com
   # TEMPORARY until we're done with https://github.com/google/docsy/issues/2243
-  # - ^https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html
+  - ^https://github.com/google/docsy/blob/main/layouts/.*_td-content-after-header.html$

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -509,13 +509,16 @@ Both [head.html] and [scripts.html] are included from [baseof.html], Docsy's
 
 ### Adding a banner before page content (EXPERIMENTAL) {#before-page-content}
 
-To have a banner, or other similar content, appear at the top of the pages in a
-section, add the content to the [td/content-after-header.html] partial. It will
-appear inside the `div.td-content`, after `</header>`, just before `.Content` is
-rendered.
+To have a banner or other similar content appear at the top of the pages in a
+section, add the relevant HTML to a [_td-content-after-header.html] file in the
+section's page path under `layouts` -- such as
+`layouts/blog/_td-content-after-header.html`. Add the file directly under
+`layouts` to have the file processed for all site pages. The file's content will
+be included inside the `div.td-content`, after `</header>`, just before
+`.Content` is rendered.
 
-[td/content-after-header.html]:
-  https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html
+[_td-content-after-header.html]:
+  https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html
 
 ## Adding custom class to the body element
 

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -514,7 +514,7 @@ section, add the relevant HTML to a [_td-content-after-header.html] file in the
 section's page path under `layouts` -- such as
 `layouts/blog/_td-content-after-header.html`. Add the file directly under
 `layouts` to have the file processed for all docs, blog, and swagger pages. The
-file's content will be included inside the `div.td-content`, after `</header>`,
+file's content will be included inside the `div.td-content` after `</header>`,
 just before `.Content` is rendered.
 
 [_td-content-after-header.html]:

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -513,9 +513,9 @@ To have a banner or other similar content appear at the top of the pages in a
 section, add the relevant HTML to a [_td-content-after-header.html] file in the
 section's page path under `layouts` -- such as
 `layouts/blog/_td-content-after-header.html`. Add the file directly under
-`layouts` to have the file processed for all site pages. The file's content will
-be included inside the `div.td-content`, after `</header>`, just before
-`.Content` is rendered.
+`layouts` to have the file processed for all docs, blog, and swagger pages. The
+file's content will be included inside the `div.td-content`, after `</header>`,
+just before `.Content` is rendered.
 
 [_td-content-after-header.html]:
   https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -731,10 +731,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:38.127906-04:00"
   },
-  "https://github.com/google/docsy/blob/main/layouts/_partials/td/content-after-header.html": {
-    "StatusCode": 206,
-    "LastSeen": "2025-05-22T15:58:34.126222-04:00"
-  },
   "https://github.com/google/docsy/blob/main/layouts/baseof.html": {
     "StatusCode": 206,
     "LastSeen": "2025-05-22T12:25:13.516369-04:00"


### PR DESCRIPTION
- Contributes to #2243
- Partially reverts #2256, recovering the `td-content-after-head.html` as a layout fragment, which is processed via `.Render`
- Updates UG and changelog accordingly
- **Preview**: https://deploy-preview-2261--docsydocs.netlify.app/docs/adding-content/lookandfeel/#before-page-content