### PR TITLE
Upgrade Hugo to 0.154.3

### DIFF
--- a/assets/scss/td/chroma/_light.scss
+++ b/assets/scss/td/chroma/_light.scss
@@ -85,4 +85,4 @@
 /* GenericSubheading */ .chroma .gu { color:#800080;font-weight:bold }
 /* GenericTraceback */ .chroma .gt { color:#a40000;font-weight:bold }
 /* GenericUnderline */ .chroma .gl { color:#000;text-decoration:underline }
-/* TextWhitespace */ .chroma .w { color:#f8f8f8;text-decoration:underline }
+/* TextWhitespace */ .chroma .w { color:#f8f8f8 }

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.23",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.152.2",
+    "hugo-extended": "0.154.3-sudoless.1",
     "netlify-cli": "^23.13.3",
     "npm-check-updates": "^19.3.1",
     "postcss-cli": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.1-dev+2-g5fd8175",
+  "version": "0.13.1-dev+3-gb7f7335",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2429, hopefully solving it.
- ~I'm still seeing some strange behavior under macOS, that I resolve by manually "re-" installing `cross-env`.~ Seems to be gone after doing a _really_ clean build.
- Submitting this now to confirm whether the CI tests will still pass.

The changes to the generated site files seem to be due to:

- Chroma upgrade: empty spans have been removed, and the light style tweaked
- Image fingerprinting

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'class="(cl|cp|gi|k|nn|nt)"' -I '_hu_' -I 'Hugo 0.15' -- ':(exclude)*.xml') | grep ^diff | grep -v \.jpg
diff --git a/scss/main.css b/scss/main.css
diff --git a/scss/main.css.map b/scss/main.css.map
```