### PR TITLE
Fix broken link to render-passthrough.html, dump tool versions

### DIFF
--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -227,7 +227,7 @@ passthrough delimiter pairs defined above.
 >   actually have it setup.
 
 [layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html]:
-  https://github.com/google/docsy/blob/main/layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html
+  https://github.com/google/docsy/blob/main/docsy.dev/layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html
 
 ### Display of Chemical Equations and Physical Units
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -24,7 +24,7 @@ If you've already installed Hugo, check your version:
 hugo version
 ```
 
-If the result is `v0.109.0` or earlier, or if you don't see `Extended`, you'll need to install the latest version. You can see a complete list of Linux installation options in [Install Hugo](https://gohugo.io/getting-started/installing/#linux). The following shows you how to install Hugo from the release page:
+If the result is `v0.146.0` or earlier, or if you don't see `Extended`, you'll need to install the latest version. You can see a complete list of Linux installation options in [Install Hugo](https://gohugo.io/getting-started/installing/#linux). The following shows you how to install Hugo from the release page:
 
 1.  Go to the [Hugo releases](https://github.com/gohugoio/hugo/releases) page.
 2.  In the most recent release, scroll down until you find a list of
@@ -70,7 +70,7 @@ Hugo's commands for module management require that the Go programming language i
 
 ```console
 $ go version
-go version go1.24.3
+go version go1.25.6
 ```
 
 Ensure that you are using version 1.12 or higher.
@@ -84,7 +84,7 @@ Hugo's commands for module management require that the `git` client is installed
 
 ```console
 $ git version
-git version 2.49.0
+git version 2.52.0
 ```
 
 If no `git` client is installed on your system yet, go to the [Git website](https://git-scm.com/), download the installer for your system architecture and execute it. Afterwards, check for a successful installation.

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -739,6 +739,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:36.355089-05:00"
   },
+  "https://github.com/google/docsy/blob/main/docsy.dev/layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-19T02:03:33.626643523+01:00"
+  },
   "https://github.com/google/docsy/blob/main/go.mod": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:37.04329-05:00"


### PR DESCRIPTION
This PR fixes a broken link in the user guide.
This PR also bump versions of the prerequisites mentioned in the user guide.