### PR TITLE
Add site build info and project build documentation

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,10 +1,11 @@
 # cSpell:ignore docsy github lookandfeel iconsimages
 
 globs:
+  - '!docsy.dev/**'
+  - '!layouts/**'
   - '!node_modules/**'
   - '!public/**'
   - '!tmp/**'
-  - '!docsy.dev/**'
   - docsy.dev/content/en/docs/content/iconsimages.md
   - docsy.dev/content/en/docs/content/language.md
   - docsy.dev/content/en/docs/content/lookandfeel.md

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -8,6 +8,7 @@
     "Docsy",
     "errorf",
     "Gantt",
+    "getenv",
     "GLFM",
     "htmltest",
     "hugo",

--- a/docsy.dev/content/en/site/_index.md
+++ b/docsy.dev/content/en/site/_index.md
@@ -1,7 +1,7 @@
 ---
-title: About this website
-linkTitle: Website docs
-description: How this site is built, maintained, and deployed.
+title: Project and website documentation
+linkTitle: Project docs
+description: How Docsy theme and website are built, maintained, and deployed.
 aliases: [project]
 cascade:
   outputs: [HTML]
@@ -10,6 +10,7 @@ cascade:
     hide_feedback: true
 params:
   FA: <i class="fa-solid fa-{1} text-{2}"></i>
+cSpell:ignore: docsydocs
 ---
 
 Planned content organization (tentative)
@@ -29,3 +30,7 @@ Planned content organization (tentative)
 
 {{% _param FA person-digging " pe-2" %}} This section is under development. {{%
 _param FA person-digging " ps-2" %}}
+
+## Site build information
+
+{{% td/site-build-info/netlify team="docsydocs" %}}

--- a/docsy.dev/content/en/site/build/_index.md
+++ b/docsy.dev/content/en/site/build/_index.md
@@ -1,0 +1,7 @@
+---
+title: Build
+description: >
+  Tooling, local development setup, CI/CD workflows, deployment environments,
+  and automation details.
+weight: 100
+---

--- a/docsy.dev/content/en/site/build/git-repo.md
+++ b/docsy.dev/content/en/site/build/git-repo.md
@@ -1,0 +1,59 @@
+---
+title: Git repository information
+linkTitle: Git repo
+cSpell:ignore: docsy hotfixes
+---
+
+## Monorepo
+
+The Docsy repository is effectively a **monorepo** containing the Docsy:
+
+- **Theme** at the repo root
+- **Website** in the `docsy.dev` directory
+
+## Branch model
+
+The repo has two main branches:
+
+- `main`: development branch
+  - All feature work and doc updates land here first.
+  - Source of leading-edge theme version for downstream sites.
+
+- `release` branch
+  - Published & supported line of the theme and website.
+  - Website production builds are deployed from this branch via Netlify.
+  - An ancestor of `main` most of the time, diverged due to hotfixes on
+    occasion.
+
+No rebases and no history rewriting for either branch.
+
+### Tags
+
+- Tags are used for **official theme releases**
+- Tags are attached to `main` commits, which are shared by `release` since the
+  two branches sync on releases.
+
+### Release flow
+
+1. Work merges into `main`.
+2. At release:
+   - Tag the release commit on `main`.
+   - Fast-forward `release` to that same commit.
+3. Netlify deploys from `release`.
+
+This keeps history mostly linear.
+
+### Hotfixes (rare)
+
+- If a fix lands on `release`, it must be forward-merged or cherry-picked to
+  `main`.
+- Next promotion fast-forwards `release` to `main` again.
+
+Invariant: `release` should converge back to `main` ASAP.
+
+## Why this model?
+
+- Preserves a clean, mostly linear history.
+- Allows website production deploys on release commits (and a rare hotfix).
+- Keeps `main` free for ongoing theme + site development.
+- Maintains clear, immutable release points for theme consumers via tags.

--- a/docsy.dev/content/en/site/implementation/_index.md
+++ b/docsy.dev/content/en/site/implementation/_index.md
@@ -4,6 +4,7 @@ linkTitle: Implementation
 description:
   Code-level structure and conventions, Hugo/Docsy templates, SCSS/JS
   customizations, patches, and internal shims.
+weight: 100
 no_list: true
 ---
 

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -149,6 +149,16 @@ taxonomies:
   tag: tags
   category: categories
 
+# Allow Netlify build environment variables to be accessed in templates.
+#
+# TODO: consider instead using a CI script to write the build information to a
+# data file that Hugo could read.
+security:
+  funcs: # cspell:disable-line
+    getenv: # cspell:disable-line
+      # Netlify build env var
+      - ^(BRANCH|BUILD_ID|COMMIT_REF|CONTEXT|DEPLOY_ID|NETLIFY|PULL_REQUEST|REVIEW_ID)$
+
 module:
   mounts:
     - source: content/en

