### PR TITLE
Update README, contrib docs for deployment and release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ details about the various usage options.
 
 Docsy has its own user guide (using Docsy, of course!) with lots more
 information about using the theme. It is hosted by [Netlify] at
-[docsy.dev](https://docsy.dev). For deploy logs and more, see [Deploys] from the
-site's Netlify dashboard.
+[docsy.dev](https://docsy.dev/).
+
+**Maintainers**: you can access deploy logs, the [deploy preview of
+`main`][main-preview], and more from the [Deploys] section of the site's Netlify
+dashboard.
 
 Alternatively you can use Hugo to generate and serve a local copy of the guide
 (also useful for testing local theme changes), making sure you have installed
@@ -77,7 +80,7 @@ all the prerequisites listed above:
 
 ```sh
 git clone --depth 1 https://github.com/google/docsy.git
-cd docsy/docsy.dev/
+cd docsy
 npm install
 npm run serve
 ```
@@ -90,13 +93,16 @@ requests, see [CONTRIBUTING.md]. Thank you to all past, present, and future
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see
-[LICENSE](https://github.com/google/docsy/blob/main/LICENSE) for details
+This project is licensed under the Apache License 2.0, see
+[LICENSE](https://github.com/google/docsy/blob/main/LICENSE) for details.
 
 [code of conduct]:
   https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md
 [CONTRIBUTING.md]: https://github.com/google/docsy/blob/main/CONTRIBUTING.md
 [contributors]: https://github.com/google/docsy/graphs/contributors
 [deploys]: https://app.netlify.com/sites/docsydocs/deploys
+[main-preview]: https://main--docsydocs.netlify.app/
 [netlify]: https://netlify.com
 [releases]: https://github.com/google/docsy/releases
+
+<!-- cSpell:ignore docsy -->

--- a/docsy.dev/content/en/site/contributing.md
+++ b/docsy.dev/content/en/site/contributing.md
@@ -188,6 +188,11 @@ accordingly.
 17. If you find issues, determine whether they need to be fixed immediately. If
     so, get fixes submitted, reviewed and approved. Then publish a dot release:
     go back to step 1.
+18. Update the [`release` branch][release-branch] to refer to the commit that
+    you tagged as {{% param version %}}. This will trigger a production deploy
+    of the website.
+19. Wait for the production deploy to complete, and checks that [docsy.dev]
+    updates are visible.
 
 ## Post-release followup
 
@@ -231,6 +236,7 @@ actions before any further changes are merged into the default branch:
 [CHANGELOG]: /site/changelog/
 [contribution guidelines]: /docs/contribution-guidelines/
 [docsy-example]: https://github.com/google/docsy-example
+[docsy.dev]: https://www.docsy.dev/
 [Draft a new release]: https://github.com/google/docsy/releases/new
 [go.mod]: https://github.com/google/docsy/blob/main/go.mod
 [package.json]: https://github.com/google/docsy/blob/main/package.json

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -283,6 +283,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:23.110933-05:00"
   },
+  "https://docsy.dev/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T17:56:33.239145-05:00"
+  },
   "https://docsy.dev/docs/get-started/other-options/#docsy-npm-install-side-effect": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:37.09511-05:00"
@@ -2138,6 +2142,10 @@
   "https://lunrjs.com/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:23.708187-05:00"
+  },
+  "https://main--docsydocs.netlify.app/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T17:53:26.999006-05:00"
   },
   "https://markmap.js.org/": {
     "StatusCode": 206,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.1-dev+10-g13ba7b2",
+  "version": "0.13.1-dev+13-g6c1e391",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2436
- Update repo README: add link to `main`'s deploy preview. Other copyedits
- Updates contrib docs: adds step to update `release` branch, etc.