### PR TITLE
Link check print pages too

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "_build": "npm run cd:docs -- _build",
     "_cd:docs": "cd userguide &&",
     "_check:format": "npx prettier --check *.md",
+    "_check:links": "npm run cd:docs -- _check:links",
     "_commit:public": "npm run cd:docs -- _commit:public",
     "_cp:bs-rfs": "npx cpy 'node_modules/bootstrap/scss/vendor/*' assets/_vendor/bootstrap/scss/",
     "_diff:check": "git diff --name-only --exit-code",

--- a/userguide/.htmltest.yml
+++ b/userguide/.htmltest.yml
@@ -6,7 +6,6 @@ IgnoreAltMissing: true # FIXME
 IgnoreDirectoryMissingTrailingSlash: true # FIXME
 TestFilesConcurrently: true
 IgnoreDirs:
-  - _print
   - ^blog/(\d+/)?page/\d+
   - ^xx # Placeholder language
 IgnoreEmptyHref: true # FIXME
@@ -24,5 +23,5 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Too flaky or unnecessary
   - ^https://badges.netlify.com/api
   - ^https://code.jquery.com
-  # TEMPORARY until the page lands in production:
-  - https://github.com/google/docsy/tree/main/userguide/content/en/tests/index.md
+  # TEMPORARY: remove after fix to https://github.com/google/docsy/issues/2323
+  - ^flags/de.png$

--- a/userguide/static/refcache.json
+++ b/userguide/static/refcache.json
@@ -1452,8 +1452,8 @@
     "LastSeen": "2025-05-16T08:36:58.469879-04:00"
   },
   "https://github.com/google/docsy/tree/main/userguide/content/en/tests/index.md": {
-    "StatusCode": 404,
-    "LastSeen": "2025-06-12T14:21:50.223573-04:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-10-05T04:30:39.242016-04:00"
   },
   "https://github.com/googleforgames/agones/tree/main/site": {
     "StatusCode": 206,
@@ -2330,10 +2330,6 @@
   "https://www.docsy.dev/docs/adding-content/feedback/#user-feedback": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:06:01.765051-05:00"
-  },
-  "https://www.docsy.dev/docs/adding-content/language/#adding-a-language-menu": {
-    "StatusCode": 404,
-    "LastSeen": "2025-08-02T17:12:43.30695-04:00"
   },
   "https://www.docsy.dev/docs/adding-content/lookandfeel/#before-page-content": {
     "StatusCode": 206,


### PR DESCRIPTION
- Contributes to #2319
- Drops `_print` directory ignore rule, which I'd forgotten to do as a part of #2320, so that links in print-version of pages are checked too
  - Helped detect a 404 in docs print pages - #2323
- Prunes 404 entries from the refcache