### PR TITLE
Fix left-padding of language menu in a foldable sidebar

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -99,7 +99,7 @@
       // Adapted from: https://github.com/twbs/bootstrap/blob/main/site/layouts/_default/examples.html
       width: 1em;
       height: 1em;
-      vertical-align: -.125em;
+      vertical-align: -0.125em;
       fill: currentcolor;
     }
   }
@@ -150,7 +150,6 @@
         transform: translateY(-50%);
       }
     }
-
   }
 }
 
@@ -180,7 +179,7 @@
       -webkit-font-smoothing: antialiased;
       font-family: $td-font-awesome-font-name;
       font-weight: 900;
-      content: "\f0d9";
+      content: '\f0d9';
       padding-left: 0.5em;
       padding-right: 0.5em;
     }
@@ -205,7 +204,8 @@ nav.foldable-nav {
     margin: 0;
   }
 
-  .ul-1 > li {
+  .ul-1 > li,
+  .dropdown {
     padding-left: 1.5em;
   }
 
@@ -217,7 +217,7 @@ nav.foldable-nav {
     display: block;
   }
 
-  input[type="checkbox"] {
+  input[type='checkbox'] {
     display: none;
   }
 
@@ -235,7 +235,7 @@ nav.foldable-nav {
     -webkit-font-smoothing: antialiased;
     font-family: $td-font-awesome-font-name;
     font-weight: 900;
-    content: "\f0da";
+    content: '\f0da';
     position: absolute;
     left: 0.1em;
     padding-left: 0.4em;

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -83,6 +83,7 @@ params:
     showLightDarkModeMenu: true
     sidebar_lang_menu: true # Set to true to show the language menu in the sidebar
     sidebar_menu_compact: true
+    sidebar_menu_foldable: true
     sidebar_search_disable: false
     # sidebar_root_enabled: true
     feedback:

--- a/layouts/_partials/sidebar-tree.html
+++ b/layouts/_partials/sidebar-tree.html
@@ -42,7 +42,7 @@
       {{- if .Site.Params.ui.sidebar_root_enabled }} data-sidebar-root="{{ $sidebarRootID }}"{{ end -}}
     >
     {{ if and .Site.Params.ui.sidebar_lang_menu (gt (len .Site.Home.Translations) 0) -}}
-    <div class="td-sidebar-nav__section nav-item dropdown d-block d-lg-none">
+    <div class="td-sidebar-nav__section nav-item d-block d-lg-none">
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end -}}


### PR DESCRIPTION
- Fixes #2001 for foldable sidebars
- Followup to 2183
- The problem was that `.dropdown` was applied to two elements. We need it on only one.
- Ran Prettier over changed style file
- Enables the foldable config parameter for the UG sidenav so that we can see this fix.
- **Preview**: https://deploy-preview-2339--docsydocs.netlify.app/docs/ - you'll need a tablet-sized viewport to see the language menu in the sidenav

### Screenshot

> <img width="888" height="648" alt="image" src="https://github.com/user-attachments/assets/4cf61e6d-d459-4725-be78-6187cc4a4065" />

