### PR TITLE
Refactor dark mode config, add experimental style-only option

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,4 +1,4 @@
-// cSpell:ignore pageinfo
+// cSpell:ignore fontawesome pageinfo
 
 @import "../vendor/bootstrap/scss/functions";
 

--- a/docsy.dev/content/en/docs/adding-content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/adding-content/lookandfeel.md
@@ -474,6 +474,7 @@ illustrated in the following example:
 The example above uses [Markdown attribute][] syntax, and might render like
 this:
 
+<!-- markdownlint-disable table-pipe-style table-column-count -->
 <!-- prettier-ignore-start -->
 | Shape    | Number of sides |
 | -------- | --------------- |

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -79,7 +79,11 @@ params:
   search:
     # algolia:
   ui:
-    showLightDarkModeMenu: true
+    # showLightDarkModeMenu param values:
+    showLightDarkModeMenu:
+      true # default
+      # false # disable
+      # 'enable-only (experimental)'
     sidebar_menu_compact: true
     sidebar_menu_foldable: true
     sidebar_search_disable: false

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -463,6 +463,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:34.090741-05:00"
   },
+  "https://getbootstrap.com/docs/5.3/customize/color-modes/#building-with-sass": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-18T12:25:52.56686-05:00"
+  },
   "https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.534269-05:00"
@@ -474,6 +478,10 @@
   "https://getbootstrap.com/docs/5.3/customize/color/#color-sass-maps": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.809637-05:00"
