### PR TITLE
Fix left sidebar height

### DIFF
--- a/assets/scss/_sidebar-tree.scss
+++ b/assets/scss/_sidebar-tree.scss
@@ -25,8 +25,9 @@
       // and adjust max-height:
       padding-top: 1rem;
 
+      $_search-box-height: 4.5rem;
       @supports (position: sticky) {
-        max-height: calc(#{$_max-height} + 4.5rem);
+        max-height: calc(#{$_max-height} + #{$_search-box-height});
       }
     }
   }
@@ -166,7 +167,6 @@
         position: sticky;
         top: 4rem;
         z-index: 10;
-        height: calc(100vh - 5rem);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+27-gc9f4299",
+  "version": "0.14.0-dev+28-g29bc71f",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2354
- Fixes #2424 (dup)
- For a **root-cause analysis**, see https://github.com/google/docsy/issues/2424#issuecomment-3764096796
- Thanks to @tekezo for reporting the issue and proposing a fix 🙌🏻 

### Preview

- https://deploy-preview-2453--docsydocs.netlify.app/docs/best-practices/

### Tests

I've tested under (most of these) conditions:

- Desktop and mobile/narrow-views
- Sidebar search being show/enabled or not
- Variation in default/browser font size

In call cases I've tested, the left sidebar height is correct (doesn't overflow into the footer).

#### Chrome with Large font size (one size above the default), on a narrow display, with the search box showing:

<img width="915" height="413" alt="image" src="https://github.com/user-attachments/assets/2dc5864f-ef3d-4e76-a18d-93d7ae6b95b1" />

#### Chrome with default (Medium) font size), on desktop, with the sidebar search box hidden:

<img width="960" height="473" alt="image" src="https://github.com/user-attachments/assets/7aafc46f-056a-4433-b6da-89638c33f845" />
