### PR TITLE
Add description for comment shortcode

### DIFF
--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -442,6 +442,16 @@ says "Couldn’t find the X-Frame-Options header in the response headers." you
 found in the HTTP response headers as highlighted below.", you **CANNOT** -
 unless it has been explicitly enabled for your site. {{% /alert %}}
 
+### comment
+
+Use the comment shortcode to add internal notes that won't be shown in the rendered page.
+
+```go-template
+{{< comment >}}
+This comment will not be visible in the rendered page.
+{{< /comment >}}
+```
+
 ## Tabbed panes
 
 Sometimes it's very useful to have tabbed panes when authoring content. One

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -444,7 +444,7 @@ unless it has been explicitly enabled for your site. {{% /alert %}}
 
 ### comment
 
-Use the comment shortcode to add internal notes that won't be shown in the rendered page.
+Use the `comment` shortcode to add internal notes or comment out large blocks of Markdown or HTML that won't be rendered on the page.
 
 ```go-template
 {{< comment >}}


### PR DESCRIPTION
In https://github.com/google/docsy/commit/9f928afd2a7e8d62bdc178d415ad3320d7cc1f19 a comment shortcode was added. However, the documentation for that was still missing.