### PR TITLE
Implement a workaround to ScrollSpy's heading-ID problem

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -2,9 +2,9 @@
 # cSpell:ignore docsy
 
 ignores:
-  - "node_modules/**"
-  - "public/**"
-  - "docsy.dev/public/**"
+  - node_modules/**
+  - public/**
+  - docsy.dev/public/**
 
 default: true
 

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -20,6 +20,7 @@
     "tabpane",
     "upvote",
     "warnf",
+    "warnidf",
     "wrapup"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ See [semver].
 
 <!-- TODO: look into https://www.conventionalcommits.org/en/v1.0.0/#summary -->
 
-## 0.13.0
+## v0.13.0
 
 > **UNRELEASED: this planned version is still under development**
 
@@ -61,15 +61,16 @@ See [semver].
 
 **Breaking changes**:
 
-- **Language menu**: Visibility changed. See [Language menu
-  visibility][0.13.0-blog-lang-menu] in the blog post.
-- **Alert shortcode**: Content processing changed. See [Alert shortcode
-  improvements][0.13.0-blog-alert] in the blog post.
+- **Language menu**: changed visibility, see [Language menu
+  visibility][0.13.0-blog-lang-menu] ([#2303]).
+- **Alert shortcode**: Markdown content processing changed, see [Alert shortcode
+  improvements][0.13.0-blog-alert] ([#941]).
 
 **New**:
 
-- [Active TOC entry tracking][0.13.0-blog-toc] using Bootstrap ScrollSpy.
-- [Section sidebar root][0.13.0-blog-sidebar] feature.
+- [Active TOC entry tracking][0.13.0-blog-toc] using Bootstrap ScrollSpy
+  ([#2366]).
+- [Section sidebar root][0.13.0-blog-sidebar] feature ([#2364]).
 
 **Other changes**:
 
@@ -85,9 +86,13 @@ See [semver].
 [#2115]: https://github.com/google/docsy/issues/2115
 [#2173]: https://github.com/google/docsy/issues/2173
 [#2285]: https://github.com/google/docsy/issues/2285
+[#2303]: https://github.com/google/docsy/pull/2303
 [#2313]: https://github.com/google/docsy/issues/2313
 [#2331]: https://github.com/google/docsy/issues/2331
 [#2332]: https://github.com/google/docsy/issues/2332
+[#2364]: https://github.com/google/docsy/pull/2364
+[#2366]: https://github.com/google/docsy/pull/2366
+[#941]: https://github.com/google/docsy/pull/941
 [0.13.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.13.0
 [0.13.0-blog]: https://www.docsy.dev/blog/2025/0.13.0/
 [0.13.0-blog-lang-menu]:
@@ -102,7 +107,7 @@ See [semver].
 [0.13.0-blog-fouc]: https://www.docsy.dev/blog/2025/0.13.0/#accessibility
 [0.13.0-blog-breaking]: https://www.docsy.dev/blog/2025/0.13.0/#breaking-changes
 
-## 0.12.0
+## v0.12.0
 
 For the full list of changes, see the [0.12.0] release page.
 
@@ -169,7 +174,7 @@ For the full list of changes, see the [0.12.0] release page.
 [_td-content-after-header.html]:
   https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html
 
-## 0.11.0
+## v0.11.0
 
 For the full list of changes, see the [0.11.0] release page.
 
@@ -190,7 +195,7 @@ For the full list of changes, see the [0.11.0] release page.
   https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options
 [rtl]: https://www.docsy.dev/docs/language/#right-to-left-languages
 
-## 0.10.0
+## v0.10.0
 
 For an introduction to this release, see the [0.10.0 release report]. For the
 full list of changes, see the [0.10.0] release page.
@@ -200,7 +205,7 @@ dark-mode support][dark-mode].
 
 **Breaking changes**:
 
-- Removes shortcode `card-code` that was [deprecated in 0.7.0](#070); use
+- Removes shortcode `card-code` that was [deprecated in 0.7.0](#v070); use
   shortcode `card` with named parameter `code=true` instead.
 - The following SCSS variables are inlined in favor of dark-mode compatible
   styling: `$border-color`, `$td-sidebar-tree-root-color`,
@@ -218,13 +223,13 @@ dark-mode support][dark-mode].
 [dark-mode]:
   https://www.docsy.dev/blog/2024/0.10.0/#color-themes-and-dark-mode-support
 
-## 0.9.1
+## v0.9.1
 
 Patch release. For details, see [0.9.1].
 
 [0.9.1]: https://github.com/google/docsy/releases/v0.9.1
 
-## 0.9.0
+## v0.9.0
 
 For an introduction and commentary, see the [0.9.0 release report]. For the full
 list of commits, see the [0.9.0] release page. The most significant changes of
@@ -287,7 +292,7 @@ For details concerning all footer changes, see [#1818].
 [union file system]:
   https://gohugo.io/getting-started/directory-structure/#union-file-system
 
-## 0.8.0
+## v0.8.0
 
 For the full list of changes, see the [0.8.0] release page.
 
@@ -325,7 +330,7 @@ For the full list of changes, see the [0.8.0] release page.
 [User feedback]:
   https://www.docsy.dev/docs/adding-content/feedback/#user-feedback
 
-## 0.7.2
+## v0.7.2
 
 For the full list of changes, see the [0.7.2] release page. We mention some
 noteworthy changes here:
@@ -354,7 +359,7 @@ noteworthy changes here:
 [Tabbed panes]:
   https://www.docsy.dev/docs/adding-content/shortcodes/#tabbed-panes
 
-## 0.7.1
+## v0.7.1
 
 For the full list of changes, see the [0.7.1] release page.
 
@@ -369,7 +374,7 @@ Followup changes to **Bootstrap (BS) 5.2 upgrade** ([#470]):
 [#1579]: https://github.com/google/docsy/issues/1579
 [0.7.1]: https://github.com/google/docsy/releases/v0.7.1
 
-## 0.7.0
+## v0.7.0
 
 For the full list of changes, see the [0.7.0] release page.
 
@@ -435,7 +440,7 @@ For the full list of changes, see the [0.7.0] release page.
 [bsv5mig]: https://getbootstrap.com/docs/5.2/migration/
 [hugo-releases]: https://github.com/gohugoio/hugo/releases
 
-## 0.6.0
+## v0.6.0
 
 For the full list of changes, see the [0.6.0] release page.
 
@@ -456,7 +461,7 @@ Bootstrap version. See [the announcement][bs-announcement] for more information.
 [0.6.0]: https://github.com/google/docsy/releases/v0.6.0
 [bs-announcement]: https://github.com/google/docsy/discussions/1308
 
-## 0.5.1
+## v0.5.1
 
 For the full list of changes, see the [0.5.1] release page. **BREAKING CHANGES**
 are documented below.
@@ -507,11 +512,11 @@ are documented below.
 [upgraded fontawesome]: https://fontawesome.com/docs/web/setup/upgrade/
 [what's changed]: https://fontawesome.com/docs/web/setup/upgrade/whats-changed
 
-## 0.5.0
+## v0.5.0
 
 Unpublished.
 
-## 0.4.0
+## v0.4.0
 
 For the full list of changes, see the [0.4.0] release page. Potential **BREAKING
 CHANGES** are documented below.
@@ -567,7 +572,7 @@ Proceed as usual to build or serve your site.
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
 
-## 0.3.0
+## v0.3.0
 
 For the full list of changes, see the [0.3.0] release page.
 
@@ -586,7 +591,7 @@ For the full list of changes, see the [0.3.0] release page.
 [#1009]: https://github.com/google/docsy/pull/1009
 [issue #1154]: https://github.com/google/docsy/issues/1154
 
-## 0.2.0
+## v0.2.0
 
 For the full list of changes, see the [0.2.0] release page.
 
@@ -608,7 +613,7 @@ For the full list of changes, see the [0.2.0] release page.
 <!-- ENTRY TEMPLATE ------------------------------------------------------
 
 ```
-## 0.X.Y
+## v0.X.Y
 
 > **UNRELEASED: this planned version is still under development**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ repo.
       ## Release summary
 
       - [Release report](https://www.docsy.dev/blog/2024/0.X.Y/)
-      - [CHANGELOG](https://github.com/google/docsy/blob/main/CHANGELOG.md#0XY)
+      - [CHANGELOG](https://github.com/google/docsy/blob/main/CHANGELOG.md#v0XY)
       ```
 
     - Select **Create a discussion for this release**.

--- a/docsy.dev/.htmltest.yml
+++ b/docsy.dev/.htmltest.yml
@@ -27,3 +27,4 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - ^https://code.jquery.com
   # TODO: remove once the 0.130.0 is released
   - ^https://www.docsy.dev/blog/2025/0.13.0/
+  - ^/blog/2025/0.13.0/#scrollspy-bug

--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -109,7 +109,7 @@ related to Bootstrap, such as:
   required
 
 For the complete list of changes, see the
-[CHANGELOG at 0.7.0](https://github.com/google/docsy/blob/main/CHANGELOG.md#070).
+[CHANGELOG at 0.7.0](https://github.com/google/docsy/blob/main/CHANGELOG.md#v070).
 
 ## Case studies
 

--- a/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
+++ b/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
@@ -225,7 +225,7 @@ change to a ​​`media-breakpoint-down()` argument, as discussed earlier.
 During the migration effort we seized the opportunity to do some long overdue
 Docsy house cleaning. For details concerning both breaking and non-breaking
 Docsy-specific changes, consult the
-[changelog](https://github.com/google/docsy/blob/main/CHANGELOG.md#070). In
+[changelog](https://github.com/google/docsy/blob/main/CHANGELOG.md#v070). In
 particular, one non-breaking but important change to be aware of is:
 [[BSv5] Docsy variables cleanup ... PR #1462](https://github.com/google/docsy/pull/1462).
 
@@ -240,7 +240,7 @@ build of the Docsy User Guide: the
 After such a smoke test, we recommend systematically walking through the
 Bootstrap [migration page](https://getbootstrap.com/docs/5.2/migration/) as
 described above, and the Docsy
-[changelog](https://github.com/google/docsy/blob/main/CHANGELOG.md#070). I used
+[changelog](https://github.com/google/docsy/blob/main/CHANGELOG.md#v070). I used
 this approach for [opentelemetry.io](https://opentelemetry.io/), which was the
 first Docsy-based project to be upgraded with a pre-release of Bootstrap-5-based
 Docsy. The upgrade went

--- a/docsy.dev/content/en/blog/2024/0.10.0.md
+++ b/docsy.dev/content/en/blog/2024/0.10.0.md
@@ -104,5 +104,5 @@ release, remember to upvote (with a thumbs up) the associated issue or PR.
 
 {{% /alert %}}
 
-[CL@0.10.0]: /project/changelog/#010
+[CL@0.10.0]: /project/changelog/#v010
 [0.10.0]: https://github.com/google/docsy/releases/tag/v0.10.0

--- a/docsy.dev/content/en/blog/2024/0.9.0.md
+++ b/docsy.dev/content/en/blog/2024/0.9.0.md
@@ -209,7 +209,7 @@ specifically:
 [#2]: https://github.com/google/docsy/issues/2
 [blocks/feature]:
   https://www.docsy.dev/docs/adding-content/shortcodes/#blocksfeature
-[CL@0.9.0]: /project/changelog/#090
+[CL@0.9.0]: /project/changelog/#v090
 [functions]: https://gohugo.io/functions/
 [hook]: https://gohugo.io/templates/render-hooks/
 [Hugo 0.112.0]: https://github.com/gohugoio/hugo/releases/tag/v0.112.0

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -22,8 +22,8 @@ In this post you'll walk through the upgrade process for:
 - **[Hugo](#update-hugo)**: 0.136.2 → 0.147.5&nbsp;[^vers-note]
 - **[Node](#update-nodejs)**: LTS 20 → LTS 22&nbsp;[^vers-note]
 
-[0.11.0]: /project/changelog/#0110
-[0.12.0]: /project/changelog/#0120
+[0.11.0]: /project/changelog/#v0110
+[0.12.0]: /project/changelog/#v0120
 
 [^vers-note]:
     These are the officially supported Node.js and Hugo versions associated with
@@ -177,7 +177,7 @@ The following commands can help you move your custom layout files and folders
 
 ## Check for additional required changes
 
-### 1. Image fingerprints
+### 1. Image fingerprints {#image-fingerprints}
 
 Skip this step if your project's CSS/SCSS does **not** use `blocks/cover`
 [hero/background images][images].
@@ -205,7 +205,7 @@ files, you need to:
 
 For CLI commands, see the [Move layout files](#move-layout-files) step.
 
-### 3. Internal layout `content.html` file rename
+### 3. Internal layout `content.html` file rename {#content-html-rename}
 
 If your project overrides Docsy `layouts/**/content.html` files:
 
@@ -258,7 +258,7 @@ Use this checklist to verify that your upgrade succeeded:
 
 For the full release notes, see:
 
-- [Docsy v0.12.0 changelog](/project/changelog/#0120)
+- [Docsy v0.12.0 changelog](/project/changelog/#v0120)
 - [Hugo release notes](https://github.com/gohugoio/hugo/releases) from 0.136.2
   (or your starting Hugo version) to 0.147.5.
 
@@ -266,7 +266,7 @@ Other references:
 
 - [Hugo 0.146.0 template system][NTS]
 - [0.11.0 release highlights](../2024/year-in-review/#release-highlights)
-- [0.11.0 changelog](/project/changelog/#0110)
+- [0.11.0 changelog](/project/changelog/#v0110)
 - [Docsy issue #2243][#2243], _Adapt to new template system in Hugo v0.146.0_.
 
 [#2243]: https://github.com/google/docsy/issues/2243

--- a/docsy.dev/content/en/docs/adding-content/feedback.md
+++ b/docsy.dev/content/en/docs/adding-content/feedback.md
@@ -121,7 +121,7 @@ As of Docsy version [0.8.0], feedback will be enabled whether
 `site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
 case where analytics is configured outside of Docsy.
 
