### PR TITLE
Adjust ScrollSpy TOC tracking and add docs, and more

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,23 @@
+# See https://github.com/DavidAnson/markdownlint/blob/main/README.md#rules--aliases
+# cSpell:ignore docsy
+
+ignores:
+  - "node_modules/**"
+  - "public/**"
+  - "docsy.dev/public/**"
+
+default: true
+
+emphasis-style: false
+first-line-h1: false
+line-length: false
+link-fragments: false
+list-marker-space: false
+no-emphasis-as-header: false
+no-hard-tabs: false
+no-inline-html: false
+no-trailing-punctuation: false
+no-trailing-spaces:
+  br_spaces: 0
+  strict: true
+table-column-style: false # Causes problems in ja and zh pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Useful links:
 >     Old entries might not follow this guidance; feel free to update them as
 >     needed.
 
-## 0.12.1 or 0.13.0
+## 0.13.0
 
 > **UNRELEASED: this planned version is still under development**
 
@@ -57,14 +57,21 @@ For the full list of changes, see the [0.x.y] release notes.
 - Projects using Docsy via NPM, directly from the GitHub repository, will no
   longer face optional and peer dependencies issues ([#2115]).
 - Fixed dark-mode [Flash Of Unstyled Content][] (FOUC) ([#2185]).
+- Added Bootstrap ScrollSpy support to highlight the active heading in the TOC
+  sidebar. ([#349], [#2289]). For details, see [Active TOC entry tracking with
+  ScrollSpy][].
 - Hamburger menu toggle button icon changed to an X when the menu is expanded
   ([#2301]). This is a style change only.
 
+[#349]: https://github.com/google/docsy/issues/349
 [#2115]: https://github.com/google/docsy/issues/2115
 [#2185]: https://github.com/google/docsy/issues/2185
+[#2289]: https://github.com/google/docsy/issues/2289
 [#2301]: https://github.com/google/docsy/pull/2301
 [#2303]: https://github.com/google/docsy/pull/2303
 [0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+[Active TOC entry tracking with ScrollSpy]:
+  https://www.docsy.dev/docs/adding-content/navigation/#toc-entry-tracking
 [Adding a language menu]:
   https://www.docsy.dev/docs/adding-content/navigation/#adding-a-language-menu
 [Flash Of Unstyled Content]:

--- a/docsy.dev/content/en/docs/adding-content/navigation.md
+++ b/docsy.dev/content/en/docs/adding-content/navigation.md
@@ -24,6 +24,7 @@ matter (in `_index.md` or `_index.html` for a section, as that's the section
 landing page). For example, here's how we added the Documentation section
 landing page to the main menu in this site:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -61,6 +62,7 @@ menu:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 The menu is ordered from left to right by page `weight`. So, for example, a
 section index or page with `weight: 30` would appear after the Documentation
@@ -69,6 +71,7 @@ section in the menu, while one with `weight: 10` would appear before it.
 If you want to add a link to an external site to this menu, add it in
 `hugo.toml`/`hugo.yaml`/`hugo.json`, specifying the `weight`.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -100,6 +103,7 @@ menu:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 ### Adding icons to the top-level menu
 
@@ -111,6 +115,7 @@ or via page front matter. For example, the following configuration adds the
 GitHub icon to the GitHub menu item, and a **New!** alert to indicate that this
 is a new addition to the menu.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -148,6 +153,7 @@ menu:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 You can find a complete list of icons to use in the
 [FontAwesome documentation](https://fontawesome.com/icons?d=gallery&p=2). Docsy
@@ -186,6 +192,7 @@ than `_index.md` or `_index.html`, those pages will appear as a submenu, again
 ordered by `weight`. For example, here's the metadata for this page showing its
 `weight` and `title`:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -221,6 +228,7 @@ description: >
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 To hide a page or section from the left navigation menu, set `toc_hide: true` in
 the front matter.
@@ -231,6 +239,7 @@ page]({{< ref "content#docs-section-landing-pages" >}}), set
 the TOC menu and the section summary list, you need to set both `toc_hide` and
 `hide_summary` to `true` in the front matter.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -266,6 +275,7 @@ description: >
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 ### Section menu options
 
@@ -297,6 +307,7 @@ for activating the cached section menu with the optional parameter
 The tabbed pane below lists the menu section options you can define in your
 project [configuration file].
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}{{< tab header="hugo.toml" lang="toml" >}}
@@ -328,6 +339,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 ### Add icons to the section menu
 
@@ -429,6 +441,102 @@ Feature notes:
 - Docsy will generally ignore `sidebar_root_for` for non "docs" pages and
   non-section index pages.
 
+## Table of contents
+
+Docsy provides a table of contents (TOC) for each "docs"page. The TOC is
+generated from the headings in the page content. The TOC is displayed in the
+right-hand sidebar by default.
+
+{{% alert title="Will shortcode headings appear in the TOC?" color=info %}}
+
+The headings contained in [Markdown shortcodes][] `{{%/* ... */%}}` get included
+in the TOC, while those in standard shortcodes `{{</* ... */>}}` will not. For
+details, see Hugo forum discussions [#55399] and [#51940].
+
+[#55399]:
+  https://discourse.gohugo.io/t/tableofcontents-doesnt-render-headings-correctly-that-contains-shortcode/55399
+[#51940]:
+  https://discourse.gohugo.io/t/can-hugo-include-shortcode-headings-in-toc/51940
+[Markdown shortcodes]: /docs/adding-content/shortcodes/#shortcode-delimiters
+
+{{% /alert %}}
+
+### Active TOC entry tracking with ScrollSpy {#toc-entry-tracking}
+
+Docsy highlights the active heading in the TOC sidebar using Bootstrap
+[ScrollSpy][]. By default, headings become active when they reach 10% from the
+top of the viewport (configured via `rootMargin`).
+
+- To disable ScrollSpy for a specific page, set `ui.scrollSpy.disable: true` in
+  that page's front matter. To disable for all pages in a section, [cascade] the
+  setting in the front matter of the section's index page.
+- To globally adjust when headings become active, set `ui.scrollSpy.rootMargin`
+  in your site configuration. The default is `0px 0px -10%`. Use a larger
+  negative percentage (e.g., `-20%`) to activate headings earlier, or a smaller
+  one (e.g., `-5%`) to activate them later.
+
+  <!-- prettier-ignore -->
+  {{< tabpane >}}
+  {{< tab header="Configuration file:" disabled=true />}}
+  {{< tab header="hugo.toml" lang="toml" >}}
+  [params.ui.scrollSpy]
+  rootMargin = "0px 0px -15%"
+  {{< /tab >}}
+  {{< tab header="hugo.yaml" lang="yaml" >}}
+  params:
+    ui:
+      scrollSpy:
+        rootMargin: 0px 0px -15%
+  {{< /tab >}}
+  {{< tab header="hugo.json" lang="json" >}}
+  {
+    "params": {
+      "ui": {
+        "scrollSpy": {
+          "rootMargin": "0px 0px -15%"
+        }
+      }
+    }
+  }
+  {{< /tab >}}
+  {{< /tabpane >}}
+
+  {{% alert title="Smooth scrolling issue" color=info %}}
+
+  We previously enabled ScrollSpy's smooth scrolling, but it interfered with
+  hash updates in the browser URL and in-page navigation, so it is disabled by
+  default. For details see PR [#2291].
+
+  {{% /alert %}}
+
+For advanced customization, such as adjusting `threshold`, override
+[layouts/_partials/td/scrollspy-attr.txt]. For ScrollSpy configuration details,
+see [ScrollSpy].
+
+{{% alert title="Note" %}}
+
+Bootstrap ScrollSpy determines the active TOC entry using the browser’s
+[IntersectionObserver API][], including its configurable [rootMargin]. Because
+of how these thresholds work, there can be brief moments where **no** heading is
+highlighted—especially when headings are close together or when the active
+region is small. For more details, see the Bootstrap [ScrollSpy options][] and
+the upstream discussion in [Bootstrap issue #34958][bs-34958].
+
+{{% /alert %}}
+
+[bs-34958]: https://github.com/twbs/bootstrap/issues/34958
+[cascade]: https://gohugo.io/content-management/front-matter/#cascade-1
+[IntersectionObserver API]:
+  https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver
+[layouts/_partials/td/scrollspy-attr.txt]:
+  https://github.com/google/docsy/blob/main/layouts/_partials/td/scrollspy-attr.txt
+[#2291]: https://github.com/google/docsy/pull/2291
+[ScrollSpy]: https://getbootstrap.com/docs/5.3/components/scrollspy/
+[rootmargin]:
+  https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin
+[ScrollSpy options]:
+  https://getbootstrap.com/docs/5.3/components/scrollspy/#options
+
 ## Breadcrumb navigation
 
 [Breadcrumb navigation] appears at the top of each non-index page be default. To
@@ -453,6 +561,7 @@ entire project, by setting `ui.breadcrumb_disable` to true in your project
 [configuration file]. Similarly, you can disabled taxonomy breadcrumbs by
 setting `ui.taxonomy_breadcrumb_disable` to true:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}{{< tab header="hugo.toml" lang="toml" >}}
@@ -478,6 +587,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-enable -->
 
 To disable breadcrumbs in a specific page or section set `ui.breadcrumb_disable`
 to true in the page or section-index front matter. Here is an example of the

--- a/docsy.dev/content/en/docs/adding-content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/adding-content/shortcodes/index.md
@@ -10,7 +10,8 @@ resources:
       byline: '*Photo*: Bjørn Erik Pedersen / CC-BY-SA'
 params:
   message: Some _message_.
-cSpell:ignore: imgproc pageinfo Bjørn Pedersen swaggerui grayscale Picea
+# prettier-ignore
+cSpell:ignore: cardpane docsy imgproc pageinfo petstore Bjørn Pedersen swaggerui grayscale Picea tryautoheight readfile buildcondition
 ---
 
 Rather than writing all your site pages from scratch, Hugo lets you define and
@@ -452,7 +453,7 @@ famous `Hello world!` program one usually writes first when learning a new
 programming language:
 
 <!-- prettier-ignore-start -->
-<!-- cSpell:ignore cout println -->
+<!-- cSpell:ignore cout println stdio stdlib endl -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab "C" >}}
 #include <stdio.h>
@@ -919,5 +920,4 @@ If you are using this shortcode, note that when evaluating the conditions,
 substring matches are matches as well. That means, if you set
 `include-if="foobar"`, and `buildcondition = "foo"`, you have a match!
 
-[shortcode delimiter]:
-  https://gohugo.io/content-management/shortcodes/#use-shortcodes
+[shortcode delimiter]: https://gohugo.io/content-management/shortcodes/#notation

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -7,7 +7,7 @@
     "_check:format": "npx prettier --prose-wrap=always --check .",
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
     "_check:links": "make --keep-going check-links",
-    "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit -m \"Site at $HASH\"",
+    "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit --allow-empty -m \"Site at $HASH\"",
     "_hugo-dev": "npm run _hugo -- -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
     "_refcache:prune-4xx": "jq 'with_entries(select(.value.StatusCode < 400))' static/refcache.json > tmp/refcache.json && mv tmp/refcache.json static/refcache.json",
@@ -33,10 +33,10 @@
     "update:packages": "npx npm-check-updates -u"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.21",
+    "autoprefixer": "^10.4.22",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.152.2",
-    "netlify-cli": "^23.9.5",
+    "netlify-cli": "^23.10.0",
     "npm-check-updates": "^19.1.2",
     "postcss-cli": "^11.0.1",
     "rtlcss": "^4.3.0"

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -103,6 +103,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-22T22:35:07.769384352+02:00"
   },
+  "https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:11.398974-05:00"
+  },
+  "https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:11.619939-05:00"
+  },
   "https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink": {
     "StatusCode": 206,
     "LastSeen": "2024-11-06T12:04:24.495606-05:00"
@@ -135,6 +143,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:41.460308-04:00"
   },
+  "https://discourse.gohugo.io/t/can-hugo-include-shortcode-headings-in-toc/51940": {
+    "StatusCode": 200,
+    "LastSeen": "2025-11-12T21:09:09.97557-05:00"
+  },
   "https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469": {
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:37.88603-04:00"
@@ -146,6 +158,10 @@
   "https://discourse.gohugo.io/t/markdown-attributes/41783": {
     "StatusCode": 200,
     "LastSeen": "2025-05-16T09:20:46.115114-04:00"
+  },
+  "https://discourse.gohugo.io/t/tableofcontents-doesnt-render-headings-correctly-that-contains-shortcode/55399": {
+    "StatusCode": 200,
+    "LastSeen": "2025-11-12T21:09:10.020103-05:00"
   },
   "https://discourse.gohugo.io/t/what-does-setting-hugo-env-to-production-do/24669/2": {
     "StatusCode": 200,
@@ -418,6 +434,14 @@
   "https://getbootstrap.com/docs/5.3/components/alerts/": {
     "StatusCode": 206,
     "LastSeen": "2025-06-10T21:33:38.654894-04:00"
+  },
+  "https://getbootstrap.com/docs/5.3/components/scrollspy/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:10.106271-05:00"
+  },
+  "https://getbootstrap.com/docs/5.3/components/scrollspy/#options": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:11.717904-05:00"
   },
   "https://getbootstrap.com/docs/5.3/content/reboot/#native-font-stack": {
     "StatusCode": 200,
@@ -735,6 +759,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:38.127906-04:00"
   },
+  "https://github.com/google/docsy/blob/main/layouts/_partials/td/scrollspy-attr.txt": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:11.101706-05:00"
+  },
   "https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html": {
     "StatusCode": 206,
     "LastSeen": "2025-05-23T09:04:28.74017-04:00"
@@ -971,6 +999,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-12T12:00:13.555016-05:00"
   },
+  "https://github.com/google/docsy/issues/2289": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:10.18619-05:00"
+  },
   "https://github.com/google/docsy/issues/331": {
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:03:57.646409-05:00"
@@ -1150,6 +1182,10 @@
   "https://github.com/google/docsy/pull/2259": {
     "StatusCode": 206,
     "LastSeen": "2025-05-22T19:21:14.104646-04:00"
+  },
+  "https://github.com/google/docsy/pull/2291": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:10.724265-05:00"
   },
   "https://github.com/google/docsy/pull/2301": {
     "StatusCode": 206,
@@ -1647,6 +1683,10 @@
     "StatusCode": 200,
     "LastSeen": "2024-11-06T12:05:09.357401-05:00"
   },
+  "https://github.com/twbs/bootstrap/issues/34958": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:12.129299-05:00"
+  },
   "https://github.com/twbs/bootstrap/pull/28517/files#diff-41667d8b9901aa9fa52483b538bb9026c287f2c663d2fdc01acffa06888cc087L13": {
     "StatusCode": 200,
     "LastSeen": "2025-10-06T11:42:12.345Z"
@@ -1723,6 +1763,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:39.15452-04:00"
   },
+  "https://gohugo.io/content-management/front-matter/#cascade-1": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:10.287327-05:00"
+  },
   "https://gohugo.io/content-management/front-matter/#front-matter-cascade": {
     "StatusCode": 206,
     "LastSeen": "2025-10-06T11:47:59.999Z"
@@ -1762,6 +1806,10 @@
   "https://gohugo.io/content-management/shortcodes/": {
     "StatusCode": 206,
     "LastSeen": "2025-05-16T09:20:34.567684-04:00"
+  },
+  "https://gohugo.io/content-management/shortcodes/#notation": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:09.686825-05:00"
   },
   "https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown": {
     "StatusCode": 206,
@@ -2390,6 +2438,10 @@
   "https://www.docsy.dev/docs/adding-content/navigation/#sidebar-root": {
     "StatusCode": 206,
     "LastSeen": "2025-11-12T12:00:13.317204-05:00"
+  },
+  "https://www.docsy.dev/docs/adding-content/navigation/#toc-entry-tracking": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-12T21:09:10.640114-05:00"
   },
   "https://www.docsy.dev/docs/adding-content/repository-links/": {
     "StatusCode": 206,

--- a/layouts/_partials/td/scrollspy-attr.txt
+++ b/layouts/_partials/td/scrollspy-attr.txt
@@ -1,10 +1,10 @@
-{{ if not (.Param "ui.scrollspy.disable") -}}
-  {{ replaceRE `\s+` " "
-  `
-  data-bs-spy="scroll"
-  data-bs-target="#TableOfContents"
-  data-bs-root-margin="0px 0px -40%"
-  `
- | strings.TrimSpace | add " " -}}
-
- {{ end -}}
+{{ if not (.Param "ui.scrollSpy.disable") -}}
+  {{ $rootMargin := .Param "ui.scrollSpy.rootMargin" | default "0px 0px -10%" -}}
+  {{/* Note that we tried `data-bs-smooth-scroll="true"`, but it breaks browser URL updates.
+       For details, see https://github.com/google/docsy/pull/2291 */ -}}
+  {{ $attr := slice
+      ` data-bs-spy="scroll"`
+      ` data-bs-target="#TableOfContents"`
+      (printf ` data-bs-root-margin="%s"` $rootMargin) -}}
+  {{ delimit $attr "" -}}
+{{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+45-g2523a8b",
+  "version": "0.13.0-dev+46-g468c081",
   "version.next": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
@@ -11,6 +11,7 @@
   "scripts": {
     "_cd:docsy.dev": "cd docsy.dev &&",
     "_check:format": "npx prettier --check *.md tasks",
+    "_check:markdown": "npx markdownlint-cli2",
     "_commit:public": "npm run _cd:docsy.dev -- npm run _commit:public",
     "_cp:bs-rfs": "npx cpy 'node_modules/bootstrap/scss/vendor/*' assets/_vendor/bootstrap/scss/",
     "_diff:check": "git diff --name-only --exit-code",
@@ -19,9 +20,11 @@
     "_prepare": "npm run _cp:bs-rfs && npm run _refresh-forward-sass-var && npm run _gen-chroma-styles && npm run get:hugo-modules",
     "_refresh-forward-sass-var": "bash -c scripts/refresh-sass-variables.pl",
     "_update:version-build-id": "node scripts/update-version-build-id/index.mjs",
+    "build": "npm run _cd:docsy.dev -- npm run build",
     "cd:docsy.dev": "npm run _cd:docsy.dev -- npm run",
     "check:format": "npm list prettier && npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
-    "check": "npm run check:format",
+    "check:markdown": "npm run _check:markdown -- '**/*.md'",
+    "check": "npm run check:format && echo 'DISABLING MARKDOWN LINTING FOR NOW. npm run check:markdown'",
     "ci:post": "npm run fix:format && npm run _diff:check && npm run test:tooling",
     "ci:prepare": "npm run docsy.dev-install && npm run _prepare && npm run _diff:check",
     "docsy.dev-install": "npm run _cd:docsy.dev -- npm install",
@@ -30,9 +33,10 @@
     "fix": "npm run fix:format && npm run fix:version && npm run cd:docsy.dev fix",
     "get:hugo-modules": "node scripts/getHugoModules/index.mjs",
     "postinstall": "npm run _mkdir:hugo-mod",
+    "serve": "npm run _cd:docsy.dev -- npm run serve",
     "test:all": "npm run ci:prepare && npm run check && npm run cd:docsy.dev test && npm run ci:post",
-    "test:tooling": "node --test",
     "test:only": "npm run cd:docsy.dev test",
+    "test:tooling": "node --test",
     "test": "echo 'RUNNING FIX AND TESTS...'; npm run fix && npm run test:only",
     "update:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
     "update:packages": "npx npm-check-updates -x @fortawesome/fontawesome-free -u && npm run cd:docsy.dev update:packages"
@@ -43,6 +47,7 @@
   },
   "devDependencies": {
     "cpy-cli": "^6.0.0",
+    "markdownlint-cli2": "^0.18.1",
     "prettier": "^3.6.2"
   },
   "config": {

--- a/tasks/0.13/wrapup-report.md
+++ b/tasks/0.13/wrapup-report.md
@@ -41,21 +41,22 @@ cSpell:ignore: docsy
 
 Expand user guide coverage for the following features:
 
-- [ ] Document `sidebar_root_for` usage with examples and configuration
-      guidance - in progress (see
-      [sidebar-root-feature.plan.md](../sidebar-root-feature.plan.md)).
-- [ ] Elaborate on ScrollSpy behavior and tuning options post-update
+- [x] Document `sidebar_root_for` usage with examples
+  - For details, see
+    [sidebar-root-feature.plan.md](../sidebar-root-feature.plan.md)
+- [x] Elaborate on ScrollSpy behavior and tuning options post-update
 - [ ] Update release process checklist with new build ID helper references
       (confirm #2266 alignment)
 
 Add changelog entries for the following issues:
 
 - [ ] Accessibility color/typography fixes (#2285)
-- [ ] ScrollSpy & TOC UX improvements (#349/#2289)
+- [x] ScrollSpy & TOC UX improvements (#349/#2289) — covered in `CHANGELOG.md`
+      (0.12.1/0.13.0 "Other changes" section).
 - [x] Sidebar-root feature (#2328) — covered in `CHANGELOG.md` (0.12.1/0.13.0
-      “New” section, `sidebar_root_for` bullet).
-- [x] Dark-mode flash fix (no issue ID) — documented in `CHANGELOG.md`
-      (0.12.1/0.13.0 “Other changes” entry).
+      "New" section, `sidebar_root_for` bullet).
+- [x] Dark-mode flash fix (#2185) — documented in `CHANGELOG.md` (0.12.1/0.13.0
+      “Other changes” entry).
 - [ ] Translation refreshes (#2173, #2313, #2331) – optional but helpful
 
 Client-upgrade support:


### PR DESCRIPTION
- Contributes to:
  - #2266
  - #2289
- Adds a description of the TOC entry tracking feature to the UG
- Adds CL entry for this feature
- Also includes various CI script updates
- Adds support for markdownlint checking
- **Preview**:
  - https://deploy-preview-2366--docsydocs.netlify.app/docs/adding-content/navigation/#toc-entry-tracking
  - https://deploy-preview-2366--docsydocs.netlify.app/project/changelog/#0130