### PR TITLE
Refine scrollspy style and behavior

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -6,11 +6,12 @@
     "Docsy",
     "errorf",
     "hugo",
+    "relref",
+    "scrollspy",
     "shortcode",
     "shortcodes",
     "tabpane",
     "upvote",
-    "warnf",
-    "relref"
+    "warnf"
   ]
 }

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -63,7 +63,7 @@
       &.active {
         color: var(--bs-primary);
         border-left-color: var(--bs-primary);
-        font-weight: $font-weight-medium;
+        background-color: var(--bs-secondary-bg-subtle);
       }
 
       &:focus,

--- a/layouts/_partials/td/scroll-spy-attr.txt
+++ b/layouts/_partials/td/scroll-spy-attr.txt
@@ -1,4 +1,0 @@
-data-bs-spy="scroll" {{/**/ -}}
-data-bs-target="#TableOfContents" {{/**/ -}}
-data-bs-smooth-scroll="true" {{/**/ -}}
-data-bs-root-margin="0px 0px -40%" {{/**/ -}}

--- a/layouts/_partials/td/scrollspy-attr.txt
+++ b/layouts/_partials/td/scrollspy-attr.txt
@@ -1,0 +1,9 @@
+{{ if not (.Param "ui.scrollspy.disable") -}}
+  {{ replaceRE `\s+` " "
+  `
+  data-bs-spy="scroll"
+  data-bs-target="#TableOfContents"
+  data-bs-smooth-scroll="true"
+  data-bs-root-margin="0px 0px -40%"
+  `
+ | strings.TrimSpace | add " " }} {{ end -}}

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -11,7 +11,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
-      <div class="td-main" {{ partialCached "td/scroll-spy-attr.txt" . | safeHTMLAttr }}>
+      <div class="td-main" {{- partialCached "td/scrollspy-attr.txt" . .Section | safeHTMLAttr }}>
         <div class="row flex-xl-nowrap">
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -11,7 +11,7 @@
       {{ partial "navbar.html" . }}
     </header>
     <div class="container-fluid td-outer">
-      <div class="td-main" {{ partialCached "td/scroll-spy-attr.txt" . | safeHTMLAttr }}>
+      <div class="td-main" {{- partialCached "td/scrollspy-attr.txt" . .Section | safeHTMLAttr }}>
         <div class="row flex-xl-nowrap">
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}

--- a/userguide/content/en/blog/_index.md
+++ b/userguide/content/en/blog/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Blog
-menu: {main: {weight: 50}}
+menu: { main: { weight: 50 } }
 ---


### PR DESCRIPTION
- Contributes to #2289
- Adjusts style of active TOC entry to use bg instead of bold
- Drops ScrollSpy's smooth scrolling since prevents the browser URL from being updated.
- Changes the partial cache scope of the ScrollSpy attributes to be `.Seciton`

**Preview**: https://deploy-preview-2290--docsydocs.netlify.app/docs/language/