### PR TITLE
Sidebar-root feature & 0.13-wrapup planning and tasks, and more

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -10,6 +10,7 @@
     "hugo",
     "isset",
     "nvmrc",
+    "Occitan",
     "refcache",
     "relref",
     "scrollspy",
@@ -18,6 +19,7 @@
     "subfolders",
     "tabpane",
     "upvote",
-    "warnf"
+    "warnf",
+    "wrapup"
   ]
 }

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -279,6 +279,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:35.708092-04:00"
   },
+  "https://en.wikipedia.org/wiki/Flash_of_unstyled_content": {
+    "StatusCode": 200,
+    "LastSeen": "2025-11-12T12:00:13.422237-05:00"
+  },
   "https://en.wikipedia.org/wiki/Wordmark": {
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:44.997719-04:00"
@@ -955,9 +959,17 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:40.019418-04:00"
   },
+  "https://github.com/google/docsy/issues/2185": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T12:00:14.199051-05:00"
+  },
   "https://github.com/google/docsy/issues/2243": {
     "StatusCode": 206,
     "LastSeen": "2025-10-25T13:13:51.198559-04:00"
+  },
+  "https://github.com/google/docsy/issues/2266": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T12:00:13.555016-05:00"
   },
   "https://github.com/google/docsy/issues/331": {
     "StatusCode": 200,
@@ -2374,6 +2386,10 @@
   "https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options": {
     "StatusCode": 200,
     "LastSeen": "2025-10-06T12:11:12.345Z"
+  },
+  "https://www.docsy.dev/docs/adding-content/navigation/#sidebar-root": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T12:00:13.317204-05:00"
   },
   "https://www.docsy.dev/docs/adding-content/repository-links/": {
     "StatusCode": 206,

--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -1,4 +1,10 @@
-{{/* The "active" toggle here may delay rendering, so we only cache this side bar menu for bigger sites. */ -}}
+{{/* Notes:
+
+- Sidebars are generated for "blog", "docs", and possibly other page types.
+- The "active" toggle here may delay rendering, so we only cache this side
+  bar menu for bigger sites.
+
+*/ -}}
 
 {{ $sidebarCacheLimit := .Site.Params.ui.sidebar_cache_limit | default 2000 -}}
 {{ $cacheSidebar := ge (len .Site.Pages) $sidebarCacheLimit -}}
@@ -27,6 +33,7 @@
       {{ break -}}
     {{ end -}}
   {{ end -}}
+
   {{/* Warn if sidebar_root_for is set to self for a top-level section */ -}}
   {{ $rootKind := $sidebarRoot.Params.sidebar_root_for -}}
   {{ if and (eq $rootKind "self") (eq $sidebarRoot $navRoot) -}}
@@ -35,9 +42,14 @@
         "The `self` mode is intended for nested sections proper."
         "Did you mean to use `children` instead?"
     -}}
-    {{ warnf "%s: %s" $sidebarRoot.File.Path (delimit $msg " ") -}}
+    {{ $filename := .Path -}}
+    {{ with $sidebarRoot.File -}}
+      {{ $filename = .Filename -}}
+    {{ end -}}
+    {{ warnf "%s: %s for page '%s'." $sidebarRoot.File.Filename (delimit $msg " ") .Path -}}
   {{ end -}}
 {{ end -}}
