### PR TITLE
Change link title from 'Documentation' to 'Docs'

### DIFF
--- a/docsy.dev/content/en/docs/_index.md
+++ b/docsy.dev/content/en/docs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Welcome to Docsy
-linkTitle: Documentation
+linkTitle: Docs
 menu: { main: { weight: 20 } }
 ---
 


### PR DESCRIPTION
- Shortens the linkTitle for the docs landing page. This save horizontal real estate on mobile:
  > <img width="333" alt="image" src="https://github.com/user-attachments/assets/2344c4b4-0ee5-44a2-a28f-69e8f454eeee" />

- Any objections @LisaFC?

**Preview**: https://deploy-preview-2408--docsydocs.netlify.app/docs/

