### PR TITLE
Document `notoc`, and update TOC CSS class names

### DIFF
--- a/assets/scss/_sidebar-toc.scss
+++ b/assets/scss/_sidebar-toc.scss
@@ -41,7 +41,7 @@
     display: block;
   }
 
-  &__title {
+  &-title {
     color: var(--bs-secondary-color);
     border-bottom: 1px solid var(--bs-tertiary-color);
     padding-bottom: 0.25rem;

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -3,7 +3,7 @@ title: Navigation and Menus
 date: 2017-01-05
 weight: 3
 description: Customize site navigation for your Docsy site.
-cSpell:ignore: navs lightdark lookandfeel frontmatter
+cSpell:ignore: navs lightdark lookandfeel frontmatter notoc
 ---
 
 Docsy provides multiple built-in navigation features for your sites, including
@@ -526,19 +526,35 @@ details, see Hugo forum discussions [#55399] and [#51940].
 
 {{% /alert %}}
 
-### Customizing the TOC
+### TOC customization
 
-You can use the following CSS classes as selectors to style the TOC:
+To **hide** the TOC for a specific page, set the following parameters in that
+page's front matter:
+
+```yaml
+notoc: true
+```
+
+You can use the following CSS classes to **style** TOC elements:
 
 - `.td-toc` for the TOC container
-- `.td-toc__title` for the TOC title element (which includes the "On this page"
+- `.td-toc-title` for the TOC title element (which includes the "On this page"
   text and the top-of-page link)
-- `.td-toc__title__text` for the TOC title text
-- `.td-toc__title__link` for the TOC title link
+- `.td-toc-title__text` for the TOC title text
+- `.td-toc-title__link` for the TOC title link
 
-The TOC labels "On this page" and "Top of page" are localizable through the keys
-`toc_on_this_page` and `toc_top_of_page`. For details, see [Internationalization
-bundles][].
+The TOC labels "On this page" and "Top of page" can be **localized**, for
+example:
+
+```toml
+# i18n/fr.toml
+toc_on_this_page = "Sur cette page"
+toc_top_of_page = "Haut de la page"
+```
+
+{{% comment %}} cSpell:ignore: cette haut {{% /comment %}}
+
+For details, see [Internationalization bundles][].
 
 [Internationalization bundles]: /docs/language/#internationalization-bundles
 

--- a/docsy.dev/content/en/docs/content/print.md
+++ b/docsy.dev/content/en/docs/content/print.md
@@ -1,9 +1,7 @@
 ---
-title: 'Print Support'
-linkTitle: 'Print Support'
+title: Print Support
 weight: 7
-description: >
-  Making it easier to print entire sections of documentation.
+description: Making it easier to print entire sections of documentation.
 ---
 
 Individual documentation pages print well from most browsers as the layouts have

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1067,6 +1067,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T10:05:47.5945-05:00"
   },
+  "https://github.com/google/docsy/issues/2404": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-23T11:57:05.06015-05:00"
+  },
   "https://github.com/google/docsy/issues/331": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:26.805722-05:00"
@@ -1421,7 +1425,7 @@
   },
   "https://github.com/google/docsy/tree/main/CONTRIBUTING.md": {
     "StatusCode": 206,
-    "LastSeen": "2025-11-16T18:27:35.339611-05:00"
+    "LastSeen": "2025-11-23T09:55:04.730025-05:00"
   },
   "https://github.com/google/docsy/tree/main/README.md": {
     "StatusCode": 206,

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -10,9 +10,9 @@
 {{ if not .Params.notoc -}}
   {{ $toc := .TableOfContents -}}
   {{ if and $toc (ne $toc `<nav id="TableOfContents"></nav>`) -}}
-    <div class="td-toc__title">
-      <span class="td-toc__title__text">{{ i18n "toc_on_this_page" }}</span>
-      <a class="td-toc__title__link" title="{{ i18n "toc_top_of_page" }}" href="#"></a>
+    <div class="td-toc-title">
+      <span class="td-toc-title__text">{{ i18n "toc_on_this_page" }}</span>
+      <a class="td-toc-title__link" title="{{ i18n "toc_top_of_page" }}" href="#"></a>
     </div>
     {{ $toc | safeHTML }}
   {{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+76-g14c2061",
+  "version": "0.13.0-dev+77-gbd7f023",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Documents the `notoc` feature that has been present from the time Docsy was made public 7+ years ago 😲 😄 
- Renames TOC CSS classes for nested components, making them more BEM like

**Preview**: https://deploy-preview-2405--docsydocs.netlify.app/docs/content/navigation/#table-of-contents