### PR TITLE
Document i18n support for TOC labels, update task docs

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -1,6 +1,7 @@
 //
 // Style Markdown content
 //
+// cSpell:ignore: katex
 
 .td-content {
   order: 1;

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -3,6 +3,7 @@ title: Navigation and Menus
 date: 2017-01-05
 weight: 3
 description: Customize site navigation for your Docsy site.
+cSpell:ignore: navs lightdark lookandfeel frontmatter
 ---
 
 Docsy provides multiple built-in navigation features for your sites, including
@@ -501,11 +502,15 @@ Feature notes:
 - Docsy will generally ignore `sidebar_root_for` for non "docs" pages and
   non-section index pages.
 
-## Table of contents
+## Table of contents (TOC) {#table-of-contents}
 
-Docsy provides a table of contents (TOC) for each "docs"page. The TOC is
-generated from the headings in the page content. The TOC is displayed in the
-right-hand sidebar by default.
+Docsy provides a table of contents (TOC) for each [`docs` page][]. The TOC is
+generated using Hugo's [TableOfContents][] function from the Markdown headings
+in the page content. The TOC is displayed in the right-hand sidebar of the
+page's main content area by default.
+
+[`docs` page]: /docs/content/adding-content/#content-sections-and-templates
+[TableOfContents]: https://gohugo.io/methods/page/tableofcontents/
 
 {{% alert title="Will shortcode headings appear in the TOC?" color=info %}}
 
@@ -530,6 +535,12 @@ You can use the following CSS classes as selectors to style the TOC:
   text and the top-of-page link)
 - `.td-toc__title__text` for the TOC title text
 - `.td-toc__title__link` for the TOC title link
+
+The TOC labels "On this page" and "Top of page" are localizable through the keys
+`toc_on_this_page` and `toc_top_of_page`. For details, see [Internationalization
+bundles][].
+
+[Internationalization bundles]: /docs/language/#internationalization-bundles
 
 ### Active TOC entry tracking with ScrollSpy {#toc-entry-tracking}
 

--- a/docsy.dev/content/en/site/changelog.md
+++ b/docsy.dev/content/en/site/changelog.md
@@ -3,7 +3,7 @@ title: Changelog
 description: Docsy repository changelog
 weight: 99999
 # prettier-ignore
-cSpell:ignore: blockssection deining docsy FOUC gitmodules gtag lookandfeel mhchem navs tabpane
+cSpell:ignore: blockssection deining docsy FOUC gitmodules gtag lookandfeel mhchem navs tabpane katex
 ---
 
 We only document **breaking changes** and release **highlights** in this page.

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -999,6 +999,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:24.821835-05:00"
   },
+  "https://github.com/google/docsy/issues/2001": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-22T21:21:22.964034-05:00"
+  },
+  "https://github.com/google/docsy/issues/2035": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-22T21:21:22.044244-05:00"
+  },
   "https://github.com/google/docsy/issues/2108": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:26:30.089027-05:00"
