### PR TITLE
Upgrade Hugo to 0.151.2, and Prettify blog posts

### DIFF
--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -12,3 +12,4 @@
 !/content/en/docs/_index.md
 !/content/en/docs/adding-content
 !/static
+!/content/en/blog

--- a/docsy.dev/content/en/blog/2022/hello.md
+++ b/docsy.dev/content/en/blog/2022/hello.md
@@ -7,15 +7,25 @@ description: Welcome to the Docsy blog!
 
 ## Hello
 
-It may seem strange to see a "Hello" post from a project that's several years old, but as Docsy matures as a community-driven project, we thought it was time to (re)introduce ourselves and talk about what's new with your favorite (we hope) Hugo documentation theme!
+It may seem strange to see a "Hello" post from a project that's several years
+old, but as Docsy matures as a community-driven project, we thought it was time
+to (re)introduce ourselves and talk about what's new with your favorite (we
+hope) Hugo documentation theme!
 
 ### Discuss amongst yourselves
 
-Our [Discussions](https://github.com/google/docsy/discussions) are really hopping lately! Don't miss our notice of the [upcoming deprecation of the Font-Awesome and Bootstrap git submodules](https://github.com/google/docsy/discussions/950) or our announcement of our [new governance model](https://github.com/google/docsy/discussions/798)!
+Our [Discussions](https://github.com/google/docsy/discussions) are really
+hopping lately! Don't miss our notice of the
+[upcoming deprecation of the Font-Awesome and Bootstrap git submodules](https://github.com/google/docsy/discussions/950)
+or our announcement of our
+[new governance model](https://github.com/google/docsy/discussions/798)!
 
 ### Milestones, releases, and roadmaps
 
-We are planning our first official release of Docsy soon—check out the [milestones for 0.2.0](https://github.com/google/docsy/milestone/2). Got a suggestion for the roadmap? Open an [issue](https://github.com/google/docsy/issues).
+We are planning our first official release of Docsy soon—check out the
+[milestones for 0.2.0](https://github.com/google/docsy/milestone/2). Got a
+suggestion for the roadmap? Open an
+[issue](https://github.com/google/docsy/issues).
 
 ### Coming soon: project metrics
 
@@ -23,11 +33,15 @@ Starting next month, we'll publish project metrics here on this blog.
 
 ### Introducing the PSC
 
-Docsy now has a Project Steering Committee! The PSC members are [@chalin][], [@LisaFC][], [@geriom][], and [@emckean][]. If you're interested in serving on the PSC, open an [issue](https://github.com/google/docsy/issues) and nominate yourself!
+Docsy now has a Project Steering Committee! The PSC members are [@chalin][],
+[@LisaFC][], [@geriom][], and [@emckean][]. If you're interested in serving on
+the PSC, open an [issue](https://github.com/google/docsy/issues) and nominate
+yourself!
 
 ### Contribute to the blog!
 
-Also coming soon: contribution guidelines. Got an idea for a blog post? Open an [issue](https://github.com/google/docsy/issues)!
+Also coming soon: contribution guidelines. Got an idea for a blog post? Open an
+[issue](https://github.com/google/docsy/issues)!
 
 [@chalin]: https://github.com/chalin
 [@LisaFC]: https://github.com/LisaFC

--- a/docsy.dev/content/en/blog/2023/priorities-for-2024.md
+++ b/docsy.dev/content/en/blog/2023/priorities-for-2024.md
@@ -3,8 +3,7 @@ title: Docsy priorities for 2024
 linkTitle: 2024 Priorities
 author: >
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
-  for the [Docsy Steering
-  Committee](/blog/2022/hello/#introducing-the-psc)
+  for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 date: 2023-11-28
 # prettier-ignore
 cSpell:ignore: CNCF Chalin opentelemetry namespacing docsy customizability deprioritize
@@ -68,6 +67,7 @@ start the new year, we'll be especially interested in getting help with testing
 and feature consolidation.
 
 [^0]: According to [Docsy's GitHub analytics][docsy-analytics].
+
 [^1]:
     Features outside the identified core could even be moved to a separate
     community-maintained repo. The steering committee is also considering a

--- a/docsy.dev/content/en/blog/2024/year-in-review.md
+++ b/docsy.dev/content/en/blog/2024/year-in-review.md
@@ -105,8 +105,8 @@ GitHub analytics show a **57% increase in usage**, reaching **2.2K projects** as
 of this writing.
 
 Adoption among CNCF projects has also grown since our [2023 report]. This year,
-[Linux Foundation mentees][LFX] [Sandra Dindi] and [Dariksha Ansari] used the [CNCF Docsy starter] to migrate the
-following sites to Docsy:
+[Linux Foundation mentees][LFX] [Sandra Dindi] and [Dariksha Ansari] used the
+[CNCF Docsy starter] to migrate the following sites to Docsy:
 
 - **[The Update Framework](https://theupdateframework.io)**
   ([theupdateframework.io#105])
@@ -132,8 +132,10 @@ the [0.3.x upgrade] and [0.5.x upgrade].
   https://www.cncf.io/blog/2023/01/19/fast-and-effective-tools-for-cncf-and-open-source-project-websites/
 [in-toto.io#76]: https://github.com/in-toto/in-toto.io/issues/76
 [Kubernetes website]: https://github.com/kubernetes/website
-[Dariksha Ansari]: https://mentorship.lfx.linuxfoundation.org/project/34314eb1-0fc3-4802-ab04-2265418c2e48
-[Sandra Dindi]: https://mentorship.lfx.linuxfoundation.org/project/e35f28f9-f333-47a8-a76a-119567cf10ca
+[Dariksha Ansari]:
+  https://mentorship.lfx.linuxfoundation.org/project/34314eb1-0fc3-4802-ab04-2265418c2e48
+[Sandra Dindi]:
+  https://mentorship.lfx.linuxfoundation.org/project/e35f28f9-f333-47a8-a76a-119567cf10ca
 
 ## What's ahead?
 

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.151.0",
-    "netlify-cli": "^23.9.1",
+    "hugo-extended": "0.151.2",
+    "netlify-cli": "^23.9.5",
     "npm-check-updates": "^19.1.1",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"


### PR DESCRIPTION
- Upgrades Hugo to 0.151.2
- No longer has Prettier ignore blog posts. No content change in the posts.