### PR TITLE
Update changelog anchors, release process docs, and vers to 0.13.1-dev

### DIFF
--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -109,7 +109,7 @@ related to Bootstrap, such as:
   required
 
 For the complete list of changes, see the
-[CHANGELOG at 0.7.0](/site/changelog/#v070).
+[CHANGELOG at 0.7.0](/site/changelog/#v0.7.0).
 
 ## Case studies
 

--- a/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
+++ b/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
@@ -224,7 +224,7 @@ change to a ​​`media-breakpoint-down()` argument, as discussed earlier.
 
 During the migration effort we seized the opportunity to do some long overdue
 Docsy house cleaning. For details concerning both breaking and non-breaking
-Docsy-specific changes, consult the [changelog](/site/changelog/#v070). In
+Docsy-specific changes, consult the [changelog](/site/changelog/#v0.7.0). In
 particular, one non-breaking but important change to be aware of is:
 [[BSv5] Docsy variables cleanup ... PR #1462](https://github.com/google/docsy/pull/1462).
 
@@ -238,7 +238,7 @@ build of the Docsy User Guide: the
 
 After such a smoke test, we recommend systematically walking through the
 Bootstrap [migration page](https://getbootstrap.com/docs/5.2/migration/) as
-described above, and the Docsy [changelog](/site/changelog/#v070). I used this
+described above, and the Docsy [changelog](/site/changelog/#v0.7.0). I used this
 approach for [opentelemetry.io](https://opentelemetry.io/), which was the first
 Docsy-based project to be upgraded with a pre-release of Bootstrap-5-based
 Docsy. The upgrade went

--- a/docsy.dev/content/en/blog/2024/0.10.0.md
+++ b/docsy.dev/content/en/blog/2024/0.10.0.md
@@ -104,5 +104,5 @@ release, remember to upvote (with a thumbs up) the associated issue or PR.
 
 {{% /alert %}}
 
-[CL@0.10.0]: /site/changelog/#v010
+[CL@0.10.0]: /site/changelog/#v0.10.0
 [0.10.0]: https://github.com/google/docsy/releases/tag/v0.10.0

--- a/docsy.dev/content/en/blog/2024/0.9.0.md
+++ b/docsy.dev/content/en/blog/2024/0.9.0.md
@@ -207,7 +207,7 @@ specifically:
 [#1852]: https://github.com/google/docsy/issues/1852
 [#2]: https://github.com/google/docsy/issues/2
 [blocks/feature]: /docs/content/shortcodes/#blocksfeature
-[CL@0.9.0]: /site/changelog/#v090
+[CL@0.9.0]: /site/changelog/#v0.9.0
 [functions]: https://gohugo.io/functions/
 [hook]: https://gohugo.io/templates/render-hooks/
 [Hugo 0.112.0]: https://github.com/gohugoio/hugo/releases/tag/v0.112.0

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -22,8 +22,8 @@ In this post you'll walk through the upgrade process for:
 - **[Hugo](#update-hugo)**: 0.136.2 → 0.147.5&nbsp;[^vers-note]
 - **[Node](#update-nodejs)**: LTS 20 → LTS 22&nbsp;[^vers-note]
 
-[0.11.0]: /site/changelog/#v0110
-[0.12.0]: /site/changelog/#v0120
+[0.11.0]: /site/changelog/#v0.11.0
+[0.12.0]: /site/changelog/#v0.12.0
 
 [^vers-note]:
     These are the officially supported Node.js and Hugo versions associated with
@@ -258,7 +258,7 @@ Use this checklist to verify that your upgrade succeeded:
 
 For the full release notes, see:
 
-- [Docsy v0.12.0 changelog](/site/changelog/#v0120)
+- [Docsy v0.12.0 changelog](/site/changelog/#v0.12.0)
 - [Hugo release notes](https://github.com/gohugoio/hugo/releases) from 0.136.2
   (or your starting Hugo version) to 0.147.5.
 
@@ -266,7 +266,7 @@ Other references:
 
 - [Hugo 0.146.0 template system][NTS]
 - [0.11.0 release highlights](../2024/year-in-review/#release-highlights)
-- [0.11.0 changelog](/site/changelog/#v0110)
+- [0.11.0 changelog](/site/changelog/#v0.11.0)
 - [Docsy issue #2243][#2243], _Adapt to new template system in Hugo v0.146.0_.
 - [0.13.0 release report and upgrade guide](/blog/2025/0.13.0/) — for upgrading
   from 0.12.0 to 0.13.0

--- a/docsy.dev/content/en/blog/2025/0.13.0.md
+++ b/docsy.dev/content/en/blog/2025/0.13.0.md
@@ -437,9 +437,9 @@ Other references:
 [#2266]: https://github.com/google/docsy/issues/2266
 [#2313]: https://github.com/google/docsy/issues/2313
 [#2331]: https://github.com/google/docsy/issues/2331
-[0.12.0]: /site/changelog/#v0120
+[0.12.0]: /site/changelog/#v0.12.0
 [0.13.0]: https://github.com/google/docsy/releases/v0.13.0
 [alert]: /docs/content/shortcodes/#alert
-[CL@0.13.0]: /site/changelog/#v0130
+[CL@0.13.0]: /site/changelog/#v0.13.0
 [upgrade-0.12]: /blog/2025/0.12.0/
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/

--- a/docsy.dev/content/en/docs/content/feedback.md
+++ b/docsy.dev/content/en/docs/content/feedback.md
@@ -122,7 +122,7 @@ As of Docsy version [0.8.0], feedback will be enabled whether
 `site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
 case where analytics is configured outside of Docsy.
 
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#v0.8.0
 
 {{% /alert %}}
 
@@ -193,7 +193,7 @@ Page feedback is reported to Google Analytics through [events].
 As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful`
 events, rather than `click` events.
 
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#v0.8.0
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/content/repository-links.md
+++ b/docsy.dev/content/en/docs/content/repository-links.md
@@ -403,7 +403,7 @@ for your project.
 
 Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
 
-[v0.9.0]: /site/changelog/#v090
+[v0.9.0]: /site/changelog/#v0.9.0
 
 {{% /alert %}}
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -346,7 +346,7 @@ set the environment variable `DOCSY_MKDIR_HUGO_MOD_SKIP=1` before running NPM
 install.
 
 [#1120]: https://github.com/google/docsy/issues/1120
-[0.8.0]: /site/changelog/#v080
+[0.8.0]: /site/changelog/#v0.8.0
 [hugo module]: /docs/get-started/docsy-as-module/
 
 {{% /alert %}}

--- a/docsy.dev/content/en/site/changelog.md
+++ b/docsy.dev/content/en/site/changelog.md
@@ -3,7 +3,7 @@ title: Changelog
 description: Docsy repository changelog
 weight: 99999
 # prettier-ignore
-cSpell:ignore: blockssection deining docsy FOUC gitmodules gtag lookandfeel mhchem navs tabpane katex
+cSpell:ignore: blockssection deining docsy FOUC gitmodules gtag katex lookandfeel mhchem navs notoc tabpane
 ---
 
 We only document **breaking changes** and release **highlights** in this page.
@@ -52,7 +52,23 @@ See [semver].
 
 <!-- TODO: look into https://www.conventionalcommits.org/en/v1.0.0/#summary -->
 
-## v0.13.0
+## v0.14.0 or v0.13.1 {#v0.14.0}
+
+> **UNRELEASED: this planned version is still under development**
+
+For the full list of changes, see the [0.X.Y] release page.
+
+**Breaking changes**:
+
+- ...
+
+**New**:
+
+**Other changes**:
+
+[0.X.Y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+
+## v0.13.0 {#v0.13.0}
 
 **Resources**:
 
@@ -119,7 +135,7 @@ See [semver].
 [#2405]: https://github.com/google/docsy/pull/2405
 [#2406]: https://github.com/google/docsy/pull/2406
 [#941]: https://github.com/google/docsy/pull/941
-[0.13.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.13.0
+[0.13.0]: https://github.com/google/docsy/releases/v0.13.0
 [0.13.0-blog]: /blog/2025/0.13.0/
 [0.13.0-blog-lang-menu]: /blog/2025/0.13.0/#language-menu-visibility
 [0.13.0-blog-alert]: /blog/2025/0.13.0/#alert-shortcode
@@ -133,7 +149,7 @@ See [semver].
 [How to pick colors with good color-contrast]:
   /docs/content/lookandfeel/#pick-good-color-contrast
 
-## v0.12.0
+## v0.12.0 {#v0.12.0}
 
 For the full list of changes, see the [0.12.0] release page.
 
@@ -197,7 +213,7 @@ For the full list of changes, see the [0.12.0] release page.
 [_td-content-after-header.html]:
   https://github.com/google/docsy/blob/main/layouts/_td-content-after-header.html
 
-## v0.11.0
+## v0.11.0 {#v0.11.0}
 
 For the full list of changes, see the [0.11.0] release page.
 
@@ -216,7 +232,7 @@ For the full list of changes, see the [0.11.0] release page.
 [params.ui.sidebar_menu_truncate]: /docs/content/navigation/#side-nav-options
 [rtl]: /docs/language/#right-to-left-languages
 
-## v0.10.0
+## v0.10.0 {#v0.10.0}
 
 For an introduction to this release, see the [0.10.0 release report]. For the
 full list of changes, see the [0.10.0] release page.
@@ -226,7 +242,7 @@ dark-mode support][dark-mode].
 
 **Breaking changes**:
 
-- Removes shortcode `card-code` that was [deprecated in 0.7.0](#v070); use
+- Removes shortcode `card-code` that was [deprecated in 0.7.0](#v0.7.0); use
   shortcode `card` with named parameter `code=true` instead.
 - The following SCSS variables are inlined in favor of dark-mode compatible
   styling: `$border-color`, `$td-sidebar-tree-root-color`,
@@ -243,13 +259,13 @@ dark-mode support][dark-mode].
 [0.10.0 release report]: /blog/2024/0.10.0/
 [dark-mode]: /blog/2024/0.10.0/#color-themes-and-dark-mode-support
 
-## v0.9.1
+## v0.9.1 {#v0.9.1}
 
 Patch release. For details, see [0.9.1].
 
 [0.9.1]: https://github.com/google/docsy/releases/v0.9.1
 
-## v0.9.0
+## v0.9.0 {#v0.9.0}
 
 For an introduction and commentary, see the [0.9.0 release report]. For the full
 list of commits, see the [0.9.0] release page. The most significant changes of
@@ -310,7 +326,7 @@ For details concerning all footer changes, see [#1818].
 [union file system]:
   https://gohugo.io/getting-started/directory-structure/#union-file-system
 
-## v0.8.0
+## v0.8.0 {#v0.8.0}
 
 For the full list of changes, see the [0.8.0] release page.
 
@@ -346,7 +362,7 @@ For the full list of changes, see the [0.8.0] release page.
 [Use Docsy as a Hugo Module]: /docs/get-started/docsy-as-module/
 [User feedback]: /docs/content/feedback/#user-feedback
 
-## v0.7.2
+## v0.7.2 {#v0.7.2}
 
 For the full list of changes, see the [0.7.2] release page. We mention some
 noteworthy changes here:
@@ -373,7 +389,7 @@ noteworthy changes here:
 [Algolia DocSearch]: /docs/content/search/#algolia-docsearch
 [Tabbed panes]: /docs/content/shortcodes/#tabbed-panes
 
-## v0.7.1
+## v0.7.1 {#v0.7.1}
 
 For the full list of changes, see the [0.7.1] release page.
 
@@ -388,7 +404,7 @@ Followup changes to **Bootstrap (BS) 5.2 upgrade** ([#470]):
 [#1579]: https://github.com/google/docsy/issues/1579
 [0.7.1]: https://github.com/google/docsy/releases/v0.7.1
 
-## v0.7.0
+## v0.7.0 {#v0.7.0}
 
 For the full list of changes, see the [0.7.0] release page.
 
@@ -452,7 +468,7 @@ For the full list of changes, see the [0.7.0] release page.
 [bsv5mig]: https://getbootstrap.com/docs/5.2/migration/
 [hugo-releases]: https://github.com/gohugoio/hugo/releases
 
-## v0.6.0
+## v0.6.0 {#v0.6.0}
 
 For the full list of changes, see the [0.6.0] release page.
 
@@ -473,7 +489,7 @@ Bootstrap version. See [the announcement][bs-announcement] for more information.
 [0.6.0]: https://github.com/google/docsy/releases/v0.6.0
 [bs-announcement]: https://github.com/google/docsy/discussions/1308
 
-## v0.5.1
+## v0.5.1 {#v0.5.1}
 
 For the full list of changes, see the [0.5.1] release page. **BREAKING CHANGES**
 are documented below.
@@ -524,11 +540,11 @@ are documented below.
 [what's changed in v6]:
   https://docs.fontawesome.com/v6/web/setup/upgrade/whats-changed
 
-## v0.5.0
+## v0.5.0 {#v0.5.0}
 
 Unpublished.
 
-## v0.4.0
+## v0.4.0 {#v0.4.0}
 
 For the full list of changes, see the [0.4.0] release page. Potential **BREAKING
 CHANGES** are documented below.
@@ -584,7 +600,7 @@ Proceed as usual to build or serve your site.
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
 
-## v0.3.0
+## v0.3.0 {#v0.3.0}
 
 For the full list of changes, see the [0.3.0] release page.
 
@@ -603,7 +619,7 @@ For the full list of changes, see the [0.3.0] release page.
 [#1009]: https://github.com/google/docsy/pull/1009
 [issue #1154]: https://github.com/google/docsy/issues/1154
 
-## v0.2.0
+## v0.2.0 {#v0.2.0}
 
 For the full list of changes, see the [0.2.0] release page.
 
@@ -629,7 +645,7 @@ For the full list of changes, see the [0.2.0] release page.
 
 > **UNRELEASED: this planned version is still under development**
 
-For the full list of changes, see the [0.x.y] release page.
+For the full list of changes, see the [0.X.Y] release page.
 
 **Breaking changes**:
 
@@ -639,7 +655,7 @@ For the full list of changes, see the [0.x.y] release page.
 
 **Other changes**:
 
-[0.x.y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
+[0.X.Y]: https://github.com/google/docsy/releases/latest?FIXME=v0.X.Y
 ```
 
 ---------------------------------------------------------------------------->

--- a/docsy.dev/content/en/site/contributing.md
+++ b/docsy.dev/content/en/site/contributing.md
@@ -47,19 +47,20 @@ See the [contribution guidelines][] in the Docsy user guide.
 
 ## Publishing a release
 
-These notes are WIP for creating a **release (v0.X.Y)** from a local copy of the
-repo.
+These notes are WIP for creating a **release** from a local copy of the repo.
+These instructions assume the release is {{% param version %}}, if not adjust
+accordingly.
 
 1.  **Change directory** to your local Docsy repo.
 
-2.  **Create or update a [CHANGELOG] entry** for v0.X.Y.
+2.  **Create or update a [CHANGELOG] entry** for {{% param version %}}.
     - The section should provide a brief summary of breaking changes using the
       section template at the end of the file.
     - Ensure to remove the UNRELEASED note.
     - You'll create a new section for the next release in a later step.
 
-3.  **Update the release report blog post** for v0.X.Y, if any. Remove draft
-    status.
+3.  **Update the release report blog post** for {{% param version %}}, if any.
+    Remove draft status.
 
 4.  Run `npm run fix`.
 
@@ -67,11 +68,12 @@ repo.
     > but you can ignore this change since you'll be setting the version
     > explicitly in the next step.
 
-5.  **Update Docsy version** to v0.X.Y using the following from a (bash or zsh)
-    terminal:
+5.  **Update Docsy version** to {{% param version %}} using the following from a
+    (bash or zsh) terminal:
 
     ```sh
-    VERSION=0.X.Y # Replace with the actual version
+    # Version {{% param version %}} or 0.X.Y; replace with actual version
+    VERSION={{% param version %}}
     npm run set:package-version -- --version $VERSION
     ```
 
@@ -81,8 +83,9 @@ repo.
 6.  Run `npm run ci:test`, which runs `ci:prepare` and more to ensure that,
     e.g., vendor assets and [go.mod] dependencies are up-to-date, etc.
 
-7.  **Submit a PR with your changes**, using a title like "Release v0.X.Y
-    preparation". Use this command to create the PR via the web interface:
+7.  **Submit a PR with your changes**, using a title like "Release
+    {{% param version %}}" preparation". Use this command to create the PR via
+    the web interface:
 
     ```sh
     gh pr create --web --title "Release $VERSION preparation" \
@@ -96,7 +99,7 @@ repo.
       ```sh
       cd themes/docs
       git fetch
-      git switch -t REPO/BRANCH-NAME # e.g. chalin/chalin-m25-0.13.0-prerelease
+      git switch -t REPO/BRANCH-NAME # e.g. chalin/chalin-m24-0.14.0-pre-release
       ```
 
 9.  **Get PR approved and merged**.
@@ -105,20 +108,24 @@ repo.
 
 11. **Ensure** that you're:
     - On the default branch, `main`
-    - At the commit that you want to tag as v0.X.Y
+    - At the commit that you want to tag as {{% param version %}}
 
-12. **Create and push a tag** for v0.X.Y. Set the REL variable to the actual
-    version, or use the VERSION variable if you set it in the previous step.
+12. **Create and push a tag** for {{% param version %}}. Set the REL variable to
+    the release version or use the `VERSION` variable if you set it in the
+    previous step.
 
     ```sh
-    REL=v0.X.Y # Replace with the actual version
-    REL=v$VERSION # Or use previously set variable
+    # Replace with the actual version, or use the VERSION variable
+    REL=v{{% param version %}}
+    REL=v$VERSION
+    echo "REL=$REL"
     ```
 
     Then:
 
     ```sh
     git tag $REL
+    git tag --list | grep $REL
     ```
 
 13. **Push the new tags** to the main remote (`origin` or `upstream` depending
@@ -127,23 +134,51 @@ repo.
     ```console
     $ git push upstream $REL
     ...
-    * [new tag]         v0.X.Y -> v0.X.Y
+    * [new tag]         v{{% param version %}} -> v{{% param version %}}
+    ```
+
+    You can push to all remotes with this alias.[^push-all-remotes] First check
+    if it's already defined.
+
+    [^push-all-remotes]:
+        You only need to run this command once. Using `--global` will make the
+        alias available in all your Git repositories; it can be omitted to make
+        the alias available only in the current repository.
+
+    ```console
+    $ git config --global --list | grep alias.push-all-remotes
+    $ git config --global alias.push-all-remotes \
+        '!f() { for r in $(git remote); do (set -x; git push "$r" "$1"); done; }; f'
+    ```
+
+    Then:
+
+    ```console
+    $ git push-all-remotes $REL
+    + git push origin v{{% param version %}}
+    * [new tag]         v{{% param version %}} -> v{{% param version %}}
+    + git push upstream v{{% param version %}}
+    * [new tag]         v{{% param version %}} -> v{{% param version %}}
+    ...
     ```
 
 14. **[Draft a new release][]** using GitHub web; fill in the fields as follows:
     - From the **release/tag dropdown**: Select the new release tag that you
-      just pushed, v0.X.Y.
-    - Set the **release title** to the release number (without the "v").
+      just pushed, v{{% param version %}}.
+
+    - Set the **release title** to the release version:
+
+      ```text
+      v{{% param version %}}
+      ```
+
     - Click **Generate release notes** to get the release details inserted into
       the release notes text area.
-    - Add the following text atop the generated release notes, but replace the
-      `0XY` anchor target with a target appropriate for this release:
+
+    - Add the following text atop the generated release notes:
 
       ```markdown
-      ## Release summary
-
-      - [Release report](/blog/2024/0.X.Y/)
-      - [CHANGELOG](/site/changelog/#v0XY)
+      {{% release-summary %}}
       ```
 
     - Select **Create a discussion for this release**.
@@ -156,19 +191,32 @@ repo.
 
 ## Post-release followup
 
-Assuming that Docsy release v0.X.Y has been successfully deployed and use by at
-least one downstream project, then perform the following actions before any
-further changes are merged into the default branch:
+Assuming that Docsy release v{{% param version %}} has been successfully
+deployed and use by at least one downstream project, then perform the following
+actions before any further changes are merged into the default branch:
 
 1. Set `version` in [package.json] to the next planned (or the next dot) release
-   with a dev suffix, such as `v0.X.Z-dev`.
+   with a dev suffix, such as `v0.X.Z-dev`. You can also run:
+
+   ```sh
+   npm run set:package-version -- --id ''
+   ```
+
 2. In the [CHANGELOG]:
    - **Create a new entry** for the next release by copying the ENTRY TEMPLATE
      at the end of the file.
-   - **Pin the 0.X.Y release URL**, which ends with `latest?FIXME=...`, to the
-     v0.X.Y release at `https://github.com/google/docsy/releases/v0.x.y`.
-3. **Submit a PR with your changes**, using a title like "Set NPM package
-   version to next unreleased dev version".
+
+   - **Pin the {{% param version %}} release URL**, which ends with
+     `latest?FIXME=...`, to the {{% param version %}} release at:
+
+     <https://github.com/google/docsy/releases/v{{% param version %}}>
+
+3. **Submit a PR with your changes**, using a title like:
+
+   ```text
+   Set NPM package version to next unreleased dev version
+   ```
+
 4. **Get PR approved and merged**.
 
 ## Release helper scripts

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://www.docsy.dev/
+# baseURL moved to be after params
 title: Docsy
 enableRobotsTXT: true
 enableGitInfo: true
@@ -57,6 +57,7 @@ markup:
     noClasses: false # Required for dark-mode
 
 params:
+  productionURL: &productionURL https://www.docsy.dev
   copyright:
     authors: >-
       Docsy Authors | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) |
@@ -139,6 +140,8 @@ params:
     enable: true
   drawio:
     enable: true
+
+baseURL: *productionURL
 
 taxonomies:
   tag: tags

--- a/docsy.dev/layouts/_shortcodes/release-summary.md
+++ b/docsy.dev/layouts/_shortcodes/release-summary.md
@@ -1,0 +1,40 @@
+{{/*
+  Generates release summary links for the version specified in page params.
+
+  Usage: {{% release-summary %}}
+
+  The version is read from .Params.version in the page's front matter.
+*/ -}}
+
+{{ $version := $.Page.Param "version" | string -}}
+{{ if not $version -}}
+  {{ errorf "%s: shortcode 'release-summary': version parameter not found in page or site params" .Position -}}
+{{ end -}}
+
+{{/* Get the blog section index page and search for a post matching the version */ -}}
+{{ $blogSection := $.Site.GetPage "/blog" -}}
+{{ $blogPage := false -}}
+{{ $currentYear := now.Year -}}
+{{ $years := slice $currentYear (add $currentYear -1) -}}
+{{ range $years -}}
+  {{ $postPath := printf "%d/%s" . $version -}}
+  {{ $blogPage = $blogSection.GetPage $postPath -}}
+  {{ if $blogPage }}{{ break }}{{ end -}}
+  {{ warnf "%s: shortcode 'release-summary': Blog post not found for version %q in year %d, path: %q" $version . $postPath -}}
+{{ end -}}
+
+{{ if not $blogPage -}}
+  {{ errorf "%s: shortcode 'release-summary': blog post not found for version %q during years: %q"
+      .Position $version (delimit $years ", ") -}}
+{{ end -}}
+
+{{ $changelogURL := printf "/site/changelog/#v%s" $version -}}
+{{ $productionURL := .Site.Params.productionURL -}}
+
+## Release summary
+
+- [{{ $blogPage.Title }}][blog-post]
+- [Changelog v{{ $version }}][changelog] entry
+
+[blog-post]: <{{ $productionURL }}{{ $blogPage.RelPermalink }}>
+[changelog]: <{{ $productionURL }}{{ $changelogURL }}>

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -679,18 +679,6 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:35.687149-05:00"
   },
-  "https://github.com/google/docsy/blob/main/CHANGELOG.md#v070": {
-    "StatusCode": 206,
-    "LastSeen": "2025-11-19T03:10:59.004293-05:00"
-  },
-  "https://github.com/google/docsy/blob/main/CHANGELOG.md/#v080": {
-    "StatusCode": 206,
-    "LastSeen": "2025-11-19T03:10:58.98347-05:00"
-  },
-  "https://github.com/google/docsy/blob/main/CHANGELOG.md/#v090": {
-    "StatusCode": 206,
-    "LastSeen": "2025-11-19T03:10:59.059607-05:00"
-  },
   "https://github.com/google/docsy/blob/main/CONTRIBUTING.md": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:37.093542-05:00"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.0",
+  "version": "0.13.1-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
     "fix-and-test": "echo 'RUNNING most FIXES AND TESTS...'; npm run fix-for-test && npm run test:website",
     "fix:format": "npm run -s _check:format -- --write && echo && npm run -s cd:docsy.dev fix:format",
     "fix:markdown": "npm run check:markdown -- --fix",
-    "fix:version": "npm run set:package-version -- --id $(scripts/get-build-id.sh)",
+    "fix:version": "npm run set:package-version -- --id \"$(scripts/get-build-id.sh)\"",
     "fix-for-test": "npm run fix:format && npm run fix:markdown && echo 'Skipping fix:version' && npm run cd:docsy.dev fix",
     "fix": "npm run fix:format && npm run fix:markdown && npm run fix:version && npm run cd:docsy.dev fix",
     "get:hugo-modules": "node scripts/getHugoModules/index.mjs",

--- a/scripts/set-package-version/index.mjs
+++ b/scripts/set-package-version/index.mjs
@@ -185,16 +185,16 @@ export function adjustVersionForBuildId(
 
   // Need to adjust: version doesn't end with -dev
   logger?.warn?.(
-    `Warning: Adding build ID to non-dev version. Incrementing minor version and adding -dev suffix.`,
+    `Warning: Adding build ID to non-dev version. Incrementing patch version and adding -dev suffix.`,
   );
 
-  // Parse version and increment minor
+  // Parse version and increment patch
   const versionMatch = baseVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
   if (versionMatch) {
     const major = parseInt(versionMatch[1], 10);
     const minor = parseInt(versionMatch[2], 10);
     const patch = parseInt(versionMatch[3], 10);
-    const incrementedBase = `${major}.${minor + 1}.${patch}-dev`;
+    const incrementedBase = `${major}.${minor}.${patch + 1}-dev`;
     return `${incrementedBase}+${buildId}`;
   }
 

--- a/scripts/set-package-version/index.test.mjs
+++ b/scripts/set-package-version/index.test.mjs
@@ -332,15 +332,15 @@ test('main adjusts non-dev version when adding build ID', () => {
     },
   });
 
-  assert.equal(pkg.version, '1.1.0-dev+build-123');
-  assert.deepEqual(writtenPkg, { version: '1.1.0-dev+build-123' });
+  assert.equal(pkg.version, '1.0.1-dev+build-123');
+  assert.deepEqual(writtenPkg, { version: '1.0.1-dev+build-123' });
   assert.equal(writeHugoYamlCallCount, 0); // hugo.yaml should not be updated
-  assert.equal(newVersion, '1.1.0-dev+build-123');
+  assert.equal(newVersion, '1.0.1-dev+build-123');
   assert.deepEqual(warnings, [
-    'Warning: Adding build ID to non-dev version. Incrementing minor version and adding -dev suffix.',
+    'Warning: Adding build ID to non-dev version. Incrementing patch version and adding -dev suffix.',
   ]);
   assert.deepEqual(messages, [
-    '✓ Updated version: 1.0.0 → 1.1.0-dev+build-123',
+    '✓ Updated version: 1.0.0 → 1.0.1-dev+build-123',
   ]);
 });
 
@@ -351,7 +351,7 @@ test('adjustVersionForBuildId adds build ID to dev version', () => {
   assert.equal(result, '1.0.0-dev+build-123');
 });
 
-test('adjustVersionForBuildId increments minor and adds -dev for non-dev version', () => {
+test('adjustVersionForBuildId increments patch and adds -dev for non-dev version', () => {
   const warnings = [];
   const logger = {
     warn(message) {
@@ -360,9 +360,9 @@ test('adjustVersionForBuildId increments minor and adds -dev for non-dev version
   };
 
   const result = adjustVersionForBuildId('1.0.0', 'build-123', { logger });
-  assert.equal(result, '1.1.0-dev+build-123');
+  assert.equal(result, '1.0.1-dev+build-123');
   assert.deepEqual(warnings, [
-    'Warning: Adding build ID to non-dev version. Incrementing minor version and adding -dev suffix.',
+    'Warning: Adding build ID to non-dev version. Incrementing patch version and adding -dev suffix.',
   ]);
 });
 
@@ -386,7 +386,7 @@ test('adjustVersionForBuildId handles unrecognized version format', () => {
   });
   assert.equal(result, 'invalid-version-dev+build-123');
   assert.deepEqual(warnings, [
-    'Warning: Adding build ID to non-dev version. Incrementing minor version and adding -dev suffix.',
+    'Warning: Adding build ID to non-dev version. Incrementing patch version and adding -dev suffix.',
     'Warning: Version format not recognized (invalid-version). Appending -dev suffix.',
   ]);
 });

--- a/tasks/0.13/release-wrapup.plan.md
+++ b/tasks/0.13/release-wrapup.plan.md
@@ -107,6 +107,6 @@ changelog updates, final release adjustments, and documentation improvements).
   significant changes.
 
 [0.13.0 release report]: ../docsy.dev/content/en/blog/2025/0.13.0.md
-[0.13.0-changelog]: ../../docsy.dev/content/en/site/changelog/#v0130
+[0.13.0-changelog]: ../../docsy.dev/content/en/site/changelog/#v0.13.0
 [v0.12.0...main]: https://github.com/google/docsy/compare/v0.12.0...main
 [0.13.0 blog post]: ../docsy.dev/content/en/blog/2025/0.13.0.md


### PR DESCRIPTION
- Contributes to #2404
- Standardizes changelog section anchors and references throughout the docs
- Improves release process instructions in `contributing.md` to use a Hugo parameter (`{{% param version %}}`) for version numbers, making the process clearer and less error-prone when preparing a new release.

**Preview**:

- https://deploy-preview-2415--docsydocs.netlify.app/site/changelog/#v0.14.0
- https://deploy-preview-2415--docsydocs.netlify.app/site/contributing/#publishing-a-release