+  },
+  "https://getbootstrap.com/docs/5.3/customize/color/#theme-colors": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-18T12:25:53.239647-05:00"
   },
   "https://getbootstrap.com/docs/5.3/customize/sass/#maps-and-loops": {
     "StatusCode": 206,
@@ -726,6 +734,10 @@
   "https://github.com/google/docsy/blob/main/assets/scss/_variables_project_after_bs.scss": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:36.3649-05:00"
+  },
+  "https://github.com/google/docsy/blob/main/assets/scss/td/_color-adjustments-dark.scss": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-18T12:25:53.067637-05:00"
   },
   "https://github.com/google/docsy/blob/main/assets/scss/td/chroma/_dark.scss": {
     "StatusCode": 206,

--- a/layouts/_partials/dark-mode-config.html
+++ b/layouts/_partials/dark-mode-config.html
@@ -1,0 +1,51 @@
+{{/* Helper partial to get dark mode configuration with backward compatibility */ -}}
+
+{{/* Initialize to config defaults */}}
+{{ $darkModeConfig := dict "enable" false "showMenu" false -}}
+{{ $ui := site.Params.ui -}}
+{{ $menuConfig := $ui.showLightDarkModeMenu -}}
+
+{{ if eq $menuConfig "enable-only (experimental)" -}}
+  {{ warnidf "experimental-dark-mode-config" (printf "%s %s %s"
+    "Site config 'params.ui.showLightDarkModeMenu' is using 'enable-only (experimental)' mode."
+    "For details, see "
+    "https://www.docsy.dev/docs/adding-content/lookandfeel/#lightdark-mode-menu"
+  ) -}}
+  {{ $darkModeConfig = dict "enable" true "showMenu" false -}}
+{{ else if $menuConfig -}}
+  {{ $darkModeConfig = dict "enable" true "showMenu" true -}}
+{{/* else not $menuConfig,
+  fallthrough and use defaults */ -}}
+{{ end -}}
+
+
+{{/* The code below is unreachable atm. Keep it here for future reference. */}}
+{{/* Skip-start ================================================================= */}}
+{{ if false -}}
+{{ $paramUiDarkMode := $ui.darkMode -}}
+
+{{/* Check for deprecated showLightDarkModeMenu */ -}}
+{{ if ne $menuConfig nil -}}
+  {{ warnidf "deprecated-showLightDarkModeMenu" (printf
+    "%s %s %s"
+    "Site config 'params.ui.showLightDarkModeMenu' is deprecated:"
+    "use 'params.ui.darkMode.showMenu' or 'params.ui.darkMode.enable'. For details, see"
+    "https://www.docsy.dev/docs/adding-content/lookandfeel/#lightdark-mode-menu"
+  ) -}}
+{{ else if eq $paramUiDarkMode true -}}
+  {{/* Shorthand */ -}}
+  {{ $darkModeConfig = dict "enable" true "showMenu" true -}}
+{{ else if $paramUiDarkMode -}}
+  {{/* Use new configuration structure */ -}}
+  {{ $showMenu := $paramUiDarkMode.showMenu -}}
+  {{ $enable := $paramUiDarkMode.enable -}}
+  {{/* showMenu implies enable when not explicitly disabled */ -}}
+  {{ if and $showMenu (ne $enable false) -}}
+    {{ $enable = true -}}
+  {{ end -}}
+  {{ $darkModeConfig = dict "enable" $enable "showMenu" $showMenu -}}
+{{ end -}}
+{{ end -}}
+{{/* Skip-end ================================================================= */}}
+
+{{ return $darkModeConfig -}}

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -2,7 +2,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+{{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+{{ if $darkMode.enable -}}
 {{/* Browser hints before CSS loads */ -}}
 <meta name="color-scheme" content="light dark">
 <meta name="theme-color" media="(prefers-color-scheme: light)" content="#ffffff">

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -57,7 +57,8 @@
         {{ partial "navbar-lang-selector.html" . -}}
       </li>
       {{ end -}}
-      {{ if .Site.Params.ui.showLightDarkModeMenu -}}
+      {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+      {{ if $darkMode.showMenu -}}
       <li class="nav-item td-navbar__light-dark-menu">
         {{ partial "theme-toggler" . }}
       </li>

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -46,7 +46,8 @@ window.markmap = {
 {{- partial "scripts/mermaid.html" . -}}
 {{ end -}}
 
-{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+{{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+{{ if $darkMode.enable -}}
   {{ $jsArray = $jsArray | append (resources.Get "js/dark-mode.js") -}}
 {{ end -}}
 

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/blog/baseof.print.html
+++ b/layouts/blog/baseof.print.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/docs/baseof.print.html
+++ b/layouts/docs/baseof.print.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
   </head>

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -3,7 +3,8 @@
     {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
     {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
     class="no-js"
-    {{- if .Site.Params.ui.showLightDarkModeMenu }} data-theme-init{{ end }}>
+    {{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+    {{- if $darkMode.enable }} data-theme-init{{ end }}>
   <head>
     {{ partial "head.html" . }}
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+60-g2570ad5",
+  "version": "0.13.0-dev+61-gef50fd1",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -25,7 +25,7 @@
     "cd:docsy.dev": "echo 'Running in docsy.dev...'; npm run _cd:docsy.dev -- npm run",
     "check:format": "npm list prettier && npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",
     "check:links": "npm run _cd:docsy.dev -- npm run check:links",
-    "check:markdown": "npm run _check:markdown -- '{docsy.dev,.}/*.md' 'tasks/**/*.md'",
+    "check:markdown": "npm run _check:markdown -- '{docsy.dev,.}/*.md' 'tasks/**/*.md' docsy.dev/content/en/docs/adding-content/lookandfeel.md",
     "check": "npm run check:format && npm run check:markdown",
     "ci:post": "npm run fix-for-test && npm run _diff:check && npm run test:tooling",
     "ci:prepare": "npm run docsy.dev-install && npm run _prepare && npm run _diff:check",
@@ -66,5 +66,5 @@
   "engines": {
     "node": ">=24"
   },
-  "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark -"
+  "spelling": "cSpell:ignore docsy hugo fortawesome fontawesome onedark lookandfeel -"
 }


### PR DESCRIPTION
- Introduces a helper partial for dark mode configuration to support backward compatibility and experimental options. Updates all relevant templates to use the new config,
- I have checked that light and dark modes work for all options