### PR TITLE
Add implementation docs and update changelog for 0.13.0

### DIFF
--- a/docsy.dev/content/en/docs/adding-content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/adding-content/lookandfeel.md
@@ -146,7 +146,7 @@ You can adjust dark-mode support as follows:
   - **Color-contrast adjustments**: if your site has custom theme colors, you
     will probably need to selectively tune your dark-mode theme colors to ensure
     that the have good color-contrast. Learn
-    [how to pick colors with good color-contrast](#how-to-pick-colors-with-good-color-contrast).
+    [how to pick colors with good color-contrast](#pick-good-color-contrast).
 
 {{% alert title="Terminology note" color=info %}}
 
@@ -181,7 +181,7 @@ To [disable dark mode][] entirely:
   https://getbootstrap.com/docs/5.3/customize/color-modes/#building-with-sass
 [site configuration]: https://gohugo.io/configuration/introduction/
 
-#### How to pick colors with good color-contrast
+#### How to pick colors with good color-contrast (EXPERIMENTAL) {#pick-good-color-contrast}
 
 Getting dark-mode theme colors to have proper contrast can be tricky. Docsy
 provides [_color-adjustments-dark.scss] as an example of theme color
@@ -215,6 +215,13 @@ dark mode theme customization file and import it in your project's
   https://github.com/google/docsy/blob/main/assets/scss/td/_color-adjustments-dark.scss
 [Chroma for code highlighting]: #code-highlighting-with-chroma
 [Light/dark code styles]: #lightdark-code-styles
+
+{{% alert title="EXPERIMENTAL" color="info" %}}
+
+This feature is experimental. We're releasing this early to so that projects can
+try out this approach and provide feedback on its usefulness and convenience.
+
+{{% /alert %}}
 
 {{% alert title="Note" %}}
 

--- a/docsy.dev/content/en/site/_index.md
+++ b/docsy.dev/content/en/site/_index.md
@@ -2,27 +2,30 @@
 title: About this website
 linkTitle: Website docs
 description: How this site is built, maintained, and deployed.
-aliases: [site]
-outputs: [HTML]
+aliases: [project]
 cascade:
+  outputs: [HTML]
   type: docs
   params:
     hide_feedback: true
-  # - target:
-  #     path: /site/repo**
-  #   params:
-  #     ui:
-  #       breadcrumb_disable: true
-  #     github_subdir: ''
-  #     path_base_for_github_subdir:
-  #       from: '^(.*)/(\w+\.md)'
-  #       to: $2
-  #     toc_hide: true
 params:
-  # github_subdir: docsy.dev # cSpell:disable-line
-  # path_base_for_github_subdir: ''
   FA: <i class="fa-solid fa-{1} text-{2}"></i>
 ---
 
-{{% _param FA person-digging " pe-2" %}} Coming soon: Design, implementation,
-and ops docs for the project {{% _param FA person-digging " ps-2" %}}
+Planned content organization (tentative)
+
+- **info** — High-level information about the website project, including its
+  purpose, ownership, and overall status.
+- **design** — Architectural design, Information Architecture (IA), layout, UX
+  choices, theme related decisions, and other design-level artifacts.
+- **implementation** — Code-level structure and conventions, Hugo/Docsy
+  templates, SCSS/JS customizations, patches, and internal shims.
+- **build** — Tooling, local development setup, CI/CD workflows, deployment
+  environments, and automation details.
+- **quality** — Link checking, accessibility standards, tests, review practices,
+  and other quality-related processes.
+- **roadmap** — Milestones, backlog, priorities, technical debt, and
+  design/implementation decisions.
+
+{{% _param FA person-digging " pe-2" %}} This section is under development. {{%
+_param FA person-digging " ps-2" %}}

--- a/docsy.dev/content/en/site/changelog.md
+++ b/docsy.dev/content/en/site/changelog.md
@@ -56,10 +56,10 @@ See [semver].
 
 > **UNRELEASED: this planned version is still under development**
 
-**References**:
+**Resources**:
 
 - [Release 0.13.0 report and upgrade guide][0.13.0-blog]
-- For the full list of changes, see the [0.13.0] release page.
+- [0.13.0] release page for the full list of changes
 
 **Breaking changes**:
 
@@ -76,14 +76,24 @@ See [semver].
 
 **Other changes**:
 
-- Improved accessibility: [color contrast and
+- **Improved accessibility**: [color contrast and
   typography][0.13.0-blog-accessibility] ([#2285]).
-- Fixed dark-mode [Flash Of Unstyled Content][0.13.0-blog-fouc] (FOUC)
-  ([#2332]).
+- Fixed **dark-mode**:
+  - [Flash Of Unstyled Content][0.13.0-blog-fouc] (FOUC) ([#2332]).
+  - Improved TOC entry color contrast in dark mode ([#2376], [#2379]).
 - Better NPM support: resolved optional and peer dependency issues ([#2115]).
   See [breaking changes][0.13.0-blog-breaking] in the blog post.
+- Dependency updates: Bootstrap 5.3.8, Hugo 0.152.2, Node LTS ≥24.
 - Updated translations: added Occitan locale ([#2173]) and refreshed Simplified
   Chinese ([#2313]) and Ukrainian ([#2331]).
+
+**Experimental**:
+
+- **Dark mode**. Added support for:
+  - Google search integration ([#2387]).
+  - Sample support for color-contrast adjustments: for details, see [How to pick
+    colors with good color-contrast][] ([#2384]).
+- New `_param` shortcode with support for parameter substitution ([#2371]).
 
 [#2115]: https://github.com/google/docsy/issues/2115
 [#2173]: https://github.com/google/docsy/issues/2173
@@ -94,6 +104,11 @@ See [semver].
 [#2332]: https://github.com/google/docsy/issues/2332
 [#2364]: https://github.com/google/docsy/pull/2364
 [#2366]: https://github.com/google/docsy/pull/2366
+[#2371]: https://github.com/google/docsy/pull/2371
+[#2376]: https://github.com/google/docsy/pull/2376
+[#2379]: https://github.com/google/docsy/pull/2379
+[#2384]: https://github.com/google/docsy/pull/2384
+[#2387]: https://github.com/google/docsy/pull/2387
 [#941]: https://github.com/google/docsy/pull/941
 [0.13.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.13.0
 [0.13.0-blog]: /blog/2025/0.13.0/
@@ -104,6 +119,8 @@ See [semver].
 [0.13.0-blog-accessibility]: /blog/2025/0.13.0/#accessibility
 [0.13.0-blog-fouc]: /blog/2025/0.13.0/#accessibility
 [0.13.0-blog-breaking]: /blog/2025/0.13.0/#breaking-changes
+[How to pick colors with good color-contrast]:
+  /docs/adding-content/lookandfeel/#pick-good-color-contrast
 
 ## v0.12.0
 

--- a/docsy.dev/content/en/site/implementation/_index.md
+++ b/docsy.dev/content/en/site/implementation/_index.md
@@ -1,0 +1,16 @@
+---
+title: Implementation
+linkTitle: Implementation
+description:
+  Code-level structure and conventions, Hugo/Docsy templates, SCSS/JS
+  customizations, patches, and internal shims.
+no_list: true
+---
+
+This section documents code-level implementation details for the Docsy website,
+including patches, internal shims, and customizations.
+
+## Patches and workarounds
+
+- [ScrollSpy patch for Bootstrap]({{< relref "scrollspy-patch" >}}) — Runtime
+  patch to fix Bootstrap ScrollSpy handling of invalid CSS selector IDs.

--- a/docsy.dev/content/en/site/implementation/scrollspy-patch.md
+++ b/docsy.dev/content/en/site/implementation/scrollspy-patch.md
@@ -1,0 +1,63 @@
+---
+title: ScrollSpy patch
+description:
+  Runtime patch for Bootstrap ScrollSpy to handle invalid CSS selector IDs.
+---
+
+<span class="badge bg-info text-bg-info">As of Docsy 0.13.0</span>
+
+{{% alert title="Summary" color="info" %}}
+
+Docsy 0.13.0 includes a **runtime patch** for Bootstrap [ScrollSpy] that fixes a
+bug affecting pages with heading IDs that aren't valid CSS selectors. The patch
+ensures that [active TOC entry
+tracking][Active TOC entry tracking with ScrollSpy] works reliably for all
+pages.
+
+{{% /alert %}}
+
+## Problem
+
+As of Bootstrap 5.3.8 (the version used by Docsy 0.13.0), [ScrollSpy] fails if a
+page contains a heading ID that is not also a valid CSS `#` selector. This can
+happen, for example, if a heading ID starts with a digit. For technical details
+about this bug, see [#2329].
+
+## Solution
+
+Docsy 0.13.0 implements a runtime patch for [ScrollSpy] that intercepts
+ScrollSpy's initialization to properly handle heading IDs starting with digits
+or contain other characters that form invalid CSS selectors. This allows active
+TOC entry tracking to work correctly without altering the original heading IDs,
+so links to headings continue to work as expected.
+
+The patch is automatically applied when ScrollSpy is enabled (which is the
+default). For implementation details, see [#2382], [#2383].
+
+## Maintenance
+
+CI/CD automatically keeps the patch up-to-date when Bootstrap is updated. The
+`ci:prepare` script extracts the method from Bootstrap, applies the patch, and
+updates the runtime patch file. If the Bootstrap method code has changed to a
+degree that the patch no longer works, CI will fail, indicating that the patch
+file needs manual review and updates.
+
+Until the [upstream ScrollSpy fix][] is released in a future Bootstrap version,
+this patch ensures that active TOC entry tracking works reliably for all pages.
+
+## References
+
+- [Active TOC entry tracking with ScrollSpy][]
+- [CI/CD `scrollspy-patch` details][]
+- [Upstream ScrollSpy fix][] (Bootstrap PR #41726)
+- [#2329] — Technical details about the bug
+
+[upstream ScrollSpy fix]: https://github.com/twbs/bootstrap/pull/41726
+[#2329]: https://github.com/google/docsy/issues/2329
+[#2382]: https://github.com/google/docsy/pull/2382
+[#2383]: https://github.com/google/docsy/pull/2383
+[Active TOC entry tracking with ScrollSpy]:
+  /docs/adding-content/navigation/#toc-entry-tracking
+[CI/CD `scrollspy-patch` details]:
+  https://github.com/google/docsy/blob/main/scripts/scrollspy-patch/README.md
+[ScrollSpy]: https://getbootstrap.com/docs/5.3/components/scrollspy/

--- a/docsy.dev/content/en/site/repo/_index.md
+++ b/docsy.dev/content/en/site/repo/_index.md
@@ -2,7 +2,6 @@
 title: Repository-root markdown files
 linkTitle: Repo files
 description: Repository-root pages for the Docsy project.
-outputs: [HTML]
 cascade:
   params:
     ui:

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -803,6 +803,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:35.15472-05:00"
   },
+  "https://github.com/google/docsy/blob/main/scripts/scrollspy-patch/README.md": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:48.212045-05:00"
+  },
   "https://github.com/google/docsy/blob/v0.7.0/assets/scss/main.scss": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:37.116869-05:00"
@@ -1045,7 +1049,7 @@
   },
   "https://github.com/google/docsy/issues/2347": {
     "StatusCode": 206,
-    "LastSeen": "2025-11-16T06:27:50.429002-05:00"
+    "LastSeen": "2025-11-16T10:05:47.5945-05:00"
   },
   "https://github.com/google/docsy/issues/331": {
     "StatusCode": 206,
@@ -1246,6 +1250,34 @@
   "https://github.com/google/docsy/pull/2366": {
     "StatusCode": 206,
     "LastSeen": "2025-11-15T19:45:06.164029-05:00"
+  },
+  "https://github.com/google/docsy/pull/2371": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T17:22:30.695583-05:00"
+  },
+  "https://github.com/google/docsy/pull/2376": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:47.09091-05:00"
+  },
+  "https://github.com/google/docsy/pull/2379": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:47.726835-05:00"
+  },
+  "https://github.com/google/docsy/pull/2382": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:47.137642-05:00"
+  },
+  "https://github.com/google/docsy/pull/2383": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:47.727885-05:00"
+  },
+  "https://github.com/google/docsy/pull/2384": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:48.336894-05:00"
+  },
+  "https://github.com/google/docsy/pull/2387": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-19T19:40:47.214729-05:00"
   },
   "https://github.com/google/docsy/pull/941": {
     "StatusCode": 206,
@@ -1761,7 +1793,7 @@
   },
   "https://github.com/twbs/bootstrap/pull/41726": {
     "StatusCode": 206,
-    "LastSeen": "2025-11-16T06:27:49.694807-05:00"
+    "LastSeen": "2025-11-16T10:05:46.680642-05:00"
   },
   "https://github.com/twbs/bootstrap/releases/tag/v4.6.2": {
     "StatusCode": 206,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+64-gc37aad0",
+  "version": "0.13.0-dev+66-gee765f4",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.13/release-wrapup.plan.md
+++ b/tasks/0.13/release-wrapup.plan.md
@@ -60,9 +60,13 @@ cSpell:ignore: docsy
   command examples
 - Keep the draft updated in [0.13.0 release report][]
 
-### Refresh actions
+---
 
-Repeat when new commits land on `main`:
+## Refresh actions
+
+Repeat when new commits land on `main` do the following.
+
+### Update the plan and reports
 
 - Revisit the plan and update the reports with new commits to `main` integrated
   into existing summaries.
@@ -72,6 +76,24 @@ Repeat when new commits land on `main`:
 Report refreshed for commits through [c37aad0] (includes dark mode enhancements,
 ScrollSpy fixes, and documentation updates).
 
+### 0.13.0 blog post
+
+- Reread the [0.13.0 blog post][].
+- Compare it to the information you recently added to the 0.13.0 release report
+  pages in this folder.
+- Is the post complete? If not identify what is missing.
+
+### Changelog
+
+- Reread the [changelog entry for 0.13.0][0.13.0-changelog].
+- Compare it to the information you recently added to the 0.13.0 release report
+  pages in this folder.
+- Is the changelog complete? If not, add the missing information.
+- Remember that the changelog is meant to only (very briefly) highlight
+  significant changes.
+
 [0.13.0 release report]: ../docsy.dev/content/en/blog/2025/0.13.0.md
+[0.13.0-changelog]: ../../docsy.dev/content/en/site/changelog/#v0130
 [c37aad0]: https://github.com/google/docsy/commit/c37aad0
 [v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main
+[0.13.0 blog post]: ../docsy.dev/content/en/blog/2025/0.13.0.md


### PR DESCRIPTION
- Contributes to #2266
- Adds a new 'site/implementation' section with documentation for the ScrollSpy runtime patch in Docsy 0.13.0. 
- Updates changelog and related docs to reflect experimental features, improved accessibility, and new references.
- Refines `/site` index and release planning documentation for clarity and completeness.

**Preview**:

- https://deploy-preview-2391--docsydocs.netlify.app/site/changelog/#v0130
- https://deploy-preview-2391--docsydocs.netlify.app/site/implementation/scrollspy-patch/