+
 {{ $sidebarRootID := $sidebarRoot.RelPermalink -}}
 {{ $args := dict
     "context" .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+43-g84526b3",
+  "version": "0.13.0-dev+44-g595b25e",
   "version.next": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",

--- a/tasks/0.13/commit-inventory.md
+++ b/tasks/0.13/commit-inventory.md
@@ -1,0 +1,75 @@
+---
+title: 0.13 commit inventory
+date: 2025-11-12
+cSpell:ignore: docsy
+---
+
+> Report refreshed for commits through `595b25e` on `main`.
+
+Chronological list of [commits since v0.12.0][], broadly grouped into a few
+categories. We'll do a more detailed analysis and groupings when we create the
+release-wrapup report, in particular identifying commits that impact theme
+client projects.
+
+## Features & fixes
+
+- `627a0df` (`#2173`) Add Occitan locale
+- `a824b2a` (`#2278`) Trim whitespace for `card` shortcode
+- `433ddb6` (`#2282`) User guide cleanup of alert calls when color is default
+- `b3e4ccf` (`#941`) More Markdown-friendly alert shortcode
+- `aa0f617` (`#2285`) Accessibility color fixes; fall back to Bootstrap defaults
+- `4323d09` (`#2287`) Add Bootstrap ScrollSpy support for active TOC entry
+- `3a5cfea` (`#2290`) Refine ScrollSpy style and behavior
+- `55db259` (`#2291`) Drop smooth scrolling from ScrollSpy
+- `2cb3725` (`#2292`) Refine TOC title styles and add top-of-page link
+- `10f7dbe` (`#2301`) Show close icon while hamburger menu is open
+- `16335ca` (`#2302`) Hamburger style tweaks for focused state
+- `aa8a701` (`#2303`) Always display language menu in navbar
+- `1502423` (`#2318`) User guide: prevent caching of sidebar include
+- `26120fc` (`#2313`) Update Simplified Chinese translations
+- `7fbdc2f` (`#2322`) Include print pages in link checking
+- `4c5c15b` (`#2324`) Fix flag image link in user guide shortcode section
+- `82d492b` (`#2325`) User guide fixes to dropdown references
+- `b2e919e` (`#2331`) Update Ukrainian translations
+- `b23e453` (`#2334`) Support non top-level section pages as sidebar roots
+- `1b961c9` (`#2338`) Update changelog to mention NPM support fix
+- `d8f54d5` (`#2339`) Fix language menu left padding in foldable sidebar
+- `2e5ebc4` (`#2340`) Rewrite `sidebar_root:true` as `sidebar_root_for:children`
+- `cf3a3d7` (`#2341`) Add support for `self` sidebar roots
+- `f0c0575` (`#2342`) Fix sidebar entry HTML attribute spacing
+- `84526b3` (`#2361`) Avoid redundant sidebar-root warning for top-level
+  sections using `children`
+- `e1bdb4e` (`#2343`) Prevent flash when entering dark mode (initial)
+- `1b8ccc3` (`#2355`) Prevent flash when entering dark mode (follow-up)
+- `3722bf7` (`#2349`) Publish upgrade guide blog for Docsy 0.12.0 → 0.11.0
+- `95de91f` (`#2356`) Align upgrade blog slugs/titles for consistency
+
+## CI / tooling only
+
+- `818f62f` (`#2344`) CI script to add build ID to version string
+- `0e2ad18` (`#2351`) Release process documentation and helper scripts
+- `595b25e` (`#2362`) Rework `fix:version` script for pre-commit use
+
+> Note: `09ed8ba` includes formatting changes beyond dependency bumps; treat as
+> mixed when evaluating documentation and changelog needs.
+
+## Dependency / package configuration updates
+
+- `0f05574` (`#2269`) Set NPM package version to next unreleased dev version
+  0.12.1-dev
+- `db526c5` (`#2274`) Hugo and Netlify NPM packages: update & change to peer;
+  docs update included
+- `614e7ec` (`#2275`) Update `package.json`: use NPM version of Node
+- `f8f02e7` (`#2286`) Update `package.json`, Hugo to 0.147.8
+- `4296f5c` (`#2304`) Update Bootstrap to 5.3.7
+- `a301026` (`#2316`) Update Bootstrap to 5.3.8
+- `8103455` (`#2315`) Update dev and peer dependencies
+- `29bd311` (`#2320`) Upgrade dependencies including Hugo to 0.150.1
+- `d57e6a8` (`#2335`) Update Hugo to 0.151.0
+- `2139e32` (`#2337`) Reorganize NPM dependencies; rename site folder to
+  `docsy.dev`
+- `09ed8ba` (`#2348`) Upgrade Hugo to 0.151.2 and prettify blog posts (mixed:
+  dependency + content formatting)
+- `53cfee7` (`#2350`) Update Node LTS version, Hugo to 0.152.2
+
+[commits since v0.12.0]: https://github.com/google/docsy/compare/v0.12.0...main

--- a/tasks/0.13/issue-audit.md
+++ b/tasks/0.13/issue-audit.md
@@ -1,0 +1,153 @@
+---
+title: 0.13 issue resolution audit
+date: 2025-11-12
+cSpell:ignore: docsy lookandfeel userguide
+---
+
+> Report refreshed for commits through `595b25e` on `main`.
+
+Assessment of issues addressed by [commits since
+v0.12.0][commits since v0.12.0].
+
+## #941 – Markdown-friendly alert shortcode
+
+- **Commits**: `b3e4ccf`, `433ddb6`, `82d492b`
+- **Status**: Resolved; new shortcode implementation and follow-up doc polish
+  merged.
+- **User Guide**: Updated (`docsy.dev` and legacy `userguide` pages covering
+  alert usage and styling).
+- **Changelog**: Entry added under 0.12.1/0.13.0 breaking changes describing the
+  new shortcode.
+- **Client impact**: Yes — theme users should switch to the Markdown-friendly
+  syntax.
+- **Follow-up**: Ensure `docsy-example` adopts new shortcode syntax and drop
+  legacy guidance.
+
+## #2173 – Add Occitan locale
+
+- **Commits**: `627a0df`
+- **Status**: Resolved; new `i18n/oc.toml` locale added.
+- **User Guide**: Not required (translation addition only).
+- **Changelog**: No entry yet; optional to mention under “Other changes”.
+- **Client impact**: Low — only projects targeting Occitan need the new locale.
+- **Follow-up**: Spot-check locale in example site build.
+
+## #2285 – Accessibility color & typography defaults
+
+- **Commits**: `aa0f617`
+- **Status**: Resolved; color contrast improvements landed.
+- **User Guide**: Updated
+  (`userguide/content/en/docs/adding-content/lookandfeel.md`, tests page).
+- **Changelog**: No coverage yet — should be captured under accessibility
+  improvements.
+- **Client impact**: Yes — visual adjustments land automatically; projects may
+  want regression checks.
+- **Follow-up**: Add changelog highlight; rerun visual regression checks.
+
+## #349 / #2289 – TOC scrollspy & navigation indication
+
+- **Commits**: `4323d09`, `3a5cfea`, `55db259`, `2cb3725`
+- **Status**: Feature shipped; ScrollSpy + TOC polish in place.
+- **User Guide**: Minor updates to `lookandfeel.md`; consider expanding docs
+  with usage guidance.
+- **Changelog**: No explicit entry; add highlight for TOC/ScrollSpy
+  improvements.
+- **Client impact**: Yes — default TOC behavior changes; verify site-specific
+  overrides.
+- **Follow-up**: Verify smooth scrolling removal impact; document configuration
+  knobs if any.
+
+## #2035 / #2001 – Language menu visibility & styling
+
+- **Commits**: `aa8a701`, `d8f54d5`
+- **Status**: Resolved; navbar dropdown always visible, sidebar styling fixed.
+- **User Guide**: Updated navigation doc & `hugo.yaml`.
+- **Changelog**: Breaking-change entry added (language menu visibility).
+- **Client impact**: Yes — menu visibility changes across breakpoints; adjust
+  custom themes/screenshots.
+- **Follow-up**: Double-check narrow viewport screenshots; confirm sidebar
+  opt-in instructions are clear.
+
+## #2115 – NPM optional/peer dependency errors
+
+- **Commits**: `2139e32`, `1b961c9`
+- **Status**: Resolved; dependency graph restructured.
+- **User Guide**: Adjusted references to renamed `docsy.dev` sample and scripts.
+- **Changelog**: Covered under “Other changes”.
+- **Client impact**: Yes — npm consumers benefit from cleaner installs; note in
+  release guidance.
+- **Follow-up**: Update downstream tooling documentation (e.g., release process
+  or dev setup guides) if needed.
+
+## #2313 – Simplified Chinese translation refresh
+
+- **Commits**: `26120fc`
+- **Status**: Resolved; translations updated.
+- **User Guide**: Not required.
+- **Changelog**: Not recorded; optional note in release summary.
+- **Client impact**: Minimal — only zh-CN locales affected.
+- **Follow-up**: Confirm translation bundle builds cleanly.
+
+## #2331 – Ukrainian translation refresh
+
+- **Commits**: `b2e919e`
+- **Status**: Resolved; translations updated.
+- **User Guide**: Not required.
+- **Changelog**: Not recorded; optional note in release summary.
+- **Client impact**: Minimal — only uk locales affected.
+- **Follow-up**: Same verification as #2313.
+
+## #2328 – Sidebar root feature (`sidebar_root_for`)
+
+- **Commits**: `b23e453`, `2e5ebc4`, `cf3a3d7`, `f0c0575`, `84526b3`
+- **Status**: Core feature merged; both `children` and `self` variants
+  implemented, and warning UX refined for docs-only root sections.
+- **User Guide**: Minimal front matter tweaks only — lacks explanatory docs.
+- **Changelog**: Missing; should appear as a headline feature.
+- **Client impact**: Yes — new optional feature; document enablement steps and
+  new warning behavior.
+- **Follow-up**: Author dedicated documentation section (examples,
+  configuration) and add changelog entry.
+
+## Dark-mode FOUC fix (no issue ID referenced)
+
+- **Commits**: `e1bdb4e`, `1b8ccc3`
+- **Status**: Fix validated in code; no formal issue linked.
+- **User Guide**: Not applicable.
+- **Changelog**: Missing; consider short note under “Other changes”.
+- **Client impact**: Yes — improves UX for sites using dark mode.
+- **Follow-up**: Capture regression test to prevent future flashes.
+
+## #2266 – Release process enhancements
+
+- **Commits**: `0e2ad18`, `595b25e`
+- **Status**: Guidance updated (scripts, instructions) and `fix:version` tooling
+  now works in pre-commit hooks.
+- **User Guide**: Release docs updated within repo (not user-facing).
+- **Changelog**: Not needed.
+- **Client impact**: No direct impact; relevant mainly for maintainers.
+- **Follow-up**: Sync milestone tracker; ensure new scripts referenced in
+  release checklist and hook instructions.
+
+## #2349 – Blog: upgrading to Docsy 0.12.0 from 0.11.0
+
+- **Commits**: `3722bf7`
+- **Status**: Blog published; provides upgrade guidance for the previous
+  release.
+- **User Guide**: Links to existing docs; no additional guide updates required.
+- **Changelog**: Not applicable (blog-only change).
+- **Client impact**: Indirect — helpful resource for users on older releases.
+- **Follow-up**: Cross-link from the forthcoming 0.13 upgrade article; monitor
+  for user feedback.
+
+## #2356 – Upgrade blog title & slug consistency
+
+- **Commits**: `95de91f`
+- **Status**: Titles/slugs aligned across upgrade posts.
+- **User Guide**: N/A (metadata-only change).
+- **Changelog**: Not needed.
+- **Client impact**: No — navigation/title housekeeping only.
+- **Follow-up**: Ensure navigation and references use the updated slugs; adopt
+  the convention for future posts.
+
+[commits since v0.12.0]: https://github.com/google/docsy/compare/v0.12.0...main

--- a/tasks/0.13/issue-mapping.md
+++ b/tasks/0.13/issue-mapping.md
@@ -1,0 +1,60 @@
+---
+title: 0.13 issue mapping
+date: 2025-11-12
+cSpell:ignore: docsy sidemenu FOUC
+---
+
+> Report refreshed for commits through `595b25e` on `main`.
+
+Mapping [commits since v0.12.0][] to their originating issues (when known).
+
+## Dependency bundles (no linked issues)
+
+| Commits                                                                                                                 | PRs                                                                                               | Summary                                                         |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `0f05574`, `db526c5`, `614e7ec`, `f8f02e7`, `4296f5c`, `a301026`, `8103455`, `29bd311`, `d57e6a8`, `09ed8ba`, `53cfee7` | `#2269`, `#2274`, `#2275`, `#2286`, `#2304`, `#2316`, `#2315`, `#2320`, `#2335`, `#2348`, `#2350` | Dependency / tooling updates (no originating issues called out) |
+
+## Feature & bug-fix commits
+
+| Commit    | PR      | Summary                                                         | Originating Issue(s) | Notes                                                                |
+| --------- | ------- | --------------------------------------------------------------- | -------------------- | -------------------------------------------------------------------- |
+| `627a0df` | `#2173` | Add Occitan locale                                              | `#2173`              | Locale request                                                       |
+| `a824b2a` | `#2278` | Trim whitespace emitted by `card` shortcode                     | —                    | Bug fix with no linked issue mentioned                               |
+| `433ddb6` | `#2282` | User guide cleanup for alert shortcode usage                    | `#941`               | Docs follow-up to new alert shortcode                                |
+| `b3e4ccf` | `#941`  | Markdown-friendly alert shortcode                               | `#941`               | Addresses the long-standing alert shortcode request                  |
+| `aa0f617` | `#2285` | Accessibility color fixes, typography defaults                  | `#2285`              | Improves contrast per accessibility discussions                      |
+| `4323d09` | `#2287` | Bootstrap ScrollSpy support for TOC                             | `#349`, `#2289`      | Implements navigation indication & scroll tuning per release tracker |
+| `3a5cfea` | `#2290` | ScrollSpy style refinements                                     | `#349`, `#2289`      | Visual polish for ScrollSpy rollout                                  |
+| `55db259` | `#2291` | Drop smooth scrolling in ScrollSpy                              | `#349`, `#2289`      | Fixes ScrollSpy focus/scroll issues                                  |
+| `2cb3725` | `#2292` | TOC title styling and top-of-page link                          | `#349`, `#2289`      | Completes ScrollSpy UX fixes                                         |
+| `10f7dbe` | `#2301` | Show close icon for open hamburger menu                         | —                    | Navigation polish, no issue noted                                    |
+| `16335ca` | `#2302` | Hamburger focus state tweaks                                    | —                    | Accessibility polish                                                 |
+| `aa8a701` | `#2303` | Always display language menu in navbar                          | `#2035`, `#2001`     | Resolves narrow-display language menu issues listed in tracker       |
+| `1502423` | `#2318` | User guide: disable sidebar caching                             | —                    | Documentation correctness                                            |
+| `26120fc` | `#2313` | Update Simplified Chinese translations                          | `#2313`              | Translation update request                                           |
+| `7fbdc2f` | `#2322` | Include print pages in link checks                              | —                    | CI/docs maintenance                                                  |
+| `4c5c15b` | `#2324` | Fix flag image link in user guide                               | —                    | Broken asset fix                                                     |
+| `82d492b` | `#2325` | User guide dropdown link/style fixes                            | `#941`               | Aligns docs with new alert shortcode guidance                        |
+| `b2e919e` | `#2331` | Update Ukrainian translations                                   | `#2331`              | Translation update                                                   |
+| `2139e32` | `#2337` | Reorganize NPM dependencies; rename site folder to `docsy.dev`  | `#2115`              | Resolves npm optional/peer dependency errors                         |
+| `b23e453` | `#2334` | Enable non top-level section sidebar roots                      | `#2328`              | Implements `sidebar_root_for` feature                                |
+| `1b961c9` | `#2338` | Changelog update noting NPM-support fix                         | `#2115`              | Release notes maintenance                                            |
+| `d8f54d5` | `#2339` | Fix language menu padding in foldable sidebar                   | `#2001`              | Resolves sidemenu spacing bug                                        |
+| `2e5ebc4` | `#2340` | Rewrite `sidebar_root:true` configuration                       | `#2328`              | Migration step for sidebar-root feature                              |
+| `cf3a3d7` | `#2341` | Support `self` sidebar roots                                    | `#2328`              | Completes sidebar-root capabilities                                  |
+| `f0c0575` | `#2342` | Sidebar entry attribute spacing fix                             | `#2328`              | Cleanup from sidebar-root implementation                             |
+| `84526b3` | `#2361` | Skip warning when root section uses `sidebar_root_for:children` | `#2328`              | Refines sidebar-root UX for top-level docs sites                     |
+| `e1bdb4e` | `#2343` | Prevent dark-mode flash (initial fix)                           | —                    | Dark-mode FOUC fix (issue number not referenced)                     |
+| `1b8ccc3` | `#2355` | Dark-mode flash follow-up                                       | —                    | Completes dark-mode FOUC fix (issue number not referenced)           |
+| `3722bf7` | `#2349` | Blog: Upgrading to Docsy 0.12.0 from 0.11.0                     | `#2349`              | Adds detailed upgrade guidance for prior release                     |
+| `95de91f` | `#2356` | Normalize upgrade blog titles/slugs                             | `#2356`              | Keeps blog naming consistent across releases                         |
+
+## CI / tooling commits
+
+| Commit    | PR      | Summary                             | Originating Issue(s) | Notes                                      |
+| --------- | ------- | ----------------------------------- | -------------------- | ------------------------------------------ |
+| `818f62f` | `#2344` | Script to embed build ID in version | —                    | Helper tooling                             |
+| `0e2ad18` | `#2351` | Release process instruction updates | `#2266`              | Prep work for 0.13 release tracker         |
+| `595b25e` | `#2362` | Rework `fix:version` for pre-commit | `#2266`              | Makes build-version helper usable in hooks |
+
+[commits since v0.12.0]: https://github.com/google/docsy/compare/v0.12.0...main

--- a/tasks/0.13/release-wrapup.plan.md
+++ b/tasks/0.13/release-wrapup.plan.md
@@ -1,0 +1,73 @@
+---
+title: 0.13 Release wrapup plan
+date: 2025-11-12
+last-main-commit: 595b25e
+cSpell:ignore: docsy
+---
+
+## Inventory commits
+
+- Pull git log from [v0.12.0...main] and export commit list with PR numbers
+- Group dependency-only commits together and flag mixed-change commits for
+  review.
+- Keep groupings broad so the list stays manageable; note detailed client-impact
+  findings during the audit phase instead of here.
+- Maintain the generated summary in [commit inventory](commit-inventory.md)
+
+## Map commits to issues
+
+- For each commit/PR identify referenced issue IDs (from titles, PR bodies,
+  linked issues)
+- Capture commits with no linked issue and decide whether to log new follow-up
+  issues
+- Maintain the mapping table in [issue mapping](issue-mapping.md)
+
+## Issue resolution audit
+
+- For each linked issue verify status: completely resolved, partial, or needs
+  follow-up
+- Check `docsy.dev/content` and other user-guide paths for corresponding
+  documentation updates
+- Confirm `CHANGELOG.md` entries exist and are complete where needed
+- Identify whether each change affects downstream theme client projects and note
+  the impact in the audit summary
+- Maintain the findings in [issue audit](issue-audit.md)
+
+## Follow-up task identification
+
+- For issues lacking docs/changelog updates, list concrete tasks (file + change
+  notes)
+- Note any post-release actions (e.g., update docsy-example, tracking issue
+  updates)
+- Capture any client-facing follow-ups (docs, release notes, example site) in
+  the [wrapup report](wrapup-report.md)
+- Log additional tasks in the [wrapup report](wrapup-report.md) if needed
+
+## Assemble wrapup report
+
+- Draft a summary document outlining resolved issues, outstanding work,
+  dependency bundles, and action items
+- Cross-reference the `google/docsy#2266` tracker and update/checklist alignment
+- Publish outcomes to the [wrapup report](wrapup-report.md)
+
+## Prepare upgrade blog post
+
+- Outline key upgrade steps and highlights since 0.12
+- Draft `docsy.dev` blog post guiding users through upgrade to 0.13
+- Keep the draft updated in [0.13.0 upgrade post][]
+
+### Refresh actions
+
+Repeat when new commits land on `main`:
+
+- Revisit the plan and update the reports with new commits to `main` integrated
+  into existing summaries.
+- Update the upgrade blog draft with the latest context (track outstanding
+  content work in the wrapup report).
+
+Report refreshed for commits through [595b25e] (includes #2361 and #2362).
+
+[0.13.0 upgrade post]: upgrade-blog.md
+[595b25e]:
+  https://github.com/google/docsy/commit/595b25e3c63894967ae5a3a0d3cf9160a69c85eb
+[v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main

--- a/tasks/0.13/upgrade-blog.md
+++ b/tasks/0.13/upgrade-blog.md
@@ -1,0 +1,55 @@
+---
+title: Upgrade to Docsy 0.13
+linkTitle: Upgrade to 0.13
+date: 2025-11-11
+description: Key changes and upgrade tips for moving from Docsy 0.12 to 0.13.
+draft: true
+---
+
+> Draft refreshed against `main` up to commit `595b25e`.
+
+> **Draft**: Populate with screenshots, code samples, and final copy once
+> follow-up actions in [wrapup-report.md](wrapup-report.md) are complete.
+
+## TL;DR
+
+- Sidebar navigation gains `sidebar_root_for` for scoped trees and quieter
+  warnings for docs roots.
+- ScrollSpy and TOC receive usability fixes.
+- Language selector is always visible; dark-mode flashing fixed.
+- Alert shortcode now accepts Markdown content.
+- Hugo, Bootstrap, and Node dependencies bumped—run through the checklist below.
+
+## Navigation & UX Improvements
+
+<!-- TODO: Summarize language menu changes (#2035/#2001), ScrollSpy updates (#349/#2289), hamburger icon tweak (#2301), and dark-mode fixes. Include before/after visuals. -->
+
+## Content Authoring Updates
+
+<!-- TODO: Detail new alert shortcode syntax (#941) and related documentation cleanups. Mention card shortcode whitespace adjustment (#2278). -->
+
+## Dependency & Tooling Updates
+
+<!-- TODO: Cover Hugo 0.152.2, Bootstrap 5.3.8, Node LTS alignment, npm dependency graph changes (#2115), and CI build ID tooling (#2344/#2351/#2362). -->
+
+## Upgrade Checklist
+
+1. Update Docsy module / npm dependency to v0.13.0.
+2. Review `config` for language menu defaults (`ui.sidebar_lang_menu`).
+3. Adjust alert shortcode usage to new Markdown-friendly form.
+4. Validate custom ScrollSpy overrides and TOC styles.
+5. Rebuild assets (Bootstrap, Sass) and re-run linters/tests.
+
+<!-- TODO: Expand checklist with sidebar-root adoption steps and translation verification guidance. -->
+
+## Looking Ahead
+
+- Outstanding work items tracked in [wrapup-report.md](wrapup-report.md).
+- Watch the 0.13 release tracker
+  ([google/docsy#2266](https://github.com/google/docsy/issues/2266)) for status
+  updates.
+- Provide feedback via
+  [GitHub Discussions](https://github.com/google/docsy/discussions).
+- Plan a cross-link to the new
+  [Upgrade to Docsy 0.12.0](../docsy.dev/content/en/blog/2025/0.12.0.md) article
+  once both posts are live.

--- a/tasks/0.13/wrapup-report.md
+++ b/tasks/0.13/wrapup-report.md
@@ -1,0 +1,88 @@
+---
+title: 0.13 release-wrapup report
+date: 2025-11-12
+cSpell:ignore: docsy
+---
+
+> Report refreshed for commits through `595b25e` on `main`.
+
+## Highlights since v0.12.0
+
+- Sidebar navigation now supports `sidebar_root_for` with `children` and `self`
+  modes.
+- ScrollSpy overhaul delivers active TOC indication and UX polish (addresses
+  #349/#2289).
+- Language selector redesign keeps the dropdown visible on all screen sizes.
+- Alert shortcode rewritten for Markdown content and nested shortcodes (#941).
+- Accessibility color and typography defaults improved for better contrast
+  (#2285).
+- Dependency stack refreshed:
+  - Bootstrap 5.3.8 (from 5.3.6)
+  - Hugo 0.152.2 (from 0.147.5)
+  - Node LTS ≥24 (from ≥22)
+- NPM workflow cleanups, including a pre-commit-ready `fix:version` helper
+- Published 0.12.0 upgrade guidance blog and aligned upgrade post slugs (#2349,
+  #2356)
+
+## References
+
+- [Release 0.13.0 preparation #2345][#2266]
+- [v0.12.0...main][]
+- Commit inventory: [commit-inventory.md](commit-inventory.md)
+- Issue mapping: [issue-mapping.md](issue-mapping.md)
+- Issue resolution audit: [issue-audit.md](issue-audit.md)
+- 0.12 upgrade article:
+  [../docsy.dev/content/en/blog/2025/0.12.0.md](../docsy.dev/content/en/blog/2025/0.12.0.md)
+
+[#2266]: https://github.com/google/docsy/issues/2266
+[v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main
+
+## Action items
+
+Expand user guide coverage for the following features:
+
+- [ ] Document `sidebar_root_for` usage with examples and configuration
+      guidance - in progress (see
+      [sidebar-root-feature.plan.md](../sidebar-root-feature.plan.md)).
+- [ ] Elaborate on ScrollSpy behavior and tuning options post-update
+- [ ] Update release process checklist with new build ID helper references
+      (confirm #2266 alignment)
+
+Add changelog entries for the following issues:
+
+- [ ] Accessibility color/typography fixes (#2285)
+- [ ] ScrollSpy & TOC UX improvements (#349/#2289)
+- [x] Sidebar-root feature (#2328) — covered in `CHANGELOG.md` (0.12.1/0.13.0
+      “New” section, `sidebar_root_for` bullet).
+- [x] Dark-mode flash fix (no issue ID) — documented in `CHANGELOG.md`
+      (0.12.1/0.13.0 “Other changes” entry).
+- [ ] Translation refreshes (#2173, #2313, #2331) – optional but helpful
+
+Client-upgrade support:
+
+- [ ] Blog: cross-link 0.12.0 and 0.13.0 upgrade blogs once 0.13 content is
+      finalized
+- [ ] `docsy-example` example site:
+  - [ ] Update to adopt new alert shortcode and language menu defaults
+  - [ ] Update to adopt new sidebar-root feature
+
+Verification, testing, and QA:
+
+- [ ] Sanity:
+  - [ ] Verify that the `docsy-example` site builds cleanly with the new
+        dependencies
+  - [ ] Ensure other reference projects build cleanly with dependency
+        reorganizations
+
+- [ ] Testing & QA:
+  - [ ] Run visual regression/snapshot checks for navigation, ScrollSpy, and
+        dark-mode fixes
+  - [ ] Validate new locales/translations render correctly
+  - [ ] Review narrow-screen language menu screenshots and guidance
+        (#2035/#2001)
+
+## Upgrade Blog
+
+- Draft outline: [0.13.0 upgrade article](upgrade-blog.md)
+- Flesh out full post with screenshots and code samples once follow-up actions
+  completed.


### PR DESCRIPTION
- Contributes to:
  - #2266
  - #2328
- Adds planning and tasks working docs for the sidebar-root feature and 0.13 prep wrapup
- Updates comments and warning message in `layouts/_partials/sidebar.html`
- There are not changes to the generated site pages (other than the refcache).