### PR TITLE
Add dark mode support for Google search

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,12 @@
-/assets
-!/assets/_cache
-# !/assets/js # soon
+# Note that Prettier ignore rules differ slightly from gitignore rules. The main
+# gotcha is that once a _directory_ is ignored, it's content cannot be
+# unignored.
+
+# Ignore all _files_ under assets
+/assets/**/*.*
+
+# Selectively unignore some files
+!/assets/scss/main.scss
+!/assets/scss/td/**/*
+
+/assets/scss/td/chroma/**/*

--- a/assets/scss/_search.scss
+++ b/assets/scss/_search.scss
@@ -83,6 +83,12 @@
     margin: 0;
     width: 100%;
   }
+
+  // FIXME: remove hardcoded column settings in the search layout.
+  &-result > div {
+    @extend .col-md-10;
+    @extend .offset-md-1;
+  }
 }
 
 // Offline search

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,44 +1,43 @@
 // cSpell:ignore fontawesome pageinfo
 
-@import "../vendor/bootstrap/scss/functions";
+@import '../vendor/bootstrap/scss/functions';
 
-@import "variables_forward";
-@import "variables_project";
-@import "variables";
-@import "support/mixins";
+@import 'variables_forward';
+@import 'variables_project';
+@import 'variables';
+@import 'support/mixins';
 
-@import "../vendor/bootstrap/scss/bootstrap";
-@import "support/bootstrap_vers_test";
+@import '../vendor/bootstrap/scss/bootstrap';
+@import 'support/bootstrap_vers_test';
 
-@import "../vendor/Font-Awesome/scss/fontawesome";
-@import "../vendor/Font-Awesome/scss/solid";
-@import "../vendor/Font-Awesome/scss/brands";
+@import '../vendor/Font-Awesome/scss/fontawesome';
+@import '../vendor/Font-Awesome/scss/solid';
+@import '../vendor/Font-Awesome/scss/brands';
 
-@import "variables_project_after_bs";
+@import 'variables_project_after_bs';
 
-@import "support/utilities";
-@import "colors";
-@import "table";
-@import "boxes";
-@import "blog";
-@import "code";
-@import "nav";
-@import "sidebar-tree";
-@import "sidebar-toc";
-@import "breadcrumb";
-@import "alerts";
-@import "content";
-@import "search";
-@import "main-container";
-@import "blocks/blocks";
-@import "section-index";
-@import "pageinfo";
-@import "taxonomy";
-@import "drawio";
-@import "shortcodes";
-@import "swagger";
-@import "support/rtl";
-
+@import 'support/utilities';
+@import 'colors';
+@import 'table';
+@import 'boxes';
+@import 'blog';
+@import 'code';
+@import 'nav';
+@import 'sidebar-tree';
+@import 'sidebar-toc';
+@import 'breadcrumb';
+@import 'alerts';
+@import 'content';
+@import 'search';
+@import 'main-container';
+@import 'blocks/blocks';
+@import 'section-index';
+@import 'pageinfo';
+@import 'taxonomy';
+@import 'drawio';
+@import 'shortcodes';
+@import 'swagger';
+@import 'support/rtl';
 
 @if $td-enable-google-fonts {
   @import url($td-web-font-path);
@@ -109,11 +108,11 @@
   h4[id]::before,
   h5[id]::before {
     display: block;
-    content: " ";
+    content: ' ';
     margin-top: -5rem;
     height: 5rem;
     visibility: hidden;
   }
 }
 
-@import "styles_project";
+@import 'styles_project';

