### PR TITLE
Always show lang menu in navbar

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -46,7 +46,7 @@
   }
 
   .navbar-nav {
-    padding-top: $spacer * 0.5;
+    // padding-top: $spacer * 0.5;
     white-space: nowrap;
   }
 
@@ -69,10 +69,6 @@
     .nav-item {
       padding-inline-end: $spacer * 0.5;
     }
-
-    .navbar-nav {
-      padding-top: 0 !important;
-    }
   }
 
   @include media-breakpoint-down(lg) {
@@ -88,12 +84,17 @@
     }
 
     .navbar-nav {
-      padding-bottom: 2rem;
+      // padding-bottom: 2rem;
       overflow-x: auto;
     }
   }
 
   .td-light-dark-menu {
+    position: unset !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     .bi {
       // Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/_default/examples.html
       width: 1em;
@@ -101,12 +102,48 @@
       vertical-align: -.125em;
       fill: currentcolor;
     }
+  }
 
-    &.dropdown {
+  .td-lang-menu {
+    position: unset !important;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &__title {
+      padding-left: 0;
+      padding-right: 0;
+
+      &::before {
+        font: var(--fa-font-solid);
+        content: fa-content($fa-var-globe);
+        padding-right: 0.5rem;
+      }
+
       @include media-breakpoint-down(lg) {
-        position: unset;
+        &-text {
+          display: none;
+        }
+        &::before {
+          padding-right: 0;
+        }
       }
     }
+
+    .dropdown-item {
+      position: relative;
+      padding-left: 2.5rem;
+
+      &.active::before {
+        font: var(--fa-font-solid);
+        content: fa-content($fa-var-check);
+        position: absolute;
+        left: 0.75rem;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+    }
+
   }
 }
 

--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -120,9 +120,16 @@
         padding-right: 0.5rem;
       }
 
