### PR TITLE
[blog] Adjust titles and slugs for consistency

### DIFF
--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -1,11 +1,12 @@
 ---
-title: Upgrading to Docsy 0.7 & Bootstrap 5
-linkTitle: Upgrading to Docsy 0.7
+title: Upgrade to Docsy 0.7 & Bootstrap 5
+linkTitle: Upgrade to Docsy 0.7
 description: A guide to upgrading to Docsy 0.7 and Bootstrap 5 with examples
 author: >
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/) &
   [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc))
 date: 2023-08-03
+aliases: [docsy-0.7]
 cSpell:ignore: CNCF Chalin opentelemetry namespacing docsy
 ---
 

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -1,6 +1,6 @@
 ---
-title: Upgrading to Docsy 0.12.0 from 0.11.0
-linkTitle: Upgrading to 0.12.0
+title: Upgrade to Docsy 0.12.0 from 0.11.0
+linkTitle: Upgrade to 0.12.0
 date: 2025-11-11
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+39-g0e2ad18",
+  "version": "0.13.0-dev+41-g3722bf7",
   "version.next": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",


### PR DESCRIPTION
- Following chat with @LisaFC, this adjusts the titles of upgrade blog posts to uniformly be "Upgrade to ...".
- Also adjusts the 0.7.x slug.

**Preview and redirect test**:

- https://deploy-preview-2356--docsydocs.netlify.app
- https://deploy-preview-2356--docsydocs.netlify.app/blog/2023/docsy-0.7