### PR TITLE
Streamline README.md and other copyedits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Docsy
 
-[![Project status: active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Project releases](https://img.shields.io/github/release/google/docsy)](https://github.com/google/docsy/releases)
-[![Project build Status](https://badges.netlify.com/api/docsydocs.svg?branch=main)](https://app.netlify.com/sites/docsydocs/deploys)
-[![Project contributors](https://img.shields.io/github/contributors/google/docsy)](https://github.com/google/docsy/graphs/contributors)
-[![Project license](https://img.shields.io/github/license/google/docsy)](https://github.com/google/docsy/blob/main/LICENSE)
-
 > **🚧 WARNING 🚧 : `main` is under development and potentially unstable! Use
 > official Docsy [releases].**
 

--- a/userguide/content/en/_index.md
+++ b/userguide/content/en/_index.md
@@ -20,7 +20,7 @@ for technical documentation sets. Our aim is to help you get a working
 documentation site up and running as easily as possible, so you can concentrate
 on creating great content for your users.
 
-<a href="https://www.netlify.com" target="_blank" rel="noopener">
+<a href="https://www.netlify.com/" target="_blank" rel="noopener">
   <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
 </a>
 {{% /blocks/lead %}}

--- a/userguide/content/en/docs/best-practices/site-guidance.md
+++ b/userguide/content/en/docs/best-practices/site-guidance.md
@@ -4,15 +4,26 @@ weight: 9
 description: Tips for authoring content for your Docsy-themed Hugo site.
 ---
 
-Docsy is a theme for the [Hugo](https://gohugo.io/) static site generator.
-If you're not already familiar with Hugo this page provides some useful tips and
-potential gotchas for adding and editing content for your site. Feel free to add your own!
+Docsy is a theme for the [Hugo](https://gohugo.io/) static site generator. If
+you're not already familiar with Hugo this page provides some useful tips and
+potential gotchas for adding and editing content for your site. Feel free to add
+your own!
 
 ## Linking
 
-By default, regular relative URLs in links are left unchanged by Hugo (they're still relative links in your site's generated HTML), hence some hardcoded relative links like `[relative cross-link](../../peer-folder/sub-file.md)` might behave unexpectedly compared to how they work on your local file system. You may find it helpful to use some of Hugo's built-in link shortcodes like [relref](https://gohugo.io/shortcodes/relref/) to avoid broken links in your generated site. For example a `{{</* ref "filename.md" */>}}` link in Hugo will actually
-find and automatically link to your file named `filename.md`.
+By default, regular relative URLs in links are left unchanged by Hugo (they're
+still relative links in your site's generated HTML), hence some hardcoded
+relative links like `[relative cross-link](../../peer-folder/sub-file.md)` might
+behave unexpectedly compared to how they work on your local file system. You may
+find it helpful to use some of Hugo's built-in link shortcodes like
+[relref](https://gohugo.io/shortcodes/relref/) to avoid broken links in your
+generated site. For example a `{{</* ref "filename.md" */>}}` link in Hugo will
+actually find and automatically link to your file named `filename.md`.
 
-Note, however, that `ref` and `relref` links don't work with `_index` or `index` files (for example, this site's [content landing page](/docs/adding-content/)): you'll need to use regular Markdown links to section landing or other index pages. Specify these links relative to the site's root URL, for example: `/docs/adding-content/`.
+Note, however, that `ref` and `relref` links don't work with `_index` or `index`
+files (for example, this site's [content landing page](/docs/adding-content/)):
+you'll need to use regular Markdown links to section landing or other index
+pages. Specify these links relative to the site's root URL, for example:
+`/docs/adding-content/`.
 
 [Learn more about linking](/docs/adding-content/content/#working-with-links).

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -1919,18 +1919,6 @@
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:03:30.862657-05:00"
   },
-  "https://img.shields.io/github/contributors/google/docsy": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-06T12:03:46.301185-05:00"
-  },
-  "https://img.shields.io/github/license/google/docsy": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-06T12:03:51.380092-05:00"
-  },
-  "https://img.shields.io/github/release/google/docsy": {
-    "StatusCode": 200,
-    "LastSeen": "2024-11-06T12:03:25.800371-05:00"
-  },
   "https://in-toto.io": {
     "StatusCode": 206,
     "LastSeen": "2024-12-12T10:10:52.769146-05:00"
@@ -2487,10 +2475,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:37.890382-04:00"
   },
-  "https://www.netlify.com": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-06T12:03:04.805936-05:00"
-  },
   "https://www.netlify.com/": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:03:41.203421-05:00"
@@ -2518,14 +2502,6 @@
   "https://www.npmjs.com/package/rtlcss": {
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:36.538411-04:00"
-  },
-  "https://www.repostatus.org/#active": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-06T12:03:15.045534-05:00"
-  },
-  "https://www.repostatus.org/badges/latest/active.svg": {
-    "StatusCode": 206,
-    "LastSeen": "2024-11-06T12:03:20.404752-05:00"
   },
   "https://www.selenium.dev/": {
     "StatusCode": 206,


### PR DESCRIPTION
- Fixes #2211
- Mainly: drops README badges. One can get the required information by other means.
- Prettifies a UG page. No change in content
- Adjusts refcache, and other minor tweaks