+      &-code {
+        display: none;
+      }
+
       @include media-breakpoint-down(lg) {
         &-text {
           display: none;
+        }
+        &-code {
+          display: inline;
         }
         &::before {
           padding-right: 0;

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -6,7 +6,7 @@
 {{ end -}}
 
 {{ $outputFormat := partial "outputformat.html" . -}}
-{{ if and hugo.IsProduction (ne $outputFormat "print") -}}
+{{ if and hugo.IsProduction (ne $outputFormat "print") (ne .Site.Language.Lang "xx") -}}
 <meta name="robots" content="index, follow">
 {{ else -}}
 <meta name="robots" content="noindex, nofollow">

--- a/layouts/_partials/navbar-lang-selector.html
+++ b/layouts/_partials/navbar-lang-selector.html
@@ -4,6 +4,7 @@
   <a class="nav-link dropdown-toggle td-lang-menu__title" href="#" role="button"
     data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <span class="td-lang-menu__title-text">{{ $langPage.Language.LanguageName }}</span>
+    <span class="td-lang-menu__title-code">{{ $langPage.Language.Lang | upper }}</span>
   </a>
 
   {{ $allPages := slice . }}

--- a/layouts/_partials/navbar-lang-selector.html
+++ b/layouts/_partials/navbar-lang-selector.html
@@ -1,12 +1,33 @@
 {{/* Link directly to documentation etc., if possible. */ -}}
 {{ $langPage := cond (gt (len .Translations) 0) . .Site.Home -}}
-<div class="dropdown">
-  <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{- $langPage.Language.LanguageName -}}
+<div class="td-lang-menu dropdown">
+  <a class="nav-link dropdown-toggle td-lang-menu__title" href="#" role="button"
+    data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <span class="td-lang-menu__title-text">{{ $langPage.Language.LanguageName }}</span>
   </a>
+
+  {{ $allPages := slice . }}
+  {{ if .Translations }}
+    {{ $allPages = $allPages | append .Translations }}
+  {{ end }}
+
   <ul class="dropdown-menu">
-    {{ range $langPage.Translations -}}
-    <li><a class="dropdown-item" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a></li>
-    {{ end -}}
-  </ul>
+    {{ range $.Site.Languages }}
+      {{ $translatedPages := where $allPages "Language.Lang" .Lang -}}
+      {{ $translated := "" -}}
+      {{ if gt (len $translatedPages) 0 -}}
+        {{ $translated = index $translatedPages 0 -}}
+      {{- end -}}
+      {{ $isActive := eq $.Site.Language.Lang .Lang -}}
+      <li>
+        {{ if $isActive }}
+          <span class="dropdown-item active">{{ .LanguageName }}</span>
+        {{ else if $translated }}
+          <a class="dropdown-item" href="{{ $translated.RelPermalink }}">{{ .LanguageName }}</a>
+        {{ else }}
+          <span class="dropdown-item disabled">{{ .LanguageName }}</span>
+        {{ end }}
+      </li>
+      {{ end }}
+    </ul>
 </div>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -53,12 +53,12 @@
       </li>
       {{ end -}}
       {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item dropdown d-none d-lg-block">
+      <li class="nav-item">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}
       {{ if .Site.Params.ui.showLightDarkModeMenu -}}
-      <li class="td-light-dark-menu nav-item dropdown">
+      <li class="nav-item">
         {{ partial "theme-toggler" . }}
       </li>
       {{ end -}}

--- a/layouts/_partials/theme-toggler.html
+++ b/layouts/_partials/theme-toggler.html
@@ -1,4 +1,6 @@
-{{/* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/icons.html */ -}}
+<div class="td-light-dark-menu dropdown">
+
+{{- /* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/icons.html */ -}}
 
 <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
   <symbol id="check2" viewBox="0 0 16 16">
@@ -16,25 +18,21 @@
   </symbol>
 </svg>
 
-{{/* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/theme-toggler.html */ -}}
+{{- /* Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/partials/theme-toggler.html */ -}}
 
 {{ $isExamples := eq .Layout "examples" -}}
-<button class="btn
-              {{- if $isExamples }} btn-bd-primary
-              {{- else }} btn-link nav-link
-              {{- end }} dropdown-toggle d-flex align-items-center"
+<button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
         id="bd-theme"
         type="button"
         aria-expanded="false"
         data-bs-toggle="dropdown"
-        {{ if not $isExamples }}data-bs-display="static"{{ end }}
         aria-label="Toggle theme (auto)">
   <svg class="bi my-1 theme-icon-active"><use href="#circle-half"></use></svg>
   {{- /* Disable menu name for Docsy:
     <span class="{{ if $isExamples }}visually-hidden{{ else }}d-lg-none ms-2{{ end }}" id="bd-theme-text">Toggle theme</span>
   */}}
 </button>
-<ul class="dropdown-menu dropdown-menu-end{{ if $isExamples }} shadow{{ end }}" aria-labelledby="bd-theme-text">
+<ul class="dropdown-menu" aria-labelledby="bd-theme">
   <li>
     <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light" aria-pressed="false">
       <svg class="bi me-2 opacity-50"><use href="#sun-fill"></use></svg>
@@ -57,3 +55,5 @@
     </button>
   </li>
 </ul>
+</div>
+{{/* */ -}}

--- a/userguide/hugo.yaml
+++ b/userguide/hugo.yaml
@@ -31,6 +31,11 @@ languages:
     languageName: English
     params:
       description: Docsy does docs
+  # Placeholder language used to demo multilingual support
+  xx:
+    languageName: Placeholder
+    params:
+      description: Docsy does multilingual docs
 
 markup:
   tableOfContents:
@@ -147,5 +152,9 @@ module:
       target: content/project/changelog.md
     - source: ../CONTRIBUTING.md
       target: content/project/contributing.md
+    # Placeholder language used to demo multilingual support
+    - source: content/en
+      target: content
+      lang: xx
 
 # cSpell:ignore docsy github goldmark markmap plantuml readingtime userguide


### PR DESCRIPTION
- Fixes #2035: the language menu will always be shown in the navbar for multilingual sites.
- Fixes #2132: added the globe icon as suggested.
  - On mobile, uses language code as menu title
- Adds a placeholder language so that multilingual features can be demonstrated. Ensure that those pages are marked as noindex.
- Fixes placement issues with light-dark dropdown
- Removes overflow-hidden for the navbar on mobile. That'll not look super pretty, but it'll make obvious a feature that most users don't know exist: that the navbar can scroll! Feedback is welcome. 

**Preview**: TBC

### Screenshots

TBC

/cc @vitorvasc @theletterf @svrnm @tiffany76 - PTAL