### PR TITLE
Fix sidebar entry HTML attribute spacing

### DIFF
--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -37,7 +37,7 @@
     "cross-env": "^10.1.0",
     "hugo-extended": "0.151.0",
     "netlify-cli": "^23.9.1",
-    "npm-check-updates": "^19.0.0",
+    "npm-check-updates": "^19.1.1",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },

--- a/layouts/_partials/sidebar-tree.html
+++ b/layouts/_partials/sidebar-tree.html
@@ -137,7 +137,7 @@
           {{- if $s.IsPage }} td-sidebar-link__page
           {{- else }} td-sidebar-link__section
           {{- end }}
-          {{- if $treeRoot }} tree-root{{ end }}" {{- /**/ -}}
+          {{- if $treeRoot }} tree-root{{ end }}" {{/**/ -}}
         id="{{ $mid }}" {{- /**/ -}}
       >
         {{- with $s.Params.Icon -}}


### PR DESCRIPTION
- (Re-)adds space between `class` and `id` attributes in sidebar entry HTML
- (Housekeeping: upgrades npm-check-updates)