### PR TITLE
Rewrite `sidebar_root:true` as `sidebar_root_for:children`

### DIFF
--- a/docsy.dev/content/en/docs/adding-content/_index.md
+++ b/docsy.dev/content/en/docs/adding-content/_index.md
@@ -2,5 +2,5 @@
 title: Content and Customization
 weight: 3
 description: How to add content to and customize your Docsy site.
-sidebar_root: true
+sidebar_root_for: children
 ---

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -85,7 +85,7 @@ params:
     sidebar_menu_compact: true
     sidebar_menu_foldable: true
     sidebar_search_disable: false
-    # sidebar_root_enabled: true
+    sidebar_root_enabled: true
     feedback:
       enable: true
       'yes': >-

--- a/layouts/_partials/sidebar-tree.html
+++ b/layouts/_partials/sidebar-tree.html
@@ -39,7 +39,7 @@
         {{- if .Site.Params.ui.sidebar_search_disable }} td-sidebar-nav--search-disabled{{ end -}}
         {{- if .Site.Params.ui.sidebar_menu_foldable }} foldable-nav{{ end }}" {{/**/ -}}
       id="td-section-nav"
-      {{- if .Site.Params.ui.sidebar_root_enabled }} data-sidebar-root="{{ $sidebarRootID }}"{{ end -}}
+      {{- if .Site.Params.ui.sidebar_root_enabled }} data-sidebar-root-id="{{ $sidebarRootID }}"{{ end -}}
     >
     {{ if and .Site.Params.ui.sidebar_lang_menu (gt (len .Site.Home.Translations) 0) -}}
     <div class="td-sidebar-nav__section nav-item d-block d-lg-none">
