### PR TITLE
Refine TOC title styles and add top-of-page link

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -30,7 +30,7 @@
 
   margin-top: 1rem;
 
-  a {
+  nav a {
     display: block;
     font-weight: $font-weight-light;
     padding-bottom: 0.25rem;
@@ -41,12 +41,40 @@
     display: block;
   }
 
-  > .toc-title {
-    font-weight: $font-weight-bold;
+  &__title {
     color: var(--bs-secondary-color);
     border-bottom: 1px solid var(--bs-tertiary-color);
-    padding-bottom: 0.5rem;
-    margin-bottom: 0.5rem;
+    padding-bottom: 0.25rem;
+    margin-bottom: 0.75rem;
+
+    &__text {
+      font-weight: $font-weight-bold;
+    }
+
+    &:hover>&__link,
+    &:focus>&__link {
+      visibility: visible !important;
+    }
+
+    &__link {
+      font-weight: $font-weight-bold;
+      padding-left: 0.25em;
+      text-decoration: none;
+      // Projects who wish to hide the link can set:
+      // visibility: hidden;
+
+      &::after {
+        content: fa-content($fa-var-chevron-up);
+        font-family: $td-font-awesome-font-name;
+      }
+
+      // Always visible on touch devices and small screens
+      @media (hover: none) and (pointer: coarse),
+      (max-width: map-get($grid-breakpoints, sm)) {
+        opacity: 1;
+        visibility: visible;
+      }
+    }
   }
 
   #TableOfContents {
@@ -75,12 +103,15 @@
     ul ul a {
       padding-left: $toc-padding-base + $toc-padding-increment;
     }
+
     ul ul ul a {
       padding-left: $toc-padding-base + ($toc-padding-increment * 2);
     }
+
     ul ul ul ul a {
       padding-left: $toc-padding-base + ($toc-padding-increment * 3);
     }
+
     ul ul ul ul ul a {
       padding-left: $toc-padding-base + ($toc-padding-increment * 4);
     }

--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -51,8 +51,8 @@
       font-weight: $font-weight-bold;
     }
 
-    &:hover>&__link,
-    &:focus>&__link {
+    @at-root .td-toc:hover &__link,
+      .td-toc:focus &__link {
       visibility: visible !important;
     }
 
@@ -61,7 +61,7 @@
       padding-left: 0.25em;
       text-decoration: none;
       // Projects who wish to hide the link can set:
-      // visibility: hidden;
+      visibility: hidden;
 
       &::after {
         content: fa-content($fa-var-chevron-up);
@@ -70,7 +70,7 @@
 
       // Always visible on touch devices and small screens
       @media (hover: none) and (pointer: coarse),
-      (max-width: map-get($grid-breakpoints, sm)) {
+        (max-width: map-get($grid-breakpoints, sm)) {
         opacity: 1;
         visibility: visible;
       }
@@ -84,8 +84,7 @@
       margin-left: 0;
       padding-left: $toc-padding-base;
       text-decoration: none;
-      border-left: .125rem solid transparent;
-      transition: color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+      border-left: 0.125rem solid transparent;
       color: var(--bs-secondary-color);
 
       &.active {

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -2,7 +2,10 @@
   {{ with .TableOfContents -}}
     {{ if ne . `<nav id="TableOfContents"></nav>` -}}
       <div class="td-toc">
-        <div class="toc-title">On this page</div>
+        <div class="td-toc__title">
+          <span class="td-toc__title__text">On this page</span>
+          <a class="td-toc__title__link" title="Scroll to top" href="#"></a>
+        </div>
         {{ . }}
       </div>
     {{ end -}}

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -4,7 +4,7 @@
       <div class="td-toc">
         <div class="td-toc__title">
           <span class="td-toc__title__text">On this page</span>
-          <a class="td-toc__title__link" title="Scroll to top" href="#"></a>
+          <a class="td-toc__title__link" title="Top of page" href="#"></a>
         </div>
         {{ . }}
       </div>

--- a/userguide/content/en/docs/adding-content/lookandfeel.md
+++ b/userguide/content/en/docs/adding-content/lookandfeel.md
@@ -270,7 +270,7 @@ project's configuration file.
 
 If you are using a Docsy 0.6.0 or later, code blocks show a "Copy to clipboard"
 button in the top right-hand corner. To disable this functionality, set
-`disable_click2copy_chroma` to `true` in your configuration file:
+`disable_click2copy_chroma` to `true` in your configuration file.
 
 ## Code highlighting with Prism
 


### PR DESCRIPTION
- Contributes to #2289
- Adds a `td-toc__title_link` as a chevron
  - Is currently visible by default, but projects can hide it until hovered over, or on mobile/touch devices
- Defines `td-toc__title_text` for the title text

**Preview**: https://deploy-preview-2292--docsydocs.netlify.app/docs/language/#selecting-a-language