### PR TITLE
docsy.dev: set to_year to "present", and shortcode cleanup

### DIFF
--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -62,6 +62,7 @@ params:
     authors: >-
       Docsy Authors | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0) |
     from_year: 2018
+    to_year: present
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
   version: 0.13.0

--- a/docsy.dev/layouts/_shortcodes/release-summary.md
+++ b/docsy.dev/layouts/_shortcodes/release-summary.md
@@ -20,7 +20,6 @@
   {{ $postPath := printf "%d/%s" . $version -}}
   {{ $blogPage = $blogSection.GetPage $postPath -}}
   {{ if $blogPage }}{{ break }}{{ end -}}
-  {{ warnf "%s: shortcode 'release-summary': Blog post not found for version %q in year %d, path: %q" $version . $postPath -}}
 {{ end -}}
 
 {{ if not $blogPage -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.1-dev",
+  "version": "0.13.1-dev+1-g69d4d6c",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Set current year to "present" in the copyright date range
- Drop informational "warning" from contrib page shortcode.