@@ -47,7 +47,6 @@
     </div>
     {{ end -}}
     {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
-    {{/* Use sidebar_root if provided, otherwise use the default navRoot */ -}}
     {{ if $sidebarRoot -}}
       {{ $navRoot = $sidebarRoot -}}
     {{ end -}}
@@ -163,7 +162,7 @@
       {{- end -}}
       <span class="
         {{- if $active }}td-sidebar-nav-active-item{{ end -}}
-        {{- if and $s.Params.sidebar_root .Site.Params.ui.sidebar_root_enabled }} td-sidebar-root-up-icon{{ end -}}
+        {{- if and $s.Params.sidebar_root_for site.Params.ui.sidebar_root_enabled }} td-sidebar-root-up-icon{{ end -}}
       ">
         {{- $s.LinkTitle -}}
       </span></a>

--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -8,13 +8,13 @@
 {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
 {{ if .Site.Params.ui.sidebar_root_enabled -}}
   {{ range .Ancestors.Reverse -}}
-    {{ if not (and .IsSection .Params.sidebar_root) -}}
+    {{ if not (and .IsSection (eq .Params.sidebar_root_for "children")) -}}
       {{ continue -}}
     {{ end -}}
     {{ $sidebarRoot = . -}}
-    {{/* Warn if sidebar_root is set on a top-level section */ -}}
+    {{/* Warn if sidebar_root_for is set on a top-level section */ -}}
     {{ if or (eq . $.Site.Home) (eq . $navRoot) -}}
-      {{ warnf "sidebar_root is set on a top-level section (%s). This parameter is intended for nested sections only." .Path -}}
+      {{ warnf "sidebar_root_for is set on a top-level section (%s). This parameter is intended for nested sections only." .Path -}}
     {{ end -}}
   {{ end -}}
 {{ end -}}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "_cd:docsy.dev": "cd docsy.dev &&",
     "_check:format": "npx prettier --check *.md tasks",
+    "_commit:public": "npm run _cd:docsy.dev -- npm run _commit:public",
     "_cp:bs-rfs": "npx cpy 'node_modules/bootstrap/scss/vendor/*' assets/_vendor/bootstrap/scss/",
     "_diff:check": "git diff --name-only --exit-code",
     "_gen-chroma-styles": "bash -c scripts/gen-chroma-styles.sh && bash -c 'scripts/gen-chroma-styles.sh -s onedark -o _dark.scss'",
@@ -22,10 +23,12 @@
     "ci:prepare": "npm run docsy.dev-install && npm run _prepare && npm run _diff:check",
     "docsy.dev-install": "npm run _cd:docsy.dev -- npm install",
     "fix:format": "npm run _check:format -- --write && npm run cd:docsy.dev fix:format",
+    "fix": "npm run fix:format",
     "get:hugo-modules": "node scripts/getHugoModules/index.mjs",
     "postinstall": "npm run _mkdir:hugo-mod",
     "test:all": "npm run ci:prepare && npm run check && npm run cd:docsy.dev test && npm run ci:post",
-    "test": "npm run check && npm run cd:docsy.dev test",
+    "test:only": "npm run cd:docsy.dev test",
+    "test": "echo 'RUNNING FIX AND TESTS...'; npm run fix && npm run test:only",
     "update:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
     "update:packages": "npx npm-check-updates -x @fortawesome/fontawesome-free -u && npm run cd:docsy.dev update:packages"
   },

--- a/tasks/sidebar-root-feature.plan.md
+++ b/tasks/sidebar-root-feature.plan.md
@@ -11,30 +11,28 @@ This is a feature description for issue [Sidenav support for section-as-root
 #2328][#2328], and some development notes. Being development notes, they might
 not fully capture the final implementation.
 
-Add a `sidebar_root` front matter parameter that can be set in a section's
+Add a `sidebar_root_for` front matter parameter that can be set in a section's
 `_index.md` to make that section the root of sidebar navigation, useful for
 deeply nested documentation sections.
 
 ## Feature characteristics
 
-- New `sidebar_root: true` parameter set in section `_index.md`. This marks the
-  section as a sidebar root.
-- When viewing pages **under** a sidebar root section (not the section index
-  page), show only that section and descendants in the sidebar. That is, the
-  sidebar becomes rooted in this designated sidebar root.
-- When viewing a sidebar-root section index page, the parent's sidebar tree is
-  shown.
+- New `sidebar_root_for` parameter set in section `_index.md`. Values:
+  `children` (current implementation) and `self` (planned).
+- When `sidebar_root_for: children`, descendant pages (but not the section
+  itself) show the rooted sidebar. When `sidebar_root_for: self`, both the
+  section and its descendants show the rooted sidebar.
 - Include navigation out of a sidebar-root section.
 - Work alongside existing `toc_root` feature (not replace it)
-- Warn if `sidebar_root` is set on a top-level section (including site home in
-  docs-only sites)
+- Warn if `sidebar_root_for` is set on a top-level section (including site home
+  in docs-only sites)
 
 ## Feature interaction: `toc_root`
 
-Since `sidebar_root` sections are always contained within a top-level section
-(whether `toc_root` or default), pages only need to determine their sidebar root
-within their already-established top-level boundary. No special interaction
-handling is required.
+Since `sidebar_root_for` sections are always contained within a top-level
+section (whether `toc_root` or default), pages only need to determine their
+sidebar root within their already-established top-level boundary. No special
+interaction handling is required.
 
 > NOTE: it might be possible to merge the two features, but that's a future
 > improvement.
@@ -43,9 +41,9 @@ handling is required.
 
 ### 1. Update `layouts/_partials/sidebar.html` - Find sidebar root and update cache key
 
-- Walk up page ancestors to find section with `sidebar_root: true`
+- Walk up page ancestors to find section with `sidebar_root_for: children`
 - Use sidebar_root section's permalink as cache key
-- Warn if `sidebar_root` is set on a top-level section
+- Warn if `sidebar_root_for` is set on a top-level section
 - Pass `sidebarRoot` to `sidebar-tree.html` as parameter
 
 ### 2. Add link back to sidebar-root section index page
@@ -56,15 +54,16 @@ section index page.
 
 **In `layouts/_partials/sidebar-tree.html`:**
 
-- When `sidebar_root` is active, add a link at the top of the sidebar navigation
+- When `sidebar_root_for` is active, add a link at the top of the sidebar
+  navigation
 - Link should point to the parent section of the sidebar_root
 - Use the `td-sidebar-root-up-icon` CSS class for the up-arrow icon
 - Style the link to be visually distinct from regular navigation items
 
 ### 3. Modify `layouts/_partials/sidebar-tree.html` - Add breadcrumb navigation (OPTIONAL)
 
-- When a `sidebar_root` is active (not the top-level section), add a breadcrumb
-  section
+- When a `sidebar_root_for` is active (not the top-level section), add a
+  breadcrumb section
 - Show "← Back to [Parent Section]" link(s) above the main navigation tree
 - Use appropriate styling to distinguish from regular navigation items
 
@@ -85,7 +84,7 @@ section index page.
 ## Testing Considerations
 
 - [ ]Test with deeply nested sections (3+ levels)
-- [ ] Verify caching works correctly with sidebar_root active
+- [ ] Verify caching works correctly with sidebar_root_for active
 - [ ] Ensure foldable menu behavior still works
 - [ ] Test with both `sidebar_menu_compact` enabled and disabled
 - [ ] Verify it doesn't conflict with existing `toc_root` functionality
@@ -99,7 +98,7 @@ Assume the following front matter in the User Guide:
 ---
 title: Content and Customization
 # ...
-sidebar_root: true
+sidebar_root_for: children
 ---
 ```
 
@@ -114,10 +113,11 @@ full docs navigation tree.
 
 ### To-dos
 
-- [x] Step 1: Implement sidebar_root lookup and cache key logic in sidebar.html
+- [x] Step 1: Implement sidebar_root_for lookup and cache key logic in
+      sidebar.html
 - [ ] Step 2: Add link back to site root section index page
 - [ ] Step 3: Add breadcrumb navigation UI (OPTIONAL/FUTURE)
-- [x] Step 4: Use sidebar_root for $navRoot calculation in sidebar-tree.html
+- [x] Step 4: Use sidebar_root_for for $navRoot calculation in sidebar-tree.html
 - [x] Step 5: Add CSS styling for up-arrow icon
 - [ ] Testing: Verify all navigation scenarios work correctly
 


### PR DESCRIPTION
- Contributes to #2328
- Refactoring: renames `sidebar_root` front-matter param to `sidebar_root_for` so that `sidebar_root: true` becomes `sidebar_root_for: children`
- Enables sidebar root for UG
- **Preview**: https://deploy-preview-2340--docsydocs.netlify.app/docs/adding-content/content/

### Screenshot

> <img width="888" height="667" alt="image" src="https://github.com/user-attachments/assets/13bef638-dfc9-440b-9062-a81f41f1015d" />
