### PR TITLE
UG cleanup of alert calls: drop color when set to default

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
   "scripts": {
+    "_build": "npm run cd:docs -- _build",
     "_cd:docs": "cd userguide &&",
     "_check:format": "npx prettier --check *.md",
     "_commit:public": "npm run cd:docs -- _commit:public",

--- a/userguide/content/en/blog/2024/0.10.0.md
+++ b/userguide/content/en/blog/2024/0.10.0.md
@@ -21,7 +21,7 @@ this Docsy version, review Hugo's deprecation notices and breaking changes since
 
 [0.123.0]: https://github.com/gohugoio/hugo/releases/tag/v0.123.0
 
-{{% alert title="Hugo version support reminder" color="primary" %}}
+{{% alert title="Hugo version support reminder" %}}
 
 Each Docsy version officially **only** supports the Hugo version specified in
 the project's [package.json] entry for [hugo-extended]. Any other compatibility
@@ -97,7 +97,7 @@ Which Docsy improvements are on the horizon? For work items _tentatively_
 planned for the next release, see
 [Release 0.11.0 preparation (#1944)](https://github.com/google/docsy/issues/1944).
 
-{{% alert title="Vote" color="primary" %}}
+{{% alert title="Vote" %}}
 
 If you'd like a feature or fix to be considered for inclusion in an upcoming
 release, remember to upvote (with a thumbs up) the associated issue or PR.

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -871,10 +871,10 @@ Hover over the image below and click edit to instantly start working with it.
 Clicking the `Save` button will cause the edited diagram to be exported using
 the same filename and filetype, and downloaded to your browser.
 
-{{%alert title="Note" %}} If you're creating a new diagram, be
-sure to `File -> Export` in either `svg` or `png` format (`svg` is usually the
-best choice) and ensure the `Include a copy of my diagram` is selected so it can
-be edited again later. {{%/alert%}}
+{{%alert title="Note" %}} If you're creating a new diagram, be sure to
+`File -> Export` in either `svg` or `png` format (`svg` is usually the best
+choice) and ensure the `Include a copy of my diagram` is selected so it can be
+edited again later. {{%/alert%}}
 
 As the diagram data is transported via the browser, the diagrams.net server does
 not need to access the content on your Docsy server directly at all.

--- a/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
+++ b/userguide/content/en/docs/adding-content/diagrams-and-formulae/index.md
@@ -871,7 +871,7 @@ Hover over the image below and click edit to instantly start working with it.
 Clicking the `Save` button will cause the edited diagram to be exported using
 the same filename and filetype, and downloaded to your browser.
 
-{{%alert title="Note"  color="primary" %}} If you're creating a new diagram, be
+{{%alert title="Note" %}} If you're creating a new diagram, be
 sure to `File -> Export` in either `svg` or `png` format (`svg` is usually the
 best choice) and ensure the `Include a copy of my diagram` is selected so it can
 be edited again later. {{%/alert%}}

--- a/userguide/content/en/docs/adding-content/feedback.md
+++ b/userguide/content/en/docs/adding-content/feedback.md
@@ -53,7 +53,7 @@ googleAnalytics][alias-discussion].
 
 {{% /alert %}}
 
-{{% alert title="Production-only feature!" color="primary" %}}
+{{% alert title="Production-only feature!" %}}
 
 Analytics are enabled _only_ for **production** builds (called "environments" in
 Hugo terminology). For information about Hugo environments and how to set them,

--- a/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
@@ -1,6 +1,6 @@
 **Installation**
 
-{{% alert title="Note" color="primary" %}} Check system compatibility before
+{{% alert title="Note" %}} Check system compatibility before
 proceeding. {{% /alert %}}
 
 1.  Download the installation files.

--- a/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/includes/installation.md
@@ -1,7 +1,7 @@
 **Installation**
 
-{{% alert title="Note" %}} Check system compatibility before
-proceeding. {{% /alert %}}
+{{% alert title="Note" %}} Check system compatibility before proceeding.
+{{% /alert %}}
 
 1.  Download the installation files.
 

--- a/userguide/content/en/docs/deployment/_index.md
+++ b/userguide/content/en/docs/deployment/_index.md
@@ -54,7 +54,7 @@ Then follow the instructions in [Host on Netlify](https://gohugo.io/hosting-and-
    If you don't want your site to be indexed by search engines, you can add an environment flag to your build command to specify a non-`production` environment, as described in [Build environments and indexing](#build-environments-and-indexing).
 1. Click **Deploy site**.
 
-{{% alert title="Note" color="primary" %}}
+{{% alert title="Note" %}}
 Netlify uses your site repo's `package.json` file to install any JavaScript dependencies (like `postcss`) before building your site. If you haven't just copied our example site's version of this file, make sure that you've specified all our [prerequisites](/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).
 
 For example, if you want to use a version of `postcss-cli` later than version 8.0.0, you need to ensure that your `package.json` also specifies `postcss` separately:
@@ -81,7 +81,7 @@ The Docsy example site repo provides a [workflow file](https://github.com/google
 
 Before deploying on GitHub Pages, make sure that you've pushed your site source to your chosen GitHub repo, following any setup instructions in [Using the theme](/docs/get-started/docsy-as-module).
 
-{{% alert title="Correct baseURL setting" color="primary" %}}
+{{% alert title="Correct baseURL setting" %}}
 Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '…'` command line parameter or inside your your `hugo.toml`/`hugo.yaml`/`hugo.json` configuration file. When deploying to GitHub pages your `baseURL` needs to be set to `https://<USERNAME>.github.io/<repository_name>`, otherwise your site layout will be broken.
 {{% /alert %}}
 
@@ -273,11 +273,11 @@ deployment:
 
 For more information about the Hugo `deploy` command, including command line options, see this [synopsis](https://gohugo.io/commands/hugo_deploy). In particular, you may find the `--maxDeletes int` option or the `--force` option (which forces upload of all files) useful.
 
-{{% alert title="Automated deployment with GitHub actions" color="primary" %}}
+{{% alert title="Automated deployment with GitHub actions" %}}
 If the source of your site lives in a GitHub repository, you can use [GitHub Actions](https://docs.github.com/en/actions) to deploy the site to your S3 bucket as soon as you commit changes to your GitHub repo. Setup of this workflow is described in this [blog post](https://capgemini.github.io/development/Using-GitHub-Actions-and-Hugo-Deploy-to-Deploy-to-AWS/).
 {{% /alert %}}
 
-{{% alert title="Handling aliases" color="primary" %}}
+{{% alert title="Handling aliases" %}}
 If you are using [aliases](https://gohugo.io/content-management/urls/#aliases) for URL management, you should have a look at this [blog post](https://blog.cavelab.dev/2021/10/hugo-aliases-to-s3-redirects/). It explains how to turn aliases into proper `301` redirects when using Amazon S3.
 {{% /alert %}}
 

--- a/userguide/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/userguide/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -48,7 +48,7 @@ As the Docsy example site repo is a [template repository](https://github.blog/20
 
 1. Go to the repo of the [Docsy example site](https://github.com/google/docsy-example).
 
-1. Use the dropdown for switching branches/tags to change to the latest released tag `v{{% param "version" %}}`. 
+1. Use the dropdown for switching branches/tags to change to the latest released tag `v{{% param "version" %}}`.
 
 1. Click the button **Use this template** and select the option `Create a new repository` from the dropdown.
 
@@ -62,7 +62,7 @@ As the Docsy example site repo is a [template repository](https://github.blog/20
     git clone https://github.com/me-at-github/my-new-site.git
     ```
 
-{{% alert title="Note" color="primary" %}}
+{{% alert title="Note" %}}
 Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227) inside your `hugo.toml` slightly, for example by adding a proxy to use when downloading remote modules.
 You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 {{% /alert %}}


### PR DESCRIPTION
- Cleanup in prep for #941
- Drops `color="primary"` since that's the default for the alert shortcode.

No changes to generated site files:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I "dateModified|modified_time|data-proofer" -- ':(exclude)*.xml')
$ (cd public && git diff) | grep ^diff | wc -l                                             
       8
```