--- a/docsy.dev/scripts/test-netlify-env.sh
+++ b/docsy.dev/scripts/test-netlify-env.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Test environment variables for Netlify build info shortcode
+# Usage: (source scripts/test-netlify-env.sh && npm run serve)
+
+export BRANCH="main"
+export BUILD_ID="6969a939575aaf0008ac7a48"
+export COMMIT_REF="884d714b43e317c83fb9df0a0a25346f1bea4974"
+export DEPLOY_ID="6969a939575aaf0008ac7a48"
+export NETLIFY="true"
+export PULL_REQUEST="false"
+export REVIEW_ID=""
+export CONTEXT="deploy-preview"
+
+# Uncomment to test PR build scenario:
+# export PULL_REQUEST="true"
+# export REVIEW_ID="1234"
+# export CONTEXT="deploy-preview"
+
+# Uncomment to test production build:
+# export CONTEXT="production"
+
+# Uncomment to test local build (no Netlify):
+# unset NETLIFY
+# export CONTEXT="local"
+
+echo "Netlify test environment variables set:"
+echo "  BRANCH=$BRANCH"
+echo "  BUILD_ID=$BUILD_ID"
+echo "  COMMIT_REF=$COMMIT_REF"
+echo "  DEPLOY_ID=$DEPLOY_ID"
+echo "  NETLIFY=$NETLIFY"
+echo "  PULL_REQUEST=$PULL_REQUEST"
+echo "  REVIEW_ID=$REVIEW_ID"
+echo "  CONTEXT=$CONTEXT"
+echo ""
+echo "To use: source scripts/test-netlify-env.sh"
+echo "Then run: npm run serve (or your build command)"

--- a/layouts/_shortcodes/td/site-build-info/netlify.md
+++ b/layouts/_shortcodes/td/site-build-info/netlify.md
@@ -1,0 +1,92 @@
+{{/*
+
+@param {string} [0/team] Netlify App team name.
+@param {string} [1/repoURL] The repository URL, optional. Defaults to site param `github_repo`.
+
+*/ -}}
+
+{{ $scName := "site-build-info/netlify" -}}
+
+{{ $team := .Get 0 | default (.Get "team") -}}
+
+{{ if not $team -}}
+  {{ warnf "%s: shortcode %q: parameter 0 ('team') is missing" .Position $scName -}}
+{{ end -}}
+
+{{ $repoURL := .Get 1 | default (.Get "repoURL") | default (.Page.Param "github_repo") -}}
+
+{{ if not $repoURL -}}
+  {{ $msg := add
+    "parameter 1 ('repoURL') is missing and "
+    "site param 'github_repo' is not defined."
+  -}}
+  {{ warnf "%s: shortcode %q: %s" .Position $scName $msg -}}
+{{ else if hasSuffix $repoURL "/" -}}
+  {{ $repoURL = strings.TrimSuffix $repoURL "/" -}}
+{{ end -}}
+
+{{ $branch := os.Getenv "BRANCH" -}}
+{{ $buildID := os.Getenv "BUILD_ID" -}}
+{{ $commitRef := os.Getenv "COMMIT_REF" -}}
+{{ $deployID := os.Getenv "DEPLOY_ID" -}}
+{{ $isNetlifyBuilt := os.Getenv "NETLIFY" | default false -}}
+{{ $isPR := os.Getenv "PULL_REQUEST" -}}
+{{ $reviewID := os.Getenv "REVIEW_ID" -}}
+{{ $now := now -}}
+
+Netlify build information:
+
+| Attribute | Value |
+|---|---|
+Netlify built | `{{ $isNetlifyBuilt }}`
+{{/**/ -}}
+
+{{/*Don't show timestamp for local builds to avoid affecting site diffs. */ -}}
+{{ with $isNetlifyBuilt -}}
+  Date/time[^date] | {{ $now.Format "2006-01-02 15:04 MST" }}[^local-time]
+{{ end -}}
+{{/**/ -}}
+
+{{ with $buildID -}}
+  ID | `{{.}}`
+{{ end -}}
+{{/**/ -}}
+
+{{ with $deployID -}}
+  Deploy log | [{{ . }}](https://app.netlify.com/teams/{{ $team }}/builds/{{ . }})
+{{ end -}}
+{{/**/ -}}
+
+{{ with $reviewID -}}
+  Build context |
+  {{- if $isPR -}}
+    [PR #{{ . }}]({{ $repoURL }}/pull/{{ . }})
+  {{ else -}}
+    merge `{{ . }}`
+  {{ end -}}
+{{ end -}}
+{{/**/ -}}
+
+Deploy context | {{ os.Getenv "CONTEXT" | default "local" }}
+{{/**/ -}}
+
+{{ with $commitRef -}}
+  Commit | [@{{substr . 0 7  }}]({{ $repoURL }}/commit/{{ . }})
+{{ end -}}
+{{/**/ -}}
+
+{{ with $branch -}}
+  Branch | `{{ . }}`
+{{ end -}}
+{{/*End of table*/}}
+
+[^date]: Approximate build timestamp.
+[^local-time]: In your timezone: <span id="local-time">unknown</span>.
+
+<script>
+document.addEventListener("DOMContentLoaded", function() {
+  var options = { hour: '2-digit', hour12: false, minute: '2-digit', timeZoneName: 'short' };
+  var buildDate = new Date("{{ $now.Format "2006-01-02T15:04:05Z07:00" }}");
+  document.getElementById("local-time").innerText = buildDate.toLocaleString(undefined, options);
+});
+</script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+16-g68cb0e7",
+  "version": "0.14.0-dev+20-g1465641",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2436
- Adds a new shortcode to display Netlify build info
- Updates the main site documentation to include this info
- Adds a new 'build' section with details on the repository structure and branch model.

**Preview**: https://deploy-preview-2444--docsydocs.netlify.app/site