### PR TITLE
Add Hugo Markdown-style alert support and docs

### DIFF
--- a/assets/scss/_alerts.scss
+++ b/assets/scss/_alerts.scss
@@ -21,3 +21,28 @@
     }
   }
 }
+
+// The following is a placeholder class:
+// .td-alert-body {}
+
+// Styles for GFM blockquote-alert types
+.alert-caution {
+  @extend .alert-warning;
+}
+
+.alert-important {
+  @extend .alert-info;
+}
+
+.alert-note {
+  @extend .alert-primary;
+}
+
+.alert-tip {
+  @extend .alert-success;
+}
+
+// Docsy custom alert type:
+.alert-nb {
+  @extend .alert-note;
+}

--- a/docsy.dev/content/en/docs/best-practices/site-guidance.md
+++ b/docsy.dev/content/en/docs/best-practices/site-guidance.md
@@ -26,4 +26,4 @@ you'll need to use regular Markdown links to section landing or other index
 pages. Specify these links relative to the site's root URL, for example:
 `/docs/content/`.
 
-[Learn more about linking](/docs/content/adding-content/#working-with-links).
+[Learn more about linking](/docs/content/adding-content/#links).

--- a/docsy.dev/content/en/docs/content/adding-content.md
+++ b/docsy.dev/content/en/docs/content/adding-content.md
@@ -2,6 +2,22 @@
 title: Adding Content
 weight: 1
 description: Add different types of content to your Docsy site.
+params:
+  alert-examples: |
+    > [!TIP]
+    >
+    > Did you know that...
+
+    > [!NOTE] Version note
+    >
+    > This feature is only available in version 2.0 and later.
+
+    > [!WARNING] :warning: Blank line required!
+    >
+    > This site uses the [Prettier] formatter, and it requires an empty line
+    > separating the alert tag/title from the alert body.
+
+    > [!DANGER] Danger Will Robinson!
 # prettier-ignore
 cSpell:ignore: goldmark Riona MacNamara frontmatter asciidoctor pandoc changefreq
 ---
@@ -311,75 +327,74 @@ also want to include `description` since Docsy uses that to generate the meta
 meta tags]({{< ref "feedback#search-engine-optimization-meta-tags" >}}) for
 details.
 
-## Page contents and markup
+## Page content
 
-By default you create pages in a Docsy site as simple
-[Markdown or HTML files](https://gohugo.io/content-management/formats/) with
-[page frontmatter](#page-frontmatter), as described above. As of version 0.100,
-[Goldmark](https://github.com/yuin/goldmark/) is the only Markdown parser
-supported by Hugo.
+Most often you create pages in a Docsy site as [Markdown or HTML files][formats]
+with [page frontmatter](#page-frontmatter). Hugo's default markup and markdown
+renderer is [Goldmark].
 
-{{% alert title="Tip" %}}
+### Markdown
 
-If you've been using versions of Hugo before 0.60 that use
-[`BlackFriday`](https://github.com/russross/blackfriday) as its Markdown parser,
-you may need to make some small changes to your site to work with the current
-`Goldmark` Markdown parser. In particular, if you cloned an earlier version of
-our example site, add the following to your `hugo.toml`/`hugo.yaml`/`hugo.json`
-to allow Goldmark to render raw HTML as well as Markdown:
+Markdown is Hugo’s default content format. Hugo renders Markdown to HTML using
+[Goldmark], which conforms to [CommonMark] and [GitHub Flavored Markdown][GFM]
+specifications and a few more extensions.
 
-<!-- prettier-ignore-start -->
-{{< tabpane >}}
-{{< tab header="Configuration file:" disabled=true />}}
-{{< tab header="hugo.toml" lang="toml" >}}
-[markup]
-  [markup.goldmark]
-    [markup.goldmark.renderer]
-      unsafe = true
-{{< /tab >}}
-{{< tab header="hugo.yaml" lang="yaml" >}}
-markup:
-  goldmark:
-    renderer:
-      unsafe: true
-{{< /tab >}}
-{{< tab header="hugo.json" lang="json" >}}
-{
-  "markup": {
-    "goldmark": {
-      "renderer": {
-        "unsafe": true
-      }
-    }
-  }
-}
-{{< /tab >}}
-{{< /tabpane >}}
-<!-- prettier-ignore-end -->
+Hugo provides Markdown features including:
 
-{{% /alert %}}
+- [Attributes] for adding custom IDs and classes to Markdown elements
+- [Extensions] such as tables, footnotes, task lists, etc.
+- [Render hooks][] for customizing the HTML output of Markdown elements.
 
-In addition to your marked-up text, you can also use Hugo and Docsy's
-[shortcodes](/docs/content/shortcodes): reusable chunks of HTML that you can use
-to quickly build your pages. Find out more about shortcodes in
-[Docsy Shortcodes](/docs/content/shortcodes).
+Docsy provides custom render hooks for the following Markdown elements:
 
-{{% alert title="Note" color="info" %}} Hugo also supports adding content using
-other markups using
-[external parsers as helpers](https://gohugo.io/content-management/formats/#additional-formats-through-external-helpers).
-For example, you can add content in RST using `rst2html` as an external parser
-(though be aware this does not support all flavors of RST, such as Sphinx RST).
-Similarly, you can use `asciidoctor` to parse Asciidoc files, or `pandoc` for
-other formats.
+- [Blockquote alerts](#alerts)
+- Code blocks for Mermaid diagrams, math and chemical equations. For details,
+  see [Diagrams and Formulae](/docs/content/diagrams-and-formulae/)
 
-External parsers may not be suitable for use with all deployment options, as
-you'll need to install the external parser and run Hugo yourself to generate
-your site (so, for example, you won't be able to use
-[Netlify's continuous deployment feature](/docs/deployment/#deployment-with-netlify)).
-In addition, adding an external parser may cause performance issues building
-larger sites. {{% /alert %}}
+### Markup, shortcodes, and content features {#markup-and-content-features}
 
-### Working with links
+Hugo supports content formats and features including HTML, [Emojis], and more.
+For details, see [Content formats][formats].
+
+In addition, you can call [shortcodes] from your content. To learn more about
+shortcodes in general, and how to use Docsy's provided shortcodes, see
+[Shortcodes](/docs/content/shortcodes).
+
+### Alerts
+
+Docsy supports Hugo's blockquote syntax for [alerts], specifically [GFM] base
+syntax for callouts, and Obsidian-style titles. For example:
+
+```markdown
+{{% _param alert-examples %}}
+```
+
+Which renders as:
+
+{{% _param alert-examples %}}
+
+In addition, Docsy supports alert types corresponding to the Bootstrap alerts
+types missing from [GFM], as well as `NB` -- short for _nota bene_.
+
+Use `NB` for short single-line notes rendered without a label. For example:
+
+```markdown
+> [!NB] **Skip this section** if the package is already installed.
+```
+
+Which renders as:
+
+> [!NB] **Skip this section** if the package is already installed.
+
+As illustrated above, the alert type is used as a title when no title is
+specified.
+
+Learn how to customize alert appearance in the [Alert][LnF-Alert] section of
+[Look and Feel][].
+
+[LnF-Alert]: /docs/content/lookandfeel/#alerts
+
+### Links
 
 Hugo lets you specify links using normal Markdown syntax, though remember that
 you need to specify links relative to your site's root URL, and that relative
@@ -980,5 +995,18 @@ sitemap:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 
-To learn more about configuring sitemaps, see
-[Sitemap Template](https://gohugo.io/templates/sitemap-template/).
+To learn more about configuring sitemaps, see [Sitemap Templates][].
+
+[alerts]: https://gohugo.io/render-hooks/blockquotes/#alerts
+[attributes]: https://gohugo.io/content-management/markdown-attributes/
+[commonmark]: https://spec.commonmark.org/
+[Emojis]: https://gohugo.io/quick-reference/emojis/
+[extensions]: https://gohugo.io/configuration/markup/#extensions
+[formats]: https://gohugo.io/content-management/formats/
+[GFM]: https://github.github.com/gfm/
+[Goldmark]: https://github.com/yuin/goldmark
+[Look and Feel]: /docs/content/lookandfeel/
+[Prettier]: https://prettier.io
+[render hooks]: https://gohugo.io/render-hooks/introduction/
+[shortcodes]: https://gohugo.io/content-management/shortcodes/
+[Sitemap Templates]: https://gohugo.io/templates/sitemap-template/

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -571,6 +571,30 @@ site's [configuration file][].
   https://gohugo.io/getting-started/configuration/#configuration-file
 [primary color]: #site-colors
 
+## Alerts
+
+> [!NOTE] Coming soon: how to customize alerts
+>
+> - `alert-primary` is the default
+> - `alert-<AlertType>` is used
+
+To change the styling of an alert of type `abc`, override the CSS class
+`.alert-abc` like so:
+
+```scss
+.alert-abc {
+  @extend .alert-primary;
+}
+```
+
+For example, to hide alert titles, use:
+
+```scss
+.td-alert-body .alert-heading {
+  display: none;
+}
+```
+
 ## Tables
 
 Docsy applies the following styles to all tables, through the class `.td-table`:

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -1,8 +1,9 @@
 # baseURL moved to be after params
 title: Docsy
+theme: [docsy]
 enableRobotsTXT: true
 enableGitInfo: true
-theme: [docsy]
+enableEmoji: true
 
 ignoreLogs:
   # FIXME: find a better way to encode `site` pages than having to ignore warnings.

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1791,9 +1791,17 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:25.535959-05:00"
   },
+  "https://github.com/yuin/goldmark": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:11.733641-05:00"
+  },
   "https://github.com/yuin/goldmark/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:39.159385-05:00"
+  },
+  "https://github.github.com/gfm/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.116768-05:00"
   },
   "https://gitlab.com": {
     "StatusCode": 206,
@@ -1835,6 +1843,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-18T18:57:42.075075-05:00"
   },
+  "https://gohugo.io/configuration/markup/#extensions": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.494463-05:00"
+  },
   "https://gohugo.io/configuration/media-types/#create-a-media-type": {
     "StatusCode": 206,
     "LastSeen": "2025-06-06T15:13:21.028725+02:00"
@@ -1874,6 +1886,10 @@
   "https://gohugo.io/content-management/image-processing/#image-processing-options": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.977096-05:00"
+  },
+  "https://gohugo.io/content-management/markdown-attributes/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.413218-05:00"
   },
   "https://gohugo.io/content-management/mathematics/#step-1": {
     "StatusCode": 206,
@@ -2035,9 +2051,21 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T12:09:28.833628-05:00"
   },
+  "https://gohugo.io/quick-reference/emojis/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.728703-05:00"
+  },
   "https://gohugo.io/quick-reference/glossary/#content-type": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.89252-05:00"
+  },
+  "https://gohugo.io/render-hooks/blockquotes/#alerts": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.815752-05:00"
+  },
+  "https://gohugo.io/render-hooks/introduction/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:12.588583-05:00"
   },
   "https://gohugo.io/render-hooks/passthrough/": {
     "StatusCode": 206,
@@ -2290,6 +2318,10 @@
   "https://semver.org/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-15T13:13:03.159531-05:00"
+  },
+  "https://spec.commonmark.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-15T20:07:11.973722-05:00"
   },
   "https://stackoverflow.com/questions/tagged/docsy": {
     "StatusCode": 200,

--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -1,0 +1,32 @@
+{{ $title := or
+  .AlertTitle
+  (and
+    .AlertType
+    (or (i18n .AlertType) (title .AlertType))
+  )
+-}}
+
+{{ $singleLineBody := eq .AlertType "nb" -}}
+{{/* For NB single-line alerts without a body, use the title as the body */ -}}
+{{ $body := .Text -}}
+{{ if and (not $body) .AlertTitle $singleLineBody -}}
+  {{ $body = .AlertTitle -}}
+  {{ $title = "" -}}
+{{ end -}}
+
+<div class="td-alert td-alert__md alert alert-{{ .AlertType }}" role="alert">
+  {{- with $title -}}
+    <div class="h4 alert-heading" role="heading">
+      {{- . -}}
+    </div>
+  {{- end }}
+  <div class="td-alert-body">
+    {{ if $singleLineBody -}}
+      {{/* The render hook doesn't add <p> for single-line bodies, so we do it to
+      ensure visual consistency */ -}}
+      <p>{{ $body }}</p>
+    {{ else -}}
+      {{ $body }}
+    {{ end -}}
+  </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+15-g884d714",
+  "version": "0.14.0-dev+16-g68cb0e7",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2390
- Adds support for Hugo's Markdown-syntax of alerts, with a few Docsy extensions
- Adds preliminary docs for this kind of alert syntax, with examples. More content regarding how to customize alert styles will come later
-  Reworks the "Page content" section of Adding Content, simplifying it and adding the alerts content

**Preview**: https://deploy-preview-2443--docsydocs.netlify.app/docs/content/adding-content/#alerts

### Screenshot

<img width="1060" height="1456" alt="image" src="https://github.com/user-attachments/assets/e7c743b2-f059-44da-825f-16b0a0b467e6" />

