### PR TITLE
fix: TOC entry colors in light mode when system is in dark mode

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -90,12 +90,13 @@
       &.active {
         color: var(--bs-primary);
         border-left-color: var(--bs-primary);
-        background-color: var(--bs-secondary-bg-subtle);
+        background-color: var(--bs-tertiary-bg);
       }
 
       &:focus,
       &:hover {
-        color: initial;
+        color: var(--bs-nav-link-disabled-color);
+        background-color: var(--bs-secondary-bg-subtle);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+53-g217fde4",
+  "version": "0.13.0-dev+54-g9da0354",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2365
- Fixes bg color for active TOC entries, as well as for entry hover and focus
- Fixes text color for focus and hover
- Also improves the contrast of the active TOC entry

### Screenshot

For a before screenshot, see #2365.

After: the TOC entry with a light gray bg is the one that is being hovered over

> <img width="248" height="315" alt="image" src="https://github.com/user-attachments/assets/8f12882f-9065-4b1a-a2ff-b42a350fe0c0" />
