### PR TITLE
Add version to docs index page, bump version to 0.14.0-dev

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -4,6 +4,7 @@
   "caseSensitive": true,
   "words": [
     "anchorize",
+    "docset",
     "Docsy",
     "errorf",
     "Gantt",

--- a/docsy.dev/.htmltest.yml
+++ b/docsy.dev/.htmltest.yml
@@ -17,6 +17,8 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   - index.xml$ # ignore <link rel=alternate ...>
   - ^https?://[^/]+/(categories|tags)/ # ignore Docsy-generated content
   - ^https?://localhost\b
+  # Ignore links to non-existent -dev versions ...
+  - ^https://github.com/google/docsy/releases/v[\d\.]+-dev
   # Ignore all deploy preview URLs because link checking is done before the preview is served
   - ^https://deploy-preview-\d+--docsydocs.netlify.app
   # Ignore Docsy-generated GitHub links for now

--- a/docsy.dev/content/en/docs/_index.md
+++ b/docsy.dev/content/en/docs/_index.md
@@ -2,11 +2,16 @@
 title: Welcome to Docsy
 linkTitle: Docs
 menu: { main: { weight: 20 } }
+cSpell:ignore: vsoch
 ---
 
-Welcome to the Docsy theme user guide! This guide shows you how to get started
-creating technical documentation sites using Docsy, including site customization
-and how to use Docsy's blocks and templates.
+Welcome to the Docsy theme user guide for version [{{% param version
+%}}][docsy-version]! This guide shows you how to get started creating technical
+documentation sites using Docsy, including site customization and how to use
+Docsy's blocks and templates.
+
+[docsy-version]:
+  <https://github.com/google/docsy/releases/v{{% param version %}}>
 
 ## What is Docsy?
 

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -65,7 +65,7 @@ params:
     to_year: present
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
-  version: 0.13.0
+  version: 0.14.0-dev
   url_latest_version: https://example.com
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy

--- a/docsy.dev/layouts/_shortcodes/release-summary.md
+++ b/docsy.dev/layouts/_shortcodes/release-summary.md
@@ -7,6 +7,7 @@
 */ -}}
 
 {{ $version := $.Page.Param "version" | string -}}
+{{ $isDevVersion := strings.Contains $version "-dev" -}}
 {{ if not $version -}}
   {{ errorf "%s: shortcode 'release-summary': version parameter not found in page or site params" .Position -}}
 {{ end -}}
@@ -22,7 +23,7 @@
   {{ if $blogPage }}{{ break }}{{ end -}}
 {{ end -}}
 
-{{ if not $blogPage -}}
+{{ if and (not $blogPage) (not $isDevVersion) -}}
   {{ errorf "%s: shortcode 'release-summary': blog post not found for version %q during years: %q"
       .Position $version (delimit $years ", ") -}}
 {{ end -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.13.1-dev+13-g6c1e391",
+  "version": "0.14.0-dev+14-g66a0c7d",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bumps version to 0.14.0-dev
- Adds the version to the docs index page
- (We can do this now because we're not publishing in production yet!)