### PR TITLE
Apply dark-mode color adjustments to the UG

### DIFF
--- a/assets/scss/td/_color-adjustments-dark.scss
+++ b/assets/scss/td/_color-adjustments-dark.scss
@@ -10,7 +10,7 @@
 
 // The following value makes sense for the Bootstrap base theme. Projects will
 // likely need to adjust this.
-$lighten-amount-for-dark-color-variant: 28% !default;
+$lighten-amount-for-dark-color-variant: 22% !default;
 
 $primary-dark: lighten($primary, $lighten-amount-for-dark-color-variant) !default;
 // $secondary-dark: lighten($secondary, $lighten-amount-for-dark-color-variant) !default;

--- a/docsy.dev/assets/scss/_styles_project.scss
+++ b/docsy.dev/assets/scss/_styles_project.scss
@@ -1,1 +1,2 @@
+@import 'td/color-adjustments-dark';
 @import 'td/code-dark';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+56-g40e1ad0",
+  "version": "0.13.0-dev+57-g4990bc1",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Enables use of the dark-mode color adjustments in the docsy.dev site
- Tweaks the base lighten %