### PR TITLE
Add i18n support for table of contents labels

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -88,3 +88,9 @@ other = "Was this page helpful?"
 other = "Yes"
 [feedback_negative]
 other = "No"
+
+# Table of contents
+[toc_on_this_page]
+other = "On this page"
+[toc_top_of_page]
+other = "Top of page"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -89,3 +89,9 @@ other = "¿Fue útil esta página?"
 other = "Si"
 [feedback_negative]
 other = "No"
+
+# Table of contents
+[toc_on_this_page]
+other = "En esta página"
+[toc_top_of_page]
+other = "Inicio de la página"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -88,3 +88,9 @@ other = "Oui"
 [feedback_negative]
 other = "Non"
 
+# Table of contents
+[toc_on_this_page]
+other = "Sur cette page"
+[toc_top_of_page]
+other = "Haut de la page"
+

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -88,3 +88,9 @@ other = "Esta página foi útil?"
 other = "Sim"
 [feedback_negative]
 other = "Não"
+
+# Table of contents
+[toc_on_this_page]
+other = "Nesta página"
+[toc_top_of_page]
+other = "Topo da página"

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -11,8 +11,8 @@
   {{ $toc := .TableOfContents -}}
   {{ if and $toc (ne $toc `<nav id="TableOfContents"></nav>`) -}}
     <div class="td-toc__title">
-      <span class="td-toc__title__text">On this page</span>
-      <a class="td-toc__title__link" title="Top of page" href="#"></a>
+      <span class="td-toc__title__text">{{ i18n "toc_on_this_page" }}</span>
+      <a class="td-toc__title__link" title="{{ i18n "toc_top_of_page" }}" href="#"></a>
     </div>
     {{ $toc | safeHTML }}
   {{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+74-ga2cd44e",
+  "version": "0.13.0-dev+75-gf2b0c56",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2289
- Closes #2289
- Adds i18n support for TOC labels

**Preview**: https://deploy-preview-2400--docsydocs.netlify.app/docs/