@@ -1038,6 +1046,10 @@
   "https://github.com/google/docsy/issues/2313": {
     "StatusCode": 206,
     "LastSeen": "2025-11-15T13:13:08.640022-05:00"
+  },
+  "https://github.com/google/docsy/issues/2328": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-22T21:21:21.19062-05:00"
   },
   "https://github.com/google/docsy/issues/2329": {
     "StatusCode": 206,
@@ -1237,7 +1249,7 @@
   },
   "https://github.com/google/docsy/pull/2276": {
     "StatusCode": 206,
-    "LastSeen": "2025-11-22T19:11:50.204149-05:00"
+    "LastSeen": "2025-11-22T19:48:06.505712-05:00"
   },
   "https://github.com/google/docsy/pull/2291": {
     "StatusCode": 206,
@@ -1294,6 +1306,10 @@
   "https://github.com/google/docsy/pull/2395": {
     "StatusCode": 206,
     "LastSeen": "2025-11-22T19:11:51.453801-05:00"
+  },
+  "https://github.com/google/docsy/pull/2400": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-22T21:21:23.506177-05:00"
   },
   "https://github.com/google/docsy/pull/941": {
     "StatusCode": 206,
@@ -2006,6 +2022,10 @@
   "https://gohugo.io/methods/page/outputformats/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:43.161476-05:00"
+  },
+  "https://gohugo.io/methods/page/tableofcontents/": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-23T08:52:31.653587-05:00"
   },
   "https://gohugo.io/methods/site/copyright/": {
     "StatusCode": 206,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+75-gf2b0c56",
+  "version": "0.13.0-dev+76-g14c2061",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.13/commit-inventory.md
+++ b/tasks/0.13/commit-inventory.md
@@ -4,7 +4,7 @@ date: 2025-11-12
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `f016114` on `main`.
+> Report refreshed for commits through `14c2061` on `main`.
 
 Chronological list of [commits since v0.12.0][], broadly grouped into a few
 categories. We'll do a more detailed analysis and groupings when we create the
@@ -77,6 +77,10 @@ client projects.
 - `ee765f4` (`#2386`) Improved light/dark-mode docs
 - `4145478` (`#2388`) Site docs reorg in prep for more design and ops docs, also
   updated tasks/0.13.0 pages
+- `a2cd44e` (`#2398`) Update changelogs and reports for KaTeX build-time
+  rendering
+- `f2b0c56` (`#2399`) Add TOC style customization section to navigation docs
+- `14c2061` (`#2400`) Add i18n support for table of contents labels
 
 ## CI / tooling only
 

--- a/tasks/0.13/issue-mapping.md
+++ b/tasks/0.13/issue-mapping.md
@@ -1,10 +1,10 @@
 ---
 title: 0.13 issue mapping
 date: 2025-11-12
-cSpell:ignore: docsy sidemenu FOUC
+cSpell:ignore: docsy sidemenu FOUC katex mhchem sidenav
 ---
 
-> Report refreshed for commits through `f016114` on `main`.
+> Report refreshed for commits through `14c2061` on `main`.
 
 Mapping [commits since v0.12.0][] to their originating issues (when known).
 
@@ -76,6 +76,9 @@ Mapping [commits since v0.12.0][] to their originating issues (when known).
 | `ef1109c` | `#2391` | Add implementation docs and update changelog for 0.13.0                               | `#2266`              | Release documentation                                                    |
 | `ee765f4` | `#2386` | Improved light/dark-mode docs                                                         | —                    | Documentation improvements                                               |
 | `4145478` | `#2388` | Site docs reorg in prep for more design and ops docs, also updated tasks/0.13.0 pages | —                    | Documentation reorganization                                             |
+| `a2cd44e` | `#2398` | Update changelogs and reports for KaTeX build-time rendering                          | `#2266`              | Release documentation maintenance                                        |
+| `f2b0c56` | `#2399` | Add TOC style customization section to navigation docs                                | `#2289`              | Documentation for TOC customization (ScrollSpy follow-up)                |
+| `14c2061` | `#2400` | Add i18n support for table of contents labels                                         | `#2289`              | Localization support for TOC "On this page" and "Top of page"            |
 
 ## CI / tooling commits
 

--- a/tasks/0.13/release-wrapup.plan.md
+++ b/tasks/0.13/release-wrapup.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.13 Release wrapup plan
 date: 2025-11-12
-last-main-commit: f016114
+last-main-commit: 14c2061
 cSpell:ignore: docsy
 ---
 
@@ -64,7 +64,11 @@ cSpell:ignore: docsy
 
 ## Refresh actions
 
-Repeat when new commits land on `main` do the following.
+Repeat when new commits land on `main` do the following:
+
+- [Update the plan and reports](#update-the-plan-and-reports)
+- [0.13.0 blog post](#0130-blog-post)
+- [Changelog](#changelog)
 
 ### Update the plan and reports
 
@@ -75,8 +79,9 @@ Repeat when new commits land on `main` do the following.
 - Take note of fixes and features that are not yet documented in the blog post
   or changelog.
 
-Report refreshed for commits through [f016114] (includes KaTeX build-time
-rendering, dark mode enhancements, ScrollSpy fixes, and documentation updates).
+Report refreshed for commits through [14c2061] (includes TOC i18n support, TOC
+style customization docs, KaTeX build-time rendering, dark mode enhancements,
+ScrollSpy fixes, and documentation updates).
 
 ### 0.13.0 blog post
 
@@ -104,6 +109,6 @@ rendering, dark mode enhancements, ScrollSpy fixes, and documentation updates).
 
 [0.13.0 release report]: ../docsy.dev/content/en/blog/2025/0.13.0.md
 [0.13.0-changelog]: ../../docsy.dev/content/en/site/changelog/#v0130
-[f016114]: https://github.com/google/docsy/commit/f016114
+[14c2061]: https://github.com/google/docsy/commit/14c2061
 [v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main
 [0.13.0 blog post]: ../docsy.dev/content/en/blog/2025/0.13.0.md

--- a/tasks/0.13/wrapup-report.md
+++ b/tasks/0.13/wrapup-report.md
@@ -4,7 +4,7 @@ date: 2025-11-12
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `f016114` on `main`.
+> Report refreshed for commits through `14c2061` on `main`.
 
 ## Highlights since v0.12.0
 


### PR DESCRIPTION
- Adds mention of i18n support for TOC labels to the navigation page. Completes: #2400
- Updates tasks reports

**Preview**: https://deploy-preview-2402--docsydocs.netlify.app/docs/content/navigation/#table-of-contents