### PR TITLE
Update changelog for navbar scroll indicators and notoc docs

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,6 +23,7 @@
     "tabpane",
     "unmarshal",
     "upvote",
+    "viewports",
     "warnf",
     "warnidf",
     "wrapup"

--- a/docsy.dev/content/en/site/changelog.md
+++ b/docsy.dev/content/en/site/changelog.md
@@ -81,11 +81,14 @@ See [semver].
 - **Dark mode** fixes and improvements:
   - [Flash Of Unstyled Content][0.13.0-blog-fouc] (FOUC) ([#2332]).
   - Improved TOC entry color contrast in dark mode ([#2376], [#2379]).
+- **Mobile navbar**: Added scroll indicators for overflow navigation ([#2406]).
 - Better **NPM support**: resolved optional and peer dependency issues
   ([#2115]). See [breaking changes][0.13.0-blog-breaking] in the blog post.
 - **Dependency updates**: Bootstrap 5.3.8, Hugo 0.152.2, Node LTS ≥24.
 - **Updated translations**: added Occitan locale ([#2173]) and refreshed
   Simplified Chinese ([#2313]) and Ukrainian ([#2331]).
+- **TOC visibility control**: Documented the `notoc` page parameter (available
+  since 2016) for hiding the table of contents on specific pages ([#2405]).
 - **Build-time rendering of mathematical and chemical formulae**: now using
   Hugo's embedded KaTeX engine ([#2276], [#2394], [#2395]). For details, see
   [LaTeX support with KaTeX][diagrams-formulae].
@@ -115,6 +118,8 @@ See [semver].
 [#2387]: https://github.com/google/docsy/pull/2387
 [#2394]: https://github.com/google/docsy/pull/2394
 [#2395]: https://github.com/google/docsy/pull/2395
+[#2405]: https://github.com/google/docsy/pull/2405
+[#2406]: https://github.com/google/docsy/pull/2406
 [#941]: https://github.com/google/docsy/pull/941
 [0.13.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.13.0
 [0.13.0-blog]: /blog/2025/0.13.0/

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1315,6 +1315,14 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-22T21:21:23.506177-05:00"
   },
+  "https://github.com/google/docsy/pull/2405": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-23T18:36:01.689139-05:00"
+  },
+  "https://github.com/google/docsy/pull/2406": {
+    "StatusCode": 206,
+    "LastSeen": "2025-11-23T18:36:01.234519-05:00"
+  },
   "https://github.com/google/docsy/pull/941": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:32:55.725597-05:00"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0-dev+78-gd3b5749",
+  "version": "0.13.0-dev+79-gf59cbb8",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.13/commit-inventory.md
+++ b/tasks/0.13/commit-inventory.md
@@ -4,7 +4,7 @@ date: 2025-11-12
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `14c2061` on `main`.
+> Report refreshed for commits through `f59cbb8` on `main`.
 
 Chronological list of [commits since v0.12.0][], broadly grouped into a few
 categories. We'll do a more detailed analysis and groupings when we create the
@@ -81,6 +81,10 @@ client projects.
   rendering
 - `f2b0c56` (`#2399`) Add TOC style customization section to navigation docs
 - `14c2061` (`#2400`) Add i18n support for table of contents labels
+- `bd7f023` (`#2402`) Document i18n support for TOC labels, update task docs
+- `d3b5749` (`#2405`) Document `notoc`, and update TOC CSS class names
+- `f59cbb8` (`#2406`) [UX] Show left/right scroll indicators for the navbar on
+  mobile
 
 ## CI / tooling only
 

--- a/tasks/0.13/issue-mapping.md
+++ b/tasks/0.13/issue-mapping.md
@@ -4,7 +4,7 @@ date: 2025-11-12
 cSpell:ignore: docsy sidemenu FOUC katex mhchem sidenav
 ---
 
-> Report refreshed for commits through `14c2061` on `main`.
+> Report refreshed for commits through `f59cbb8` on `main`.
 
 Mapping [commits since v0.12.0][] to their originating issues (when known).
 
@@ -79,6 +79,9 @@ Mapping [commits since v0.12.0][] to their originating issues (when known).
 | `a2cd44e` | `#2398` | Update changelogs and reports for KaTeX build-time rendering                          | `#2266`              | Release documentation maintenance                                        |
 | `f2b0c56` | `#2399` | Add TOC style customization section to navigation docs                                | `#2289`              | Documentation for TOC customization (ScrollSpy follow-up)                |
 | `14c2061` | `#2400` | Add i18n support for table of contents labels                                         | `#2289`              | Localization support for TOC "On this page" and "Top of page"            |
+| `bd7f023` | `#2402` | Document i18n support for TOC labels, update task docs                                | `#2289`              | Documentation follow-up for TOC i18n                                     |
+| `d3b5749` | `#2405` | Document `notoc`, and update TOC CSS class names                                      | `#2289`              | Documentation for `notoc` parameter and TOC CSS class updates            |
+| `f59cbb8` | `#2406` | [UX] Show left/right scroll indicators for the navbar on mobile                       | —                    | UX improvement for mobile navbar scrolling                               |
 
 ## CI / tooling commits
 

--- a/tasks/0.13/release-wrapup.plan.md
+++ b/tasks/0.13/release-wrapup.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.13 Release wrapup plan
 date: 2025-11-12
-last-main-commit: 14c2061
+last-main-commit: f59cbb8
 cSpell:ignore: docsy
 ---
 
@@ -79,9 +79,9 @@ Repeat when new commits land on `main` do the following:
 - Take note of fixes and features that are not yet documented in the blog post
   or changelog.
 
-Report refreshed for commits through [14c2061] (includes TOC i18n support, TOC
-style customization docs, KaTeX build-time rendering, dark mode enhancements,
-ScrollSpy fixes, and documentation updates).
+Report refreshed for commits through [f59cbb8] (includes mobile navbar scroll
+indicators, TOC i18n support, TOC style customization docs, KaTeX build-time
+rendering, dark mode enhancements, ScrollSpy fixes, and documentation updates).
 
 ### 0.13.0 blog post
 
@@ -109,6 +109,6 @@ ScrollSpy fixes, and documentation updates).
 
 [0.13.0 release report]: ../docsy.dev/content/en/blog/2025/0.13.0.md
 [0.13.0-changelog]: ../../docsy.dev/content/en/site/changelog/#v0130
-[14c2061]: https://github.com/google/docsy/commit/14c2061
+[f59cbb8]: https://github.com/google/docsy/commit/f59cbb8
 [v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main
 [0.13.0 blog post]: ../docsy.dev/content/en/blog/2025/0.13.0.md

--- a/tasks/0.13/wrapup-report.md
+++ b/tasks/0.13/wrapup-report.md
@@ -4,7 +4,7 @@ date: 2025-11-12
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `14c2061` on `main`.
+> Report refreshed for commits through `f59cbb8` on `main`.
 
 ## Highlights since v0.12.0
 


### PR DESCRIPTION
- CL entry for #2406
- Also mentions `notoc` docs

**Preview**: https://deploy-preview-2407--docsydocs.netlify.app/site/changelog/#v0130