-[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
+[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#v080
 
 {{% /alert %}}
 
@@ -183,7 +183,7 @@ Page feedback is reported to Google Analytics through [events].
 As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful`
 events, rather than `click` events.
 
-[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
+[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#v080
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/adding-content/navigation.md
+++ b/docsy.dev/content/en/docs/adding-content/navigation.md
@@ -171,16 +171,33 @@ You can find out more in the guide to
 
 If your site is [multilingual], Docsy adds a **language selector menu** to the
 navbar. Selecting a language takes the user to the translated version of the
-current page, or the home page for the given language. The menu is visible for
-all screen sizes. By default, the current site language name is shown. On narrow
-displays, this is replaced by the language code.
+current page, or the home page for the given language. The menu is visible in
+the navbar for all screen sizes.
+
+By default, the current site language name is shown. On narrow displays, this is
+replaced by the language code.
 
 You can find out more in [Multi-language support](/docs/language/).
 
-Prior to Docsy 0.13.0, the language selector menu was displayed in the left
-sidebar on narrow screens. As of Docsy 0.13.0, it remains hidden. To restore the
-legacy behavior, set the optional parameter `.ui.sidebar_lang_menu` to `true` in
-your site configuration.
+{{% alert title="Legacy UX" color="info" %}}
+
+Prior to Docsy 0.13.0, the language selector menu was displayed as follows.
+
+| Location     | Default visibility | Visibility on narrow screens |
+| ------------ | ------------------ | ---------------------------- |
+| Navbar       | Visible            | Hidden                       |
+| Left sidebar | Hidden             | Visible                      |
+
+To restore the legacy behavior:
+
+set the optional parameter `.ui.sidebar_lang_menu` to `true` in your site
+configuration.
+
+- In the left sidebar on narrow screens. As of Docsy 0.13.0, it remains hidden.
+  To restore the legacy behavior, set the optional parameter
+  `.ui.sidebar_lang_menu` to `true` in your site configuration.
+
+{{% /alert %}}
 
 [multilingual]: https://gohugo.io/content-management/multilingual/
 
@@ -531,31 +548,16 @@ options][] and the discussion in [Bootstrap issue #34958][bs-34958].
 
 {{% /alert %}}
 
-#### <i class="fa-solid fa-exclamation-triangle fa-lg text-warning px-1"></i> Current ScrollSpy limitations
+{{% alert title="<i class='fa-solid fa-exclamation-triangle fa-lg px-1'></i> Current ScrollSpy bug" color=warning %}}
 
-##### Headings starting with numbers
+As of Docsy 0.13.0, ScrollSpy fails if a page contains heading IDs that start
+with a digit. As a result, active TOC entry tracking will not work for that
+page. For details, see [ScrollSpy bug][].
 
-ScrollSpy will **throw an exception** if a heading ID starts with a digit, which
-usually happens because the heading text itself starts with a number.
+[ScrollSpy bug]: /blog/2025/0.13.0/#scrollspy-bug
 
-If you encounter this issue, you can try one of the following workarounds:
+{{% /alert %}}
 
-- Explicitly set the heading ID using the attribute syntax `{#id}` to avoid the
-  leading digit. For example, prefix the ID with a hyphen:
-
-  ```markdown
-  # 1. Introduction {#-1-introduction}
-  ```
-
-- Change the heading text so that it doesn't start with a number.
-
-- Disable ScrollSpy for affected pages by setting `ui.scrollSpy.disable: true`
-  in the page front matter.
-
-For the technical details behind this limitation, see [TOC scrolling results in
-runtime error when heading ID starts with a digit (#2329)][#2329].
-
-[#2329]: https://github.com/google/docsy/issues/2329
 [cascade]: https://gohugo.io/content-management/front-matter/#cascade-1
 [IntersectionObserver API]:
   https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver

--- a/docsy.dev/content/en/docs/adding-content/repository-links.md
+++ b/docsy.dev/content/en/docs/adding-content/repository-links.md
@@ -403,7 +403,7 @@ for your project.
 
 Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
 
-[v0.9.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#090
+[v0.9.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#v090
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -346,7 +346,7 @@ set the environment variable `DOCSY_MKDIR_HUGO_MOD_SKIP=1` before running NPM
 install.
 
 [#1120]: https://github.com/google/docsy/issues/1120
-[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#080
+[0.8.0]: https://github.com/google/docsy/blob/main/CHANGELOG.md/#v080
 [hugo module]: /docs/get-started/docsy-as-module/
 
 {{% /alert %}}

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -84,6 +84,9 @@ params:
     sidebar_menu_foldable: true
     sidebar_search_disable: false
     sidebar_root_enabled: true
+    scrollSpy:
+      # disable: true
+      # safeIds: false
     feedback:
       enable: true
       'yes': >-

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -675,6 +675,10 @@
     "StatusCode": 200,
     "LastSeen": "2025-10-06T11:42:12.345Z"
   },
+  "https://github.com/google/docsy/blob/main/CHANGELOG.md#v070": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-16T05:34:10.075948-05:00"
+  },
   "https://github.com/google/docsy/blob/main/CHANGELOG.md/#080": {
     "StatusCode": 200,
     "LastSeen": "2025-10-06T11:42:12.345Z"
@@ -682,6 +686,14 @@
   "https://github.com/google/docsy/blob/main/CHANGELOG.md/#090": {
     "StatusCode": 200,
     "LastSeen": "2025-10-06T11:42:12.345Z"
+  },
+  "https://github.com/google/docsy/blob/main/CHANGELOG.md/#v080": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-16T05:34:10.115248-05:00"
+  },
+  "https://github.com/google/docsy/blob/main/CHANGELOG.md/#v090": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-16T05:34:10.099688-05:00"
   },
   "https://github.com/google/docsy/blob/main/CONTRIBUTING.md": {
     "StatusCode": 206,
@@ -1219,6 +1231,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-08-02T17:12:43.051065-04:00"
   },
+  "https://github.com/google/docsy/pull/2364": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T19:45:06.164034-05:00"
+  },
+  "https://github.com/google/docsy/pull/2366": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T19:45:06.164029-05:00"
+  },
   "https://github.com/google/docsy/pull/941": {
     "StatusCode": 206,
     "LastSeen": "2025-06-10T18:59:25.465236-04:00"
@@ -1270,6 +1290,10 @@
   "https://github.com/google/docsy/releases/v0.12.0": {
     "StatusCode": 206,
     "LastSeen": "2025-05-27T12:33:39.089373-04:00"
+  },
+  "https://github.com/google/docsy/releases/v0.13.0": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-14T12:01:21.148819-05:00"
   },
   "https://github.com/google/docsy/releases/v0.2.0": {
     "StatusCode": 200,
@@ -1694,6 +1718,10 @@
   "https://github.com/theupdateframework/theupdateframework.io/pull/105": {
     "StatusCode": 200,
     "LastSeen": "2024-12-12T10:10:47.645841-05:00"
+  },
+  "https://github.com/theupdateframework/theupdateframework.io/pull/126": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-14T11:08:52.393954-05:00"
   },
   "https://github.com/twbs/bootstrap/blob/v5.2.3/scss/_functions.scss": {
     "StatusCode": 206,
@@ -2392,32 +2420,32 @@
     "LastSeen": "2025-10-06T11:55:12.345Z"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:03.490464-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.517725-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#accessibility": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:05.649648-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.992216-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#active-toc-entry-tracking": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:03.744578-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.824226-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#alert-shortcode": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:03.662235-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.677853-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#breaking-changes": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:06.695952-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:46.082539-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#language-menu-visibility": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:03.575377-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.592858-05:00"
   },
   "https://www.docsy.dev/blog/2025/0.13.0/#section-sidebar-root": {
-    "StatusCode": 404,
-    "LastSeen": "2025-11-15T13:13:03.830801-05:00"
+    "StatusCode": 206,
+    "LastSeen": "2025-11-15T14:02:45.90823-05:00"
   },
   "https://www.docsy.dev/blog/index.xml": {
     "StatusCode": 206,

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -48,23 +48,23 @@
       </li>
       {{ end -}}
       {{ if .Site.Params.versions -}}
-      <li class="nav-item dropdown d-none d-lg-block">
+      <li class="nav-item dropdown d-none d-lg-block td-navbar__version-menu ">
         {{ partial "navbar-version-selector.html" . -}}
       </li>
       {{ end -}}
       {{ if (gt (len .Site.Home.Translations) 0) -}}
-      <li class="nav-item">
+      <li class="nav-item td-navbar__lang-menu">
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}
       {{ if .Site.Params.ui.showLightDarkModeMenu -}}
-      <li class="nav-item">
+      <li class="nav-item td-navbar__light-dark-menu">
         {{ partial "theme-toggler" . }}
       </li>
       {{ end -}}
     </ul>
   </div>
-  <div class="d-none d-lg-block">
+  <div class="d-none d-lg-block td-navbar__search">
     {{ partial "search-input.html" . }}
   </div>
 </div>

--- a/layouts/_partials/td/render-heading.html
+++ b/layouts/_partials/td/render-heading.html
@@ -1,5 +1,42 @@
+{{/*
+
+FIXME: This is a temporary hack to adjust the heading IDs until Bootstrap fixes
+ScrollSpy. For details, see https://github.com/google/docsy/issues/2329.
+
+*/ -}}
+
+{{ $id := .Anchor -}}
+{{ $scrollSpyEnabled := not (site.Param "ui.scrollSpy.disable") -}}
+{{ $safeIds := site.Param "ui.scrollSpy.safeIds" | default $scrollSpyEnabled -}}
+{{ if $scrollSpyEnabled -}}
+  {{/* Rough 'CSS-safe ID' check:
+      - must start with a letter or underscore
+      - then only letters, digits, underscore, or dash
+  */ -}}
+  {{ if not (findRE `^[A-Za-z_][A-Za-z0-9_-]*$` $id) -}}
+    {{ $extraInfo := "" -}}
+    {{ if and $safeIds (findRE `^[0-9]` $id) -}}
+      {{ $id = add "_toc_id_patch_" $id -}}
+      {{ $extraInfo = printf "The ID was modified to: %q." $id -}}
+    {{ else if not $safeIds -}}
+      {{ $extraInfo = "Active TOC entry tracking may not work for this page." -}}
+    {{ end -}}
+    {{ $msg := slice
+      (printf "heading ID %q on page %q is not a valid CSS-selector." .Anchor .Page.RelPermalink)
+      $extraInfo
+      "For details, see https://www.docsy.dev/blog/2025/0.13.0/."
+    -}}
+    {{/* Disable for now. Warning is printed by toc.html.
+      warnidf "scrollspy-heading-id" "[Docsy] %s" (delimit $msg " ")
+    */ -}}
+  {{ end -}}
+{{ end -}}
+
 <h{{ .Level }}
   {{- range $key, $value := .Attributes -}}
+    {{ if and $safeIds (eq $key "id") -}}
+      {{ $value = $id -}}
+    {{ end -}}
     {{ printf " %s=%q" $key (string $value) | safeHTMLAttr -}}
   {{ end -}}
 >

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -1,12 +1,40 @@
+{{/*
+
+  FIXME: This is a temporary hack to adjust the heading IDs until Bootstrap fixes
+  ScrollSpy. For details, see:
+
+  - https://www.docsy.dev/blog/2025/0.13.0
+  - https://github.com/google/docsy/issues/2329
+
+  cSpell:ignore notoc
+*/ -}}
+
+{{ $scrollSpyEnabled := not (.Param "ui.scrollSpy.disable") -}}
+{{ $safeIds := .Param "ui.scrollSpy.safeIds" | default $scrollSpyEnabled -}}
+
 {{ if not .Params.notoc -}}
+  {{ $page := . }}
   {{ with .TableOfContents -}}
     {{ if ne . `<nav id="TableOfContents"></nav>` -}}
-      <div class="td-toc">
+      <div class="td-toc" data-proofer-ignore>
         <div class="td-toc__title">
           <span class="td-toc__title__text">On this page</span>
           <a class="td-toc__title__link" title="Top of page" href="#"></a>
         </div>
-        {{ . }}
+        {{ $toc := . -}}
+        {{ if $safeIds -}}
+          {{/* Adjust any href values that start with a digit by adding a prefixing */ -}}
+          {{ $toc = replaceRE `(href="#)([0-9])` "${1}_toc_id_patch_$2" $toc -}}
+        {{ else if $scrollSpyEnabled -}}
+          {{ with findRE `href="#[0-9][^"]*"` . -}}
+            {{ $msg := slice
+              (printf "%s: TOC contains href that may cause ScrollSpy to fail: %s." $page.File.Filename .)
+              "For details, see https://www.docsy.dev/blog/2025/0.13.0/."
+            -}}
+            {{ warnidf "scrollspy-toc-href" "[Docsy] %s" (delimit $msg " ") -}}
+          {{ end -}}
+        {{ end -}}
+        {{ $toc | safeHTML }}
       </div>
     {{ end -}}
   {{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+48-g4d72b4b",
+  "version": "0.13.0-dev+49-gada99ce",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -31,8 +31,9 @@
     "docsy.dev-install": "npm run _cd:docsy.dev -- npm install",
     "fix-and-test": "echo 'RUNNING FIX AND TESTS...'; npm run fix && npm run test:website",
     "fix:format": "npm run _check:format -- --write && npm run cd:docsy.dev fix:format",
+    "fix:markdown": "npm run check:markdown -- --fix",
     "fix:version": "npm run set:package-version -- --id $(scripts/get-build-id.sh)",
-    "fix": "npm run fix:format && npm run fix:version && npm run cd:docsy.dev fix",
+    "fix": "npm run fix:format && npm run fix:markdown && npm run fix:version && npm run cd:docsy.dev fix",
     "get:hugo-modules": "node scripts/getHugoModules/index.mjs",
     "postinstall": "npm run _mkdir:hugo-mod",
     "serve": "npm run _cd:docsy.dev -- npm run serve",

--- a/tasks/0.13/hugo-upgrade-notes.md
+++ b/tasks/0.13/hugo-upgrade-notes.md
@@ -119,9 +119,12 @@ The `--omitEmpty` flag on the `chromastyles` command is deprecated. A new
 
 ## Summary for Docsy clients
 
-The main breaking change to be aware of is the file mount validation in
-v0.152.0, which was fixed in v0.152.2. If you use file mounts (especially for
-`node_modules`), ensure you're using v0.152.2 or later.
+The main breaking change to be aware of is the file mount validation in v0.152.0
+([#2347]), which was fixed in v0.152.2. Docsy 0.13.0 does not work with Hugo
+0.152.0 or 0.152.1; if you use file mounts (especially for `node_modules`),
+ensure you're using Hugo v0.152.2 or later.
+
+[#2347]: https://github.com/google/docsy/issues/2347
 
 The TOC rendering improvements in v0.149.0 may cause minor visual differences
 but should improve consistency.


### PR DESCRIPTION
- Contributes to: #2266
- Implements a **workaround** for #2329
- Adjusts the heading text in various pages so that they don't start with a digit