### PR TITLE
[EXPERIMENTAL] Sidebar-root UG and CHANGELOG additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-  cSpell:ignore deining docsy gitmodules gtag lookandfeel mhchem navs tabpane
+  cSpell:ignore deining docsy gitmodules gtag lookandfeel mhchem navs tabpane FOUC
 -->
 
 # Changelog
@@ -50,20 +50,27 @@ For the full list of changes, see the [0.x.y] release notes.
 
 **New**:
 
+- Added [Section sidebar root][] feature.
+
 **Other changes**:
 
 - Projects using Docsy via NPM, directly from the GitHub repository, will no
-  longer face optional and peer dependencies errors ([#2115]).
-- Hamburger menu toggle button icon changes to an X when the menu is expanded
+  longer face optional and peer dependencies issues ([#2115]).
+- Fixed dark-mode [Flash Of Unstyled Content][] (FOUC) ([#2185]).
+- Hamburger menu toggle button icon changed to an X when the menu is expanded
   ([#2301]). This is a style change only.
 
 [#2115]: https://github.com/google/docsy/issues/2115
-[#2300]: https://github.com/google/docsy/pull/2300
+[#2185]: https://github.com/google/docsy/issues/2185
 [#2301]: https://github.com/google/docsy/pull/2301
 [#2303]: https://github.com/google/docsy/pull/2303
 [0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
 [Adding a language menu]:
   https://www.docsy.dev/docs/adding-content/navigation/#adding-a-language-menu
+[Flash Of Unstyled Content]:
+  https://en.wikipedia.org/wiki/Flash_of_unstyled_content
+[Section sidebar root]:
+  https://www.docsy.dev/docs/adding-content/navigation/#sidebar-root
 
 ## 0.12.0
 

--- a/docsy.dev/content/en/docs/adding-content/navigation.md
+++ b/docsy.dev/content/en/docs/adding-content/navigation.md
@@ -177,8 +177,8 @@ unset).
 
 ## Section menu
 
-The section menu, as shown in the left side of the `docs` section, is
-automatically built from the `content` tree. Like the top-level menu, it is
+The section menu, as shown in the left side of the `docs` and `blog` sections,
+is automatically built from the `content` tree. Like the top-level menu, it is
 ordered by page or section index `weight` (or by page creation `date` if
 `weight` is not set), with the page or index's `Title`, or `linkTitle` if
 different, as its link title in the menu. If a section subfolder has pages other
@@ -380,6 +380,54 @@ file, albeit one with no generated links to it. To avoid confusion if users
 accidentally land on a generated placeholder page, we recommend specifying the
 URL for the external link in the normal content and / or page description of the
 page. {{% /alert %}}
+
+### Section as sidebar root (EXPERIMENTAL) {#sidebar-root}
+
+To help readers stay focused within a section, you can “root” a section in the
+sidebar navigation. This is particularly useful when there is deeply nested
+pages.
+
+Enable the feature in your site configuration:
+
+```yaml
+params:
+  ui:
+    sidebar_root_enabled: true
+```
+
+Then add `sidebar_root_for` to a section’s `_index.md`. Available options are:
+
+- `self` applies the rooted sidebar to the index page as well as descendants.
+- `children` keeps the section’s index page in the global docs menu, but limits
+  descendant pages to the rooted sidebar.
+
+Example:
+
+```yaml
+---
+title: API Reference v2.0
+linkTitle: v2.0
+sidebar_root_for: self
+---
+```
+
+Examples:
+
+| `sidebar_root_for` | Example                                            |
+| ------------------ | -------------------------------------------------- |
+| `self`             | [Content and customization](/docs/adding-content/) |
+| `children`         | [Best practices](/docs/best-practices/)            |
+
+To navigate out of a rooted section, click the “up” icon in the sidebar next to
+the section title.
+
+Feature notes:
+
+- You can nest rooted sections.
+- Docsy will warn you if you set `sidebar_root_for` to `self` on a section root
+  page, since it is redundant.
+- Docsy will generally ignore `sidebar_root_for` for non "docs" pages and
+  non-section index pages.
 
 ## Breadcrumb navigation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+44-g595b25e",
+  "version": "0.13.0-dev+45-g2523a8b",
   "version.next": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",


### PR DESCRIPTION
- Contributes to:
  - #2266
  - #2328
- Adds a description of the section-sidebar-root feature to the UG
- Adds CL entries for the sidebar-root feature, and a commentary about a dark-mode fix
- **Preview**:
  - https://deploy-preview-2364--docsydocs.netlify.app/docs/adding-content/navigation/#sidebar-root
  - https://deploy-preview-2364--docsydocs.netlify.app/project/changelog/#0121-or-0130