### PR TITLE
Shortcode 'card': trimming of whitespace

### DIFF
--- a/assets/scss/shortcodes/cards-pane.scss
+++ b/assets/scss/shortcodes/cards-pane.scss
@@ -24,7 +24,6 @@
 
     pre {
       margin: 0;
-      padding: 0 1rem 1rem 1rem;
     }
   }
 }

--- a/layouts/_shortcodes/card.html
+++ b/layouts/_shortcodes/card.html
@@ -31,7 +31,7 @@
     {{ end -}}
     {{ with $.Inner -}}
       {{ if $code -}}
-        {{ highlight . $lang $highlight -}}
+        {{ highlight ( . | strings.TrimSpace ) $lang $highlight -}}
       {{ else -}}
       <p class="card-text">
         {{ . -}}

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -669,10 +669,18 @@ int main(void)
 
 This code translates to the card shown below:
 
-{{< card code=true header="**C**" lang="C" highlight="" >}} #include <stdio.h>
+<!-- prettier-ignore-start -->
+{{< card code=true header="**C**" lang="C" highlight="" >}}
+#include <stdio.h>
 #include <stdlib.h>
 
-int main(void) { puts("Hello World!"); return EXIT_SUCCESS; } {{< /card >}}
+int main(void)
+{
+  puts("Hello World!");
+  return EXIT_SUCCESS;
+}
+{{< /card >}}
+<!-- prettier-ignore-end -->
 
 <br/>If called with parameter `code=true`, the `card` shortcode can optionally
 hold the named parameters `lang` and/or `highlight`. The values of these


### PR DESCRIPTION
This code

````
{{< card code=true header="My Header" lang="go-html-template" highlight="linenos=inline,lineNoStart=1" >}}
First line
{{< /card >}}
````

is currently rendered to:

````
My Header
1 
2 First line
````

This PR fixes that issue.

---

**Preview**: https://deploy-preview-2278--docsydocs.netlify.app/docs/adding-content/shortcodes/#shortcode-card-programming-code