### PR TITLE
Remove ScrollSpy safeIds workaround and related docs

### DIFF
--- a/docsy.dev/content/en/docs/adding-content/navigation.md
+++ b/docsy.dev/content/en/docs/adding-content/navigation.md
@@ -595,16 +595,6 @@ options][] and the discussion in [Bootstrap issue #34958][bs-34958].
 
 {{% /alert %}}
 
-{{% alert title="<i class='fa-solid fa-exclamation-triangle fa-lg px-1'></i> Current ScrollSpy bug" color=warning %}}
-
-As of Docsy 0.13.0, ScrollSpy fails if a page contains heading IDs that start
-with a digit. As a result, active TOC entry tracking will not work for that
-page. For details, see [ScrollSpy bug][].
-
-[ScrollSpy bug]: /blog/2025/0.13.0/#scrollspy-bug
-
-{{% /alert %}}
-
 [cascade]: https://gohugo.io/content-management/front-matter/#cascade-1
 [IntersectionObserver API]:
   https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -84,9 +84,6 @@ params:
     sidebar_menu_foldable: true
     sidebar_search_disable: false
     sidebar_root_enabled: true
-    scrollSpy:
-      # disable: true
-      safeIds: false
     feedback:
       enable: true
       'yes': >-

--- a/layouts/_partials/td/render-heading.html
+++ b/layouts/_partials/td/render-heading.html
@@ -1,42 +1,5 @@
-{{/*
-
-FIXME: This is a temporary hack to adjust the heading IDs until Bootstrap fixes
-ScrollSpy. For details, see https://github.com/google/docsy/issues/2329.
-
-*/ -}}
-
-{{ $id := .Anchor -}}
-{{ $scrollSpyEnabled := not (site.Param "ui.scrollSpy.disable") -}}
-{{ $safeIds := site.Param "ui.scrollSpy.safeIds" | default $scrollSpyEnabled -}}
-{{ if $scrollSpyEnabled -}}
-  {{/* Rough 'CSS-safe ID' check:
-      - must start with a letter or underscore
-      - then only letters, digits, underscore, or dash
-  */ -}}
-  {{ if not (findRE `^[A-Za-z_][A-Za-z0-9_-]*$` $id) -}}
-    {{ $extraInfo := "" -}}
-    {{ if and $safeIds (findRE `^[0-9]` $id) -}}
-      {{ $id = add "_toc_id_patch_" $id -}}
-      {{ $extraInfo = printf "The ID was modified to: %q." $id -}}
-    {{ else if not $safeIds -}}
-      {{ $extraInfo = "Active TOC entry tracking may not work for this page." -}}
-    {{ end -}}
-    {{ $msg := slice
-      (printf "heading ID %q on page %q is not a valid CSS-selector." .Anchor .Page.RelPermalink)
-      $extraInfo
-      "For details, see https://www.docsy.dev/blog/2025/0.13.0/."
-    -}}
-    {{/* Disable for now. Warning is printed by toc.html.
-      warnidf "scrollspy-heading-id" "[Docsy] %s" (delimit $msg " ")
-    */ -}}
-  {{ end -}}
-{{ end -}}
-
 <h{{ .Level }}
   {{- range $key, $value := .Attributes -}}
-    {{ if and $safeIds (eq $key "id") -}}
-      {{ $value = $id -}}
-    {{ end -}}
     {{ printf " %s=%q" $key (string $value) | safeHTMLAttr -}}
   {{ end -}}
 >

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -1,10 +1,6 @@
 {{/*
 
-  FIXME: The $safeIds functionality is a temporary workaround for the ScrollSpy
-  bug described in https://github.com/google/docsy/issues/2329. For details,
-  also see https://www.docsy.dev/blog/2025/0.13.0.
-
-  Always render the dev.td-toc element. ScrollSpy is counting on it to exist,
+  Always render the td-toc element. ScrollSpy is counting on it to exist,
   even if it's empty.
 
   cSpell:ignore notoc
@@ -14,24 +10,10 @@
 {{ if not .Params.notoc -}}
   {{ $toc := .TableOfContents -}}
   {{ if and $toc (ne $toc `<nav id="TableOfContents"></nav>`) -}}
-    {{ $scrollSpyEnabled := not (.Param "ui.scrollSpy.disable") -}}
-    {{ $safeIds := .Param "ui.scrollSpy.safeIds" | default $scrollSpyEnabled -}}
     <div class="td-toc__title">
       <span class="td-toc__title__text">On this page</span>
       <a class="td-toc__title__link" title="Top of page" href="#"></a>
     </div>
-    {{ if $safeIds -}}
-      {{/* Adjust any href values that start with a digit by adding a prefixing */ -}}
-      {{ $toc = replaceRE `(href="#)([0-9])` "${1}_toc_id_patch_$2" $toc -}}
-    {{ else if $scrollSpyEnabled -}}
-      {{ with findRE `href="#[0-9][^"]*"` . -}}
-        {{ $msg := slice
-          (printf "%s: TOC contains href that may cause ScrollSpy to fail: %s." .File.Filename .)
-          "For details, see https://www.docsy.dev/blog/2025/0.13.0/."
-        -}}
-        {{ warnidf "scrollspy-toc-href" "[Docsy] %s" (delimit $msg " ") -}}
-      {{ end -}}
-    {{ end -}}
     {{ $toc | safeHTML }}
   {{ end -}}
 {{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+58-g8979f79",
+  "version": "0.13.0-dev+60-g2570ad5",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Followup to #2382
- Fixes #2329. I'm going to consider the issue fixed.
  > **NOTE**: If/once ScrollSpy gets fixed, we can remove the patching code added via #2382
- Carefully reverts the relevant parts of #2370 while preserving #2373.
- Eliminates the temporary safeIds workaround for ScrollSpy issues with heading IDs starting with digits. Cleanes up related documentation, configuration, and template logic now that the workaround is no longer needed.