### PR TITLE
Add general dropdowns to main menu

### DIFF
--- a/layouts/_partials/navbar-general-selector.html
+++ b/layouts/_partials/navbar-general-selector.html
@@ -1,0 +1,13 @@
+<a class="nav-link {{- if .active }} active {{- end }} dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  {{ .menuItem.Name }}
+</a>
+<ul class="dropdown-menu">
+  {{ $page := .page -}}
+  {{ range .menuItem.Children -}}
+  {{ $isActive := or ($page.IsMenuCurrent "main" .) ($page.HasMenuCurrent "main" .) -}}
+  {{ with .Page -}}
+    {{ $isActive = or $isActive ( $page.IsDescendant .) -}}
+  {{ end -}}
+  <li><a class="dropdown-item {{- if $isActive }} active {{- end }}" href="{{ .URL }}">{{ .Name }}</a></li>
+  {{ end -}}
+</ul>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -41,7 +41,11 @@
         </a>
         <ul class="dropdown-menu">
           {{ range .Children -}}
-          <li><a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a></li>
+          {{ $isActive := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+          {{ with .Page -}}
+            {{ $isActive = or $isActive ( $.IsDescendant .) -}}
+          {{ end -}}
+          <li><a class="dropdown-item {{- if $isActive }} active {{- end }}" href="{{ .URL }}">{{ .Name }}</a></li>
           {{ end -}}
         </ul>
       </li>

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -26,15 +26,27 @@
     <ul class="navbar-nav">
       {{ $p := . -}}
       {{ range .Site.Menus.main -}}
+      {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
+      {{ $href := "" -}}
+      {{ with .Page -}}
+        {{ $active = or $active ( $.IsDescendant .) -}}
+        {{ $href = .RelPermalink -}}
+      {{ else -}}
+        {{ $href = .URL | relLangURL -}}
+      {{ end -}}
+      {{ if .HasChildren -}}
       <li class="nav-item">
-        {{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
-        {{ $href := "" -}}
-        {{ with .Page -}}
-          {{ $active = or $active ( $.IsDescendant .) -}}
-          {{ $href = .RelPermalink -}}
-        {{ else -}}
-          {{ $href = .URL | relLangURL -}}
-        {{ end -}}
+        <a class="nav-link {{- if $active }} active {{- end }} dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          {{ .Name }}
+        </a>
+        <ul class="dropdown-menu">
+          {{ range .Children -}}
+          <li><a class="dropdown-item" href="{{ .URL }}">{{ .Name }}</a></li>
+          {{ end -}}
+        </ul>
+      </li>
+      {{ else -}}
+      <li class="nav-item">
         {{ $isExternal := ne $baseURL.Host (urls.Parse .URL).Host -}}
         <a {{/**/ -}}
           class="nav-link {{- if $active }} active {{- end }}" {{/**/ -}}
@@ -46,6 +58,7 @@
             {{- .Post -}}
         </a>
       </li>
+      {{ end -}}
       {{ end -}}
       {{ if .Site.Params.versions -}}
       <li class="nav-item dropdown d-none d-lg-block">

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -36,18 +36,7 @@
       {{ end -}}
       {{ if .HasChildren -}}
       <li class="nav-item">
-        <a class="nav-link {{- if $active }} active {{- end }} dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          {{ .Name }}
-        </a>
-        <ul class="dropdown-menu">
-          {{ range .Children -}}
-          {{ $isActive := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) -}}
-          {{ with .Page -}}
-            {{ $isActive = or $isActive ( $.IsDescendant .) -}}
-          {{ end -}}
-          <li><a class="dropdown-item {{- if $isActive }} active {{- end }}" href="{{ .URL }}">{{ .Name }}</a></li>
-          {{ end -}}
-        </ul>
+        {{ partial "navbar-general-selector.html" (dict "menuItem" . "active" $active "page" $p) -}}
       </li>
       {{ else -}}
       <li class="nav-item">

--- a/userguide/content/en/docs/adding-content/navigation.md
+++ b/userguide/content/en/docs/adding-content/navigation.md
@@ -66,6 +66,52 @@ The menu is ordered from left to right by page `weight`. So, for example, a
 section index or page with `weight: 30` would appear after the Documentation
 section in the menu, while one with `weight: 10` would appear before it.
 
+To group menu items in a dropdown, add a `parent` parameter to the page front
+matter. All menu items with the same `parent` value will be grouped together
+under a dropdown menu. For example, here's how to add a page to a
+"Community" dropdown:
+
+<!-- prettier-ignore-start -->
+{{< tabpane >}}
+{{< tab header="Front matter:" disabled=true />}}
+{{< tab header="toml" lang="toml" >}}
++++
+title = "Contributing to the Project"
+linkTitle = "Contributing"
+description = "How to contribute to our documentation project."
+
+[menu.main]
+parent = "Community"
+weight = 10
++++
+{{< /tab >}}
+{{< tab header="yaml" lang="yaml" >}}
+---
+title: "Contributing to the Project"
+linkTitle: "Contributing"
+description: "How to contribute to our documentation project."
+menu:
+  main:
+    parent: "Community"
+    weight: 10
+---
+{{< /tab >}}
+{{< tab header="json" lang="json" >}}
+{
+  "title": "Contributing to the Project",
+  "linkTitle": "Contributing",
+  "description": "How to contribute to our documentation project.",
+  "menu": {
+    "main": {
+      "parent": "Community",
+      "weight": 10
+    }
+  }
+}
+{{< /tab >}}
+{{< /tabpane >}}
+<!-- prettier-ignore-end -->
+
 If you want to add a link to an external site to this menu, add it in
 `hugo.toml`/`hugo.yaml`/`hugo.json`, specifying the `weight`.
 


### PR DESCRIPTION
* Fixes #311 and #1673: a dropdown menu item can be added.
* Adds general dropdown menu items to the top-level menu.
  * Active submenu items are highlighted when they are open or when a subordinate page is open.
* Adds documentation for the new dropdown menu items.

## Screenshots

### Mobile / narrow

| Closed | Open |
|:---:|:---:|
| <img width="515" height="241" alt="image" src="https://github.com/user-attachments/assets/02a7333d-ccf1-4743-9f33-80eef2edd3f2" /> | <img width="485" height="224" alt="image" src="https://github.com/user-attachments/assets/e17b7f02-30aa-4a55-a795-4269ec3972f7" /> |

### Tablet

<img width="1246" height="217" alt="image" src="https://github.com/user-attachments/assets/d74fcdc3-7cd5-4449-9701-d144882eb719" />

### Desktop

<img width="1594" height="341" alt="image" src="https://github.com/user-attachments/assets/930980d2-185d-43ec-bcd2-904d9c4dac88" />
