### PR TITLE
[CI] Update Node LTS version, and Hugo to 0.152.2

### DIFF
--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -35,9 +35,9 @@
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.151.2",
+    "hugo-extended": "0.152.2",
     "netlify-cli": "^23.9.5",
-    "npm-check-updates": "^19.1.1",
+    "npm-check-updates": "^19.1.2",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "hugo_version": "0.151.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark -"
 }


### PR DESCRIPTION
- Updates Hugo to 0.152.2, now that issues have been resolved -- see #2345
- Updates min Node version to match active LTS
- No change to generated site file other than the Hugo version ID.