### PR TITLE
Fix spacing of page meta due to new dark-mode meta elt

### DIFF
--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-{{- $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
+{{ $darkMode := partialCached "dark-mode-config.html" "dark-mode-global" -}}
 {{ if $darkMode.enable -}}
 {{/* Browser hints before CSS loads */ -}}
 <meta name="color-scheme" content="light dark">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+61-gef50fd1",
+  "version": "0.13.0-dev+62-g5891c6c",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Removes excess formatting that I missed in #2384