### PR TITLE
Add _param.html shortcode

### DIFF
--- a/layouts/_shortcodes/_param.html
+++ b/layouts/_shortcodes/_param.html
@@ -1,0 +1,41 @@
+{{/*
+
+@param {string} [0] The name of the parameter to look up and embed.
+@param {string} [1...] Optional numbered arguments to replace {0}, {1}, {2}, etc. in the parameter value.
+                        {0} corresponds to the parameter name itself.
+
+This shortcode looks up a parameter by name from site params or page params
+and outputs its raw content, so that any HTML is not escaped. Numbered
+placeholders like {0}, {1}, {2}, etc. in the parameter value are replaced with
+the corresponding numbered arguments. {0} is replaced with the parameter name.
+
+Usage:
+  {{% _param paramName %}}
+  {{% _param paramName arg1 arg2 %}}
+
+NOTE: This is currently an Docsy-private shortcode.
+*/ -}}
+
+{{ $position := .Position -}}
+{{ $paramName := .Get 0 | default (.Get "name") -}}
+{{ $paramValue := $.Page.Param $paramName | string -}}
+{{ if not $paramName -}}
+  {{ errorf "%s: shortcode '_param': parameter name is missing" $position -}}
+{{ else if not $paramValue -}}
+  {{ errorf "%s: shortcode '_param': parameter %q not found in page or site params" $position $paramName -}}
+{{ end -}}
+
+{{ $result := $paramValue -}}
+{{ range $i, $v := .Params -}}
+  {{ $placeholder := printf "{%d}" $i -}}
+  {{ $replacement := $v | string -}}
+  {{ $result = replace $result $placeholder $replacement -}}
+{{ end -}}
+
+{{/* After replacements, check for any unresolved numeric placeholders. */ -}}
+{{ $unresolved := findRE `\{(\d+)\}` $result -}}
+{{ if gt (len $unresolved) 0 -}}
+  {{ warnf "%s: shortcode '_param' %q: unresolved placeholder(s) %q in value %q" $position $paramName (delimit $unresolved ", ") $paramValue -}}
+{{ end -}}
+
+{{ $result | safeHTML -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+49-gada99ce",
+  "version": "0.13.0-dev+50-gf23f1ab",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2266
- Adds `_param` internal/Docsy-private shortcode that is like Hugo's `param`, but:
  - Allows for `safeHTML` in the parameter value
  - Supports placeholder arguments `{0}`, `{1}`, ...