### PR TITLE
chore: part 2 of reverting ScrollSpy safeId PR

### DIFF
--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -109,7 +109,7 @@ related to Bootstrap, such as:
   required
 
 For the complete list of changes, see the
-[CHANGELOG at 0.7.0](/site/changelog/#v070).
+[CHANGELOG at 0.7.0](/site/changelog/#070).
 
 ## Case studies
 

--- a/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
+++ b/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
@@ -224,7 +224,7 @@ change to a ​​`media-breakpoint-down()` argument, as discussed earlier.
 
 During the migration effort we seized the opportunity to do some long overdue
 Docsy house cleaning. For details concerning both breaking and non-breaking
-Docsy-specific changes, consult the [changelog](/site/changelog/#v070). In
+Docsy-specific changes, consult the [changelog](/site/changelog/#070). In
 particular, one non-breaking but important change to be aware of is:
 [[BSv5] Docsy variables cleanup ... PR #1462](https://github.com/google/docsy/pull/1462).
 
@@ -238,7 +238,7 @@ build of the Docsy User Guide: the
 
 After such a smoke test, we recommend systematically walking through the
 Bootstrap [migration page](https://getbootstrap.com/docs/5.2/migration/) as
-described above, and the Docsy [changelog](/site/changelog/#v070). I used this
+described above, and the Docsy [changelog](/site/changelog/#070). I used this
 approach for [opentelemetry.io](https://opentelemetry.io/), which was the first
 Docsy-based project to be upgraded with a pre-release of Bootstrap-5-based
 Docsy. The upgrade went

--- a/docsy.dev/content/en/blog/2024/0.10.0.md
+++ b/docsy.dev/content/en/blog/2024/0.10.0.md
@@ -104,5 +104,5 @@ release, remember to upvote (with a thumbs up) the associated issue or PR.
 
 {{% /alert %}}
 
-[CL@0.10.0]: /site/changelog/#v010
+[CL@0.10.0]: /site/changelog/#010
 [0.10.0]: https://github.com/google/docsy/releases/tag/v0.10.0

--- a/docsy.dev/content/en/blog/2024/0.9.0.md
+++ b/docsy.dev/content/en/blog/2024/0.9.0.md
@@ -209,7 +209,7 @@ specifically:
 [#2]: https://github.com/google/docsy/issues/2
 [blocks/feature]:
   https://www.docsy.dev/docs/adding-content/shortcodes/#blocksfeature
-[CL@0.9.0]: /site/changelog/#v090
+[CL@0.9.0]: /site/changelog/#090
 [functions]: https://gohugo.io/functions/
 [hook]: https://gohugo.io/templates/render-hooks/
 [Hugo 0.112.0]: https://github.com/gohugoio/hugo/releases/tag/v0.112.0

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -22,8 +22,8 @@ In this post you'll walk through the upgrade process for:
 - **[Hugo](#update-hugo)**: 0.136.2 → 0.147.5&nbsp;[^vers-note]
 - **[Node](#update-nodejs)**: LTS 20 → LTS 22&nbsp;[^vers-note]
 
-[0.11.0]: /site/changelog/#v0110
-[0.12.0]: /site/changelog/#v0120
+[0.11.0]: /site/changelog/#0110
+[0.12.0]: /site/changelog/#0120
 
 [^vers-note]:
     These are the officially supported Node.js and Hugo versions associated with
@@ -258,7 +258,7 @@ Use this checklist to verify that your upgrade succeeded:
 
 For the full release notes, see:
 
-- [Docsy v0.12.0 changelog](/site/changelog/#v0120)
+- [Docsy v0.12.0 changelog](/site/changelog/#0120)
 - [Hugo release notes](https://github.com/gohugoio/hugo/releases) from 0.136.2
   (or your starting Hugo version) to 0.147.5.
 
@@ -266,7 +266,7 @@ Other references:
 
 - [Hugo 0.146.0 template system][NTS]
 - [0.11.0 release highlights](../2024/year-in-review/#release-highlights)
-- [0.11.0 changelog](/site/changelog/#v0110)
+- [0.11.0 changelog](/site/changelog/#0110)
 - [Docsy issue #2243][#2243], _Adapt to new template system in Hugo v0.146.0_.
 
 [#2243]: https://github.com/google/docsy/issues/2243

--- a/docsy.dev/content/en/docs/adding-content/feedback.md
+++ b/docsy.dev/content/en/docs/adding-content/feedback.md
@@ -122,7 +122,7 @@ As of Docsy version [0.8.0], feedback will be enabled whether
 `site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
 case where analytics is configured outside of Docsy.
 
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#080
 
 {{% /alert %}}
 
@@ -193,7 +193,7 @@ Page feedback is reported to Google Analytics through [events].
 As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful`
 events, rather than `click` events.
 
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#080
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/adding-content/repository-links.md
+++ b/docsy.dev/content/en/docs/adding-content/repository-links.md
@@ -403,7 +403,7 @@ for your project.
 
 Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
 
-[v0.9.0]: /site/changelog/#v090
+[v0.9.0]: /site/changelog/#090
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -346,7 +346,7 @@ set the environment variable `DOCSY_MKDIR_HUGO_MOD_SKIP=1` before running NPM
 install.
 
 [#1120]: https://github.com/google/docsy/issues/1120
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#080
 [hugo module]: /docs/get-started/docsy-as-module/
 
 {{% /alert %}}

--- a/docsy.dev/content/en/site/changelog.md
+++ b/docsy.dev/content/en/site/changelog.md
@@ -52,7 +52,7 @@ See [semver].
 
 <!-- TODO: look into https://www.conventionalcommits.org/en/v1.0.0/#summary -->
 
-## v0.13.0
+## 0.13.0
 
 > **UNRELEASED: this planned version is still under development**
 
@@ -105,7 +105,7 @@ See [semver].
 [0.13.0-blog-fouc]: /blog/2025/0.13.0/#accessibility
 [0.13.0-blog-breaking]: /blog/2025/0.13.0/#breaking-changes
 
-## v0.12.0
+## 0.12.0
 
 For the full list of changes, see the [0.12.0] release page.
 
@@ -169,7 +169,7 @@ For the full list of changes, see the [0.12.0] release page.
 [_td-content-after-header.html]:
   https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html
 
-## v0.11.0
+## 0.11.0
 
 For the full list of changes, see the [0.11.0] release page.
 
@@ -189,7 +189,7 @@ For the full list of changes, see the [0.11.0] release page.
   /docs/adding-content/navigation/#side-nav-options
 [rtl]: /docs/language/#right-to-left-languages
 
-## v0.10.0
+## 0.10.0
 
 For an introduction to this release, see the [0.10.0 release report]. For the
 full list of changes, see the [0.10.0] release page.
@@ -199,7 +199,7 @@ dark-mode support][dark-mode].
 
 **Breaking changes**:
 
-- Removes shortcode `card-code` that was [deprecated in 0.7.0](#v070); use
+- Removes shortcode `card-code` that was [deprecated in 0.7.0](#070); use
   shortcode `card` with named parameter `code=true` instead.
 - The following SCSS variables are inlined in favor of dark-mode compatible
   styling: `$border-color`, `$td-sidebar-tree-root-color`,
@@ -216,13 +216,13 @@ dark-mode support][dark-mode].
 [0.10.0 release report]: /blog/2024/0.10.0/
 [dark-mode]: /blog/2024/0.10.0/#color-themes-and-dark-mode-support
 
-## v0.9.1
+## 0.9.1
 
 Patch release. For details, see [0.9.1].
 
 [0.9.1]: https://github.com/google/docsy/releases/v0.9.1
 
-## v0.9.0
+## 0.9.0
 
 For an introduction and commentary, see the [0.9.0 release report]. For the full
 list of commits, see the [0.9.0] release page. The most significant changes of
@@ -283,7 +283,7 @@ For details concerning all footer changes, see [#1818].
 [union file system]:
   https://gohugo.io/getting-started/directory-structure/#union-file-system
 
-## v0.8.0
+## 0.8.0
 
 For the full list of changes, see the [0.8.0] release page.
 
@@ -319,7 +319,7 @@ For the full list of changes, see the [0.8.0] release page.
 [Use Docsy as a Hugo Module]: /docs/get-started/docsy-as-module/
 [User feedback]: /docs/adding-content/feedback/#user-feedback
 
-## v0.7.2
+## 0.7.2
 
 For the full list of changes, see the [0.7.2] release page. We mention some
 noteworthy changes here:
@@ -346,7 +346,7 @@ noteworthy changes here:
 [Algolia DocSearch]: /docs/adding-content/search/#algolia-docsearch
 [Tabbed panes]: /docs/adding-content/shortcodes/#tabbed-panes
 
-## v0.7.1
+## 0.7.1
 
 For the full list of changes, see the [0.7.1] release page.
 
@@ -361,7 +361,7 @@ Followup changes to **Bootstrap (BS) 5.2 upgrade** ([#470]):
 [#1579]: https://github.com/google/docsy/issues/1579
 [0.7.1]: https://github.com/google/docsy/releases/v0.7.1
 
-## v0.7.0
+## 0.7.0
 
 For the full list of changes, see the [0.7.0] release page.
 
@@ -425,7 +425,7 @@ For the full list of changes, see the [0.7.0] release page.
 [bsv5mig]: https://getbootstrap.com/docs/5.2/migration/
 [hugo-releases]: https://github.com/gohugoio/hugo/releases
 
-## v0.6.0
+## 0.6.0
 
 For the full list of changes, see the [0.6.0] release page.
 
@@ -446,7 +446,7 @@ Bootstrap version. See [the announcement][bs-announcement] for more information.
 [0.6.0]: https://github.com/google/docsy/releases/v0.6.0
 [bs-announcement]: https://github.com/google/docsy/discussions/1308
 
-## v0.5.1
+## 0.5.1
 
 For the full list of changes, see the [0.5.1] release page. **BREAKING CHANGES**
 are documented below.
@@ -497,11 +497,11 @@ are documented below.
 [what's changed in v6]:
   https://docs.fontawesome.com/v6/web/setup/upgrade/whats-changed
 
-## v0.5.0
+## 0.5.0
 
 Unpublished.
 
-## v0.4.0
+## 0.4.0
 
 For the full list of changes, see the [0.4.0] release page. Potential **BREAKING
 CHANGES** are documented below.
@@ -557,7 +557,7 @@ Proceed as usual to build or serve your site.
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
 
-## v0.3.0
+## 0.3.0
 
 For the full list of changes, see the [0.3.0] release page.
 
@@ -576,7 +576,7 @@ For the full list of changes, see the [0.3.0] release page.
 [#1009]: https://github.com/google/docsy/pull/1009
 [issue #1154]: https://github.com/google/docsy/issues/1154
 
-## v0.2.0
+## 0.2.0
 
 For the full list of changes, see the [0.2.0] release page.
 
@@ -598,7 +598,7 @@ For the full list of changes, see the [0.2.0] release page.
 <!-- ENTRY TEMPLATE ------------------------------------------------------
 
 ```
-## v0.X.Y
+## 0.X.Y
 
 > **UNRELEASED: this planned version is still under development**
 

--- a/docsy.dev/content/en/site/contributing.md
+++ b/docsy.dev/content/en/site/contributing.md
@@ -134,7 +134,7 @@ repo.
       ## Release summary
 
       - [Release report](/blog/2024/0.X.Y/)
-      - [CHANGELOG](/site/changelog/#v0XY)
+      - [CHANGELOG](/site/changelog/#0XY)
       ```
 
     - Select **Create a discussion for this release**.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+64-gc37aad0",
+  "version": "0.13.0-dev+65-g4145478",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Reverts the prefixing of changelog version-number headings do via #2370
- Followup to #2383