### PR TITLE
[UX] Prevent flash when in dark mode, part two

### DIFF
--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -2,7 +2,8 @@
 <html itemscope itemtype="http://schema.org/WebPage"
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
-    class="no-js">
+    class="no-js"
+    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/blog/baseof.print.html
+++ b/layouts/blog/baseof.print.html
@@ -2,7 +2,8 @@
 <html itemscope itemtype="http://schema.org/WebPage"
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
-    class="no-js">
+    class="no-js"
+    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -2,7 +2,8 @@
 <html itemscope itemtype="http://schema.org/WebPage"
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
-    class="no-js">
+    class="no-js"
+    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.print.html
+++ b/layouts/docs/baseof.print.html
@@ -2,7 +2,8 @@
 <html itemscope itemtype="http://schema.org/WebPage"
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
-    class="no-js">
+    class="no-js"
+    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -2,7 +2,8 @@
 <html itemscope itemtype="http://schema.org/WebPage"
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
-    class="no-js">
+    class="no-js"
+    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+38-g53cfee7",
+  "version": "0.13.0-dev+39-g0e2ad18",
   "version.next": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",


### PR DESCRIPTION
- Contributes to #2185
- Followup to #2343
- Adds the necessary data-init to all other `baseof` layouts