### PR TITLE
fix: TOC entry color contrast, even better

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -88,14 +88,15 @@
       color: var(--bs-secondary-color);
 
       &.active {
-        color: var(--bs-primary);
+        color: var(--bs-primary-text-emphasis);
         border-left-color: var(--bs-primary);
         background-color: var(--bs-tertiary-bg);
       }
 
       &:focus,
       &:hover {
-        color: var(--bs-nav-link-disabled-color);
+        // Possible alternative color:
+        // color: var(--bs-nav-link-disabled-color);
         background-color: var(--bs-secondary-bg-subtle);
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+54-g9da0354",
+  "version": "0.13.0-dev+55-g2c84dd3",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes color contrast issues for table of contents entries in dark mode.
- Companion / followup to #2376

Details:

- Active state now uses `var(--bs-primary-text-emphasis)` for better contrast
- Removed hover/focus text color; falling back to the non-hover/focused color since the background color is changing, and that's enough.

### Screenshot

Before (left), and after (right)

> <img width="593" height="150" alt="image" src="https://github.com/user-attachments/assets/9acc4683-fb68-497e-897a-81fc55e4fdc5" />
