### PR TITLE
[UG] Fix link to flag img in shortcode section

### DIFF
--- a/userguide/.htmltest.yml
+++ b/userguide/.htmltest.yml
@@ -7,14 +7,14 @@ IgnoreDirectoryMissingTrailingSlash: true # FIXME
 TestFilesConcurrently: true
 IgnoreDirs:
   - ^blog/(\d+/)?page/\d+
-  - ^xx # Placeholder language
+  - ^xx # Placeholder language pages
 IgnoreEmptyHref: true # FIXME
 IgnoreInternalEmptyHash: true # FIXME
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
-  - ^(https://www.docsy.dev/)?xx/ # Placeholder language
+  - ^(https://www.docsy.dev/)?xx/ # Placeholder language pages
   - \?no-link-check
-  - (index.xml|_print/)$ # ignore <link rel=alternate ...>
+  - index.xml$ # ignore <link rel=alternate ...>
   - ^https?://[^/]+/(categories|tags)/ # ignore Docsy-generated content
   - ^https?://localhost\b
   # Ignore Docsy-generated GitHub links for now
@@ -23,5 +23,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Too flaky or unnecessary
   - ^https://badges.netlify.com/api
   - ^https://code.jquery.com
-  # TEMPORARY: remove after fix to https://github.com/google/docsy/issues/2323
-  - ^flags/de.png$

--- a/userguide/content/en/docs/adding-content/shortcodes/index.md
+++ b/userguide/content/en/docs/adding-content/shortcodes/index.md
@@ -10,7 +10,7 @@ resources:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
 params:
   message: Some _message_.
-cSpell:ignore: imgproc pageinfo Bjørn Pedersen
+cSpell:ignore: imgproc pageinfo Bjørn Pedersen swaggerui grayscale Picea
 ---
 
 Rather than writing all your site pages from scratch, Hugo lets you define and
@@ -452,6 +452,7 @@ famous `Hello world!` program one usually writes first when learning a new
 programming language:
 
 <!-- prettier-ignore-start -->
+<!-- cSpell:ignore cout println -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab "C" >}}
 #include <stdio.h>
@@ -517,16 +518,18 @@ easily create tabbed panes. To see how to use them, have a look at the following
 code block, which renders to a right aligned pane with one disabled and three
 active tabs:
 
+<!-- cSpell:ignore Herzlich willkommen Karibu sana -->
+
 ```go-html-template
 {{</* tabpane text=true right=true */>}}
   {{%/* tab header="**Languages**:" disabled=true /*/%}}
   {{%/* tab header="English" lang="en" */%}}
   ![Flag United Kingdom](flags/uk.png)
-  Welcome!
+  **Welcome!**
   {{%/* /tab */%}}
   {{</* tab header="German" lang="de" */>}}
+    <img src="/docs/adding-content/shortcodes/flags/de.png" alt="Flag Germany">
     <b>Herzlich willkommen!</b>
-    <img src="flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
   {{</* /tab */>}}
   {{%/* tab header="Swahili" lang="sw" */%}}
   ![Flag Tanzania](flags/tz.png)
@@ -546,8 +549,8 @@ This code translates to the right aligned tabbed pane below, showing a
   **Welcome!**
   {{% /tab %}}
   {{< tab header="German" lang="de" >}}
+    <img src="/docs/adding-content/shortcodes/flags/de.png" alt="Flag Germany">
     <b>Herzlich willkommen!</b>
-    <img src="flags/de.png" alt="Flag Germany" style="float: right; padding: 0 0 0 0px">
   {{< /tab >}}
   {{% tab header="Swahili" lang="sw" %}}
   ![Flag Tanzania](flags/tz.png)


### PR DESCRIPTION
- Fixes #2323
- Gives full path to (default locale) image of `flags/de.png`.
  > **NOTE**: I'm not sure that this is the best example of the use of an HTML `tab`, because Docsy users are better relying on the Markdown render-hook to get proper paths than to hard code them. But, I've chosen not to keep the example as close as possible to the original for now.
- Drops temporary htmltest ignore rule
- **Preview** https://deploy-preview-2324--docsydocs.netlify.app/_print/docs/adding-content/#pg-c37f349a2c654ed77db995c28626490d

After a bit of CSS tweaking in the inspector view, we can see that the image is accessible now (re-validating the successful link checking):

> <img width="692" height="341" alt="image" src="https://github.com/user-attachments/assets/390c8b80-a725-4d37-b618-2d18875f9a94" />