--- a/assets/scss/td/_code-dark.scss
+++ b/assets/scss/td/_code-dark.scss
@@ -1,10 +1,13 @@
-[data-bs-theme="light"] {
-  @import 'td/chroma/light';
-}
+@if $enable-dark-mode {
+  [data-bs-theme='light'] {
+    @import 'td/chroma/light';
+  }
 
-[data-bs-theme="dark"] {
-  @import 'td/chroma/dark';
-  .chroma {
-    background-color: var(--td-pre-bg);
+  [data-bs-theme='dark'] {
+    @import 'td/chroma/dark';
+
+    .chroma {
+      background-color: var(--td-pre-bg);
+    }
   }
 }

--- a/assets/scss/td/_color-adjustments-dark.scss
+++ b/assets/scss/td/_color-adjustments-dark.scss
@@ -8,36 +8,41 @@
 // Usage: @import 'td/color-adjustments-dark'; // in client _styles_project.scss
 // =============================================================================
 
-// The following value makes sense for the Bootstrap base theme. Projects will
-// likely need to adjust this.
-$lighten-amount-for-dark-color-variant: 22% !default;
+@if $enable-dark-mode {
+  // The following value makes sense for the Bootstrap base theme. Projects will
+  // likely need to adjust this.
+  $lighten-amount-for-dark-color-variant: 22% !default;
 
-$primary-dark: lighten($primary, $lighten-amount-for-dark-color-variant) !default;
-// $secondary-dark: lighten($secondary, $lighten-amount-for-dark-color-variant) !default;
-// $success-dark: lighten($success, $lighten-amount-for-dark-color-variant) !default;
-// $info-dark: lighten($info, $lighten-amount-for-dark-color-variant) !default;
-// $warning-dark: lighten($warning, $lighten-amount-for-dark-color-variant) !default;
-// $danger-dark: lighten($danger, $lighten-amount-for-dark-color-variant) !default;
+  $primary-dark: lighten(
+    $primary,
+    $lighten-amount-for-dark-color-variant
+  ) !default;
+  // $secondary-dark: lighten($secondary, $lighten-amount-for-dark-color-variant) !default;
+  // $success-dark: lighten($success, $lighten-amount-for-dark-color-variant) !default;
+  // $info-dark: lighten($info, $lighten-amount-for-dark-color-variant) !default;
+  // $warning-dark: lighten($warning, $lighten-amount-for-dark-color-variant) !default;
+  // $danger-dark: lighten($danger, $lighten-amount-for-dark-color-variant) !default;
 
-[data-bs-theme='dark'] {
-  --bs-primary: #{$primary-dark} !important;
-  // --bs-success: #{$success-dark} !important;
+  [data-bs-theme='dark'] {
+    --bs-primary: #{$primary-dark} !important;
+    // --bs-success: #{$success-dark} !important;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tips 'n tricks
+  // ---------------------------------------------------------------------------
+
+  // If you need to adjust properties of a deeply nested class in dark mode, you
+  // can use the following syntax:
+
+  // .td-some-class {
+  //   .td-deeply-nested-class {
+  //     @at-root [data-bs-theme="dark"] #{&} {
+  //       // ...
+  //     }
+  //   }
+  // }
+
+  // Want to see the var value? Try:
+  // @warn "primary-dark: #{$primary-dark}";
 }
-
-// ---------------------------------------------------------------------------
-// Tips 'n tricks
-// ---------------------------------------------------------------------------
-
-// If you need to adjust properties of a deeply nested class in dark mode, you
-// can use the following syntax:
-
-// .td-some-class {
-//   .td-deeply-nested-class {
-//     @at-root [data-bs-theme="dark"] #{&} {
-//       // ...
-//     }
-//   }
-// }
-
-// Want to see the var value? Try:
-// @warn "primary-dark: #{$primary-dark}";

--- a/assets/scss/td/_gcs-search-dark.scss
+++ b/assets/scss/td/_gcs-search-dark.scss
@@ -1,0 +1,307 @@
+// Google Programmable Search Engine. Based on:
+//
+// - https://www.google.com/cse/static/style/look/v4/default.css
+// - https://www.google.com/cse/static/element/6467658b9628de43/default+en.css
+//
+// cSpell:ignore gcsc tabh refinementhActive subelements
+
+@if $enable-dark-mode {
+  /* ------------------------------------------------------------
+    * TD THEME VARIABLES
+    * ------------------------------------------------------------ */
+
+  :root {
+    /* Thematic alias vars for Google Programmable Search customization */
+    --td-gcs-primary: var(--bs-link-color, var(--bs-primary));
+    --td-gcs-secondary: var(--bs-secondary-color);
+    --td-gcs-bg: var(--bs-body-bg);
+    --td-gcs-text: var(--bs-body-color);
+    --td-gcs-border: var(--bs-border-color);
+    --td-gcs-success: var(--bs-success);
+    --td-gcs-radius: var(--bs-border-radius);
+  }
+
+  .gs-web-image-box {
+    margin-right: 0.5rem !important;
+  }
+
+  /* ------------------------------------------------------------
+  * Google Programmable Search – base typography (light and dark themes)
+  * ------------------------------------------------------------ */
+
+  .gsc-control-cse {
+    font-family: var(--bs-body-font-family, system-ui, sans-serif) !important;
+    font-size: var(--bs-body-font-size, 1rem) !important;
+    line-height: var(--bs-body-line-height, 1.5) !important;
+    color: var(--bs-body-color, #212529) !important;
+  }
+
+  /* Sub-elements: maintain consistent sizing */
+  .gsc-tabHeader,
+  .gsc-orderby,
+  .gsc-result-info,
+  .gs-snippet,
+  .gsc-refinementHeader,
+  .gsc-result {
+    font-size: var(--bs-body-font-size, 1rem) !important;
+    line-height: var(--bs-body-line-height, 1.5) !important;
+  }
+
+  /* Ensure Sort-by UI inherits the same size */
+  .gsc-orderby,
+  .gsc-orderby-label,
+  .gsc-selected-option-container,
+  .gsc-selected-option,
+  .gsc-option-menu-item {
+    font-size: var(--bs-body-font-size, 1rem) !important;
+    line-height: var(--bs-body-line-height, 1.5) !important;
+  }
+
+  /* Slightly larger for result titles */
+  .gs-title {
+    font-size: calc(var(--bs-body-font-size, 1rem) * 1.1) !important;
+    line-height: 1.4 !important;
+  }
+
+  /* ------------------------------------------------------------
+  * Google Programmable Search – dark-mode overrides
+  * ------------------------------------------------------------ */
+
+  [data-bs-theme='dark'] {
+    /* ------------------------------------------------------------
+    * ROOT / GENERAL
+    * ------------------------------------------------------------ */
+    .gsc-control-cse,
+    .gsc-control-cse .gsc-control-wrapper-cse {
+      background-color: var(--td-gcs-bg) !important;
+      color: var(--td-gcs-text) !important;
+      border: 0 !important;
+    }
+
+    .gsc-above-wrapper-area,
+    .gsc-tabsArea,
+    .gsc-refinementsArea {
+      border-bottom: 1px solid var(--td-gcs-border) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * SEARCH BOX
+    * ------------------------------------------------------------ */
+    .gsc-search-box {
+      background: transparent !important;
+    }
+
+    .gsc-input-box,
+    td.gsc-input {
+      background-color: var(--td-gcs-bg) !important;
+      border: 1px solid var(--td-gcs-border) !important;
+    }
+
+    input.gsc-input,
+    input.gsc-input:focus {
+      background-color: transparent !important;
+      color: var(--td-gcs-text) !important;
+      box-shadow: none !important;
+    }
+
+    input.gsc-search-button,
+    input.gsc-search-button-v2 {
+      background-color: var(--td-gcs-primary) !important;
+      border-color: var(--td-gcs-primary) !important;
+      color: #fff !important;
+      border-radius: var(--td-gcs-radius);
+    }
+
+    /* ------------------------------------------------------------
+    * TABS / REFINEMENTS
+    * ------------------------------------------------------------ */
+    .gsc-tabHeader {
+      background: transparent !important;
+    }
+
+    .gsc-tabHeader.gsc-tabhInactive {
+      color: var(--td-gcs-secondary) !important;
+      border-bottom: 2px solid transparent !important;
+      cursor: pointer;
+    }
+
+    .gsc-tabHeader.gsc-tabhActive,
+    .gsc-refinementHeader.gsc-refinementhActive {
+      border-bottom: 2px solid var(--td-gcs-primary) !important;
+      color: var(--td-gcs-primary) !important;
+      background: transparent !important;
+    }
+
+    .gsc-refinementHeader {
+      color: var(--td-gcs-secondary) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * RESULTS
+    * ------------------------------------------------------------ */
+    .gsc-results,
+    .gsc-results .gsc-result,
+    .gsc-webResult.gsc-result,
+    .gsc-imageResult-classic {
+      background-color: var(--td-gcs-bg) !important;
+      color: var(--td-gcs-text) !important;
+    }
+
+    .gsc-results .gsc-webResult.gsc-result,
+    .gsc-webResult.gsc-result {
+      border: 1px solid transparent !important;
+      background-color: var(--td-gcs-bg) !important;
+    }
+
+    .gsc-webResult.gsc-result.gsc-promotion {
+      background-color: var(--td-gcs-bg) !important;
+      border-color: transparent !important;
+    }
+
+    .gs-title,
+    .gs-title * {
+      color: var(--td-gcs-primary) !important;
+    }
+
+    .gs-snippet {
+      color: var(--td-gcs-secondary) !important;
+    }
+
+    .gs-visibleUrl,
+    .gs-visibleUrl-short {
+      color: var(--td-gcs-success) !important;
+    }
+
+    .gsc-result-info {
+      color: var(--td-gcs-secondary) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * ORDER BY ("Sort by:")
+    * ------------------------------------------------------------ */
+    .gsc-orderby {
+      background: transparent !important;
+    }
+
+    .gsc-orderby-label {
+      color: var(--td-gcs-secondary) !important;
+    }
+
+    /* the pill container */
+    .gsc-selected-option-container {
+      background-color: var(--td-gcs-bg) !important;
+      border: 1px solid var(--td-gcs-border) !important;
+      border-radius: var(--td-gcs-radius);
+      color: var(--td-gcs-text) !important;
+      position: relative;
+      padding-right: 1.7rem;
+      /* make room for arrow */
+    }
+
+    .gsc-selected-option {
+      color: inherit !important;
+    }
+
+    /* replace Google's light arrow with our own */
+    .gsc-control-cse .gsc-option-selector {
+      background: none !important;
+      width: 0 !important;
+      height: 0 !important;
+      padding: 0 !important;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 6px solid var(--td-gcs-secondary);
+      position: absolute !important;
+      top: 50% !important;
+      right: 0.55rem !important;
+      transform: translateY(-50%);
+    }
+
+    /* the dropdown menu itself */
+    .gsc-control-cse .gsc-option-menu {
+      background: var(--td-gcs-bg) !important;
+      border: 1px solid var(--td-gcs-border) !important;
+      color: var(--td-gcs-text) !important;
+    }
+
+    .gsc-option-menu-item {
+      color: var(--td-gcs-text) !important;
+      background: transparent !important;
+    }
+
+    .gsc-option-menu-item-highlighted {
+      background: rgba(255, 255, 255, 0.08) !important;
+      color: var(--td-gcs-text) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * PAGINATION
+    * ------------------------------------------------------------ */
+    .gsc-results .gsc-cursor-box {
+      margin: 10px 0;
+    }
+
+    .gsc-results .gsc-cursor-box .gsc-cursor-page {
+      text-decoration: none;
+      color: var(--td-gcs-text) !important;
+      background: transparent;
+    }
+
+    .gsc-results .gsc-cursor-box .gsc-cursor-current-page {
+      border: var(--td-gcs-primary) solid 1px !important;
+      color: var(--bs-body-color) !important;
+      border-radius: 999px;
+      padding: 0.25rem 0.6rem;
+    }
+
+    /* ------------------------------------------------------------
+    * AUTOCOMPLETE
+    * ------------------------------------------------------------ */
+    .gsc-completion-container {
+      background: var(--td-gcs-bg) !important;
+      border: 1px solid var(--td-gcs-border) !important;
+      color: var(--td-gcs-text) !important;
+    }
+
+    .gsc-completion-selected {
+      background: rgba(255, 255, 255, 0.08) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * SPELLING / "DID YOU MEAN"
+    * ------------------------------------------------------------ */
+    .gs-spelling a {
+      color: var(--td-gcs-primary) !important;
+    }
+
+    /* ------------------------------------------------------------
+    * TABLE LINES
+    * ------------------------------------------------------------ */
+    .gsc-table-result,
+    .gsc-table-cell-snippet-close {
+      border: 0 !important;
+    }
+
+    /* ------------------------------------------------------------
+    * "Find more on Google" footer
+    * ------------------------------------------------------------ */
+    .gcsc-find-more-on-google {
+      color: var(--td-gcs-secondary) !important;
+    }
+
+    .gcsc-find-more-on-google a,
+    .gcsc-find-more-on-google-text,
+    .gcsc-find-more-on-google-query {
+      color: var(--td-gcs-primary) !important;
+      text-decoration: none !important;
+    }
+
+    .gcsc-find-more-on-google-magnifier path {
+      fill: var(--td-gcs-primary) !important;
+    }
+
+    .gcsc-find-more-on-google:hover .gcsc-find-more-on-google-magnifier path {
+      fill: var(--td-gcs-link-hover, var(--td-gcs-primary)) !important;
+    }
+  }
+}

--- a/docsy.dev/assets/scss/_styles_project.scss
+++ b/docsy.dev/assets/scss/_styles_project.scss
@@ -1,2 +1,3 @@
 @import 'td/color-adjustments-dark';
 @import 'td/code-dark';
+@import 'td/gcs-search-dark';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+62-g5891c6c",
+  "version": "0.13.0-dev+63-g3abe89f",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2358
- Introduces `_gcs-search-dark.scss` for Google Programmable Search Engine dark theme support
- Wraps `scss/td/*.scss` file content with `@if $enable-dark-mode {...}`
- Fixes `.prettierignore` rules
- Runs Prettier over `main.scss` and `scss/td/**/*.*` except for chroma styles
- Fixes Google Search results pane with

### Preview

- https://deploy-preview-2387--docsydocs.netlify.app/search/?q=dark%20mode

### Screenshots

After:

> <img width="1016" height="751" alt="image" src="https://github.com/user-attachments/assets/942e19dc-e377-4839-b451-80be5ad46e55" />

Before:

> <img width="1016" height="781" alt="image" src="https://github.com/user-attachments/assets/413c1296-474f-4f70-ab4d-bbd9082ba269" />

