### PR TITLE
Hugo and Netlify NPM pkgs: update & change to peer; update UG

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run check && npm run cd:docs test",
     "update:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
     "update:hugo": "npm install --save-exact -D hugo-extended@latest",
-    "update:pkgs": "npx npm-check-updates -u && npm run cd:docs update:pkgs"
+    "update:pkgs": "npx npm-check-updates --dep 'prod,dev,optional,peer' -u && npm run cd:docs update:pkgs"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.7.2",
@@ -41,13 +41,21 @@
   },
   "devDependencies": {
     "cpy-cli": "^5.0.0",
-    "hugo-extended": "0.147.5",
-    "netlify-cli": "^21.5.0",
-    "npm-check-updates": "^18.0.1",
     "prettier": "^3.5.3"
   },
+  "peerDependencies": {
+    "hugo-extended": "0.147.6",
+    "netlify-cli": "^21.5.0",
+    "npm-check-updates": "^18.0.1"
+  },
+  "peerDependenciesMeta": {
+    "netlify-cli": {
+      "optional": true
+    }
+  },
   "engines": {
-    "node": ">=22"
+    "node": ">=22",
+    "npm": ">=11"
   },
   "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark twbs netlify pkgs userguide -"
 }

--- a/userguide/content/en/docs/get-started/other-options.md
+++ b/userguide/content/en/docs/get-started/other-options.md
@@ -89,11 +89,10 @@ The following shows you how to install Hugo from the release page:
 Install Hugo using
 [Brew](https://gohugo.io/getting-started/installing/#homebrew-macos).
 
-#### As an NPM module
+#### Hugo-extended NPM package {#hugo-extended-npm}
 
 You can install Hugo as an NPM module using
-[hugo-extended](https://www.npmjs.com/package/hugo-extended). To install the
-extended version of Hugo:
+[hugo-extended](https://www.npmjs.com/package/hugo-extended):
 
 ```sh
 npm install hugo-extended --save-dev
@@ -263,14 +262,23 @@ You can use Docsy as an NPM module as follows:
     echo "theme: docsy\nthemesDir: node_modules" >> hugo.yaml
     ```
 
-2.  Install Docsy, and postCSS (as [instructed earlier](#install-postcss)):
+2.  Install Docsy, and postCSS as [instructed earlier](#install-postcss):
 
     ```console
     npm init -y
-    npm install --save-dev google/docsy#semver:{{% param version %}} autoprefixer postcss-cli
+    npm install --save-dev autoprefixer postcss-cli
+    npm install --save-dev google/docsy#semver:{{% param version %}} --omit=peer
     ```
 
-    > **Important**: read the [Docsy NPM install side-effect] note.
+    {{% alert title="Hugo-module compatibility" color="warning" %}} Installing
+    Docsy using NPM creates an empty `github.com` sibling folder. For details,
+    see [Docsy NPM install side-effect](#docsy-npm-install-side-effect). {{%
+    /alert %}}
+
+    {{% alert title="Hugo install tip" color="info" %}} You can install Docsy's
+    officially supported version of [Hugo using NPM](#hugo-extended-npm) at the
+    same time as Docsy. Just omit the `--omit` flag from the command above. {{%
+    /alert %}}
 
 3.  Build or serve your new site using the usual Hugo commands, specifying the
     path to the Docsy theme files. For example, build your site as follows:

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -33,6 +33,8 @@ languages:
       description: Docsy does docs
 
 markup:
+  tableOfContents:
+    endLevel: 4
   goldmark:
     parser:
       attribute:


### PR DESCRIPTION
- Updates Hugo one minor patch version to 0.147.6
- Contributes to #2115 
- A step towards addressing the problems detailed in #2172
- Makes Hugo and Netlify-cli peer dependences. Marks Netlify-cli as optional, and hence as of NPM v11, will no longer be installed by default.
- Updates UG to clarify that projects installing Docsy via NPM can use `--omit=peer` to exclude Hugo and Netlify-cli packages. Or omit the `--omit=peer` and have the officially supported version of Hugo installed via `hugo-extended`
- Adjusts UG toc level inclusion
- **Preview**: https://deploy-preview-2274--docsydocs.netlify.app/docs/get-started/other-options/#option-3-docsy-as-an-npm-package

/cc @LisaFC @emckean 

### Screenshot

> <img width="858" alt="image" src="https://github.com/user-attachments/assets/6690545d-a794-4f3d-a6d6-547b723fd58c" />
