### PR TITLE
Update Hugo to 0.154.5

### DIFF
--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.23",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.154.3-sudoless.1",
+    "hugo-extended": "0.154.5",
     "netlify-cli": "^23.13.3",
     "npm-check-updates": "^19.3.1",
     "postcss-cli": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.1-dev+3-gb7f7335",
+  "version": "0.13.1-dev+4-g9334955",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2431
- Upgrades Hugo to 0.154.5 now that https://github.com/gohugoio/hugo/issues/14361 has been addressed

Generated site diff:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'Hugo 0.154')                                      
diff --git a/_print/docs/getting-started/index.html b/_print/docs/getting-started/index.html
index b4924d1..6ed8845 100644
--- a/_print/docs/getting-started/index.html
+++ b/_print/docs/getting-started/index.html
@@ -2,7 +2,7 @@
 <html lang="xx">
   <head>
     <title>http://localhost/xx/_print/docs/get-started/</title>
-    <link rel="canonical" href="http://localhost/xx/_print/docs/get-started/">
+    <link rel="canonical" href="http://localhost/xx/docs/get-started/">
     <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url=http://localhost/xx/_print/docs/get-started/">
   </head>
```

While the above shows that the canonical link is now more correct under the new version of Hugo (by referring to the original page not the print version), the reference to the `xx` language is wrong. I'll address that separately.