### PR TITLE
Hamburger style tweaks to make focused state look better

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -140,10 +140,10 @@
     }
 
     // Ensure hamburger stays the same size in both toggle states
-    width: 1rem;
-    flex-shrink: 0;
-    margin: 0;
-    padding: 0 1.2rem;
+    width: 1.25rem;
+    margin-left: 1rem;
+    margin-right: 0.5rem;
+    padding: 2px;
 
     &[aria-expanded='true']::before {
       // We'd want to use xmark-large here, but it isn't free. Instead, we'll


### PR DESCRIPTION
- Followup to #2301 
- Contributes to #2300 
- Fixes styles so that hamburger button outline when in focus:
  > <img width="444" height="357" alt="image" src="https://github.com/user-attachments/assets/8263d8fa-609f-4a15-b060-6c7ddcf15742" />
