### PR TITLE
Convert most shortcode alerts to markdown, and more

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -6,14 +6,13 @@ globs:
   - '!node_modules/**'
   - '!public/**'
   - '!tmp/**'
-  - docsy.dev/content/en/docs/content/iconsimages.md
-  - docsy.dev/content/en/docs/content/language.md
-  - docsy.dev/content/en/docs/content/lookandfeel.md
-  - docsy.dev/content/en/docs/content/navigation.md
-  # - docsy.dev/content/en/docs/content/repository-links.md
-  # - docsy.dev/content/en/docs/content/search.md
-  # - docsy.dev/content/en/docs/content/shortcodes.md
-  # - docsy.dev/content/en/docs/content/versioning.md
-  - docsy.dev/content/en/blog/2025/0.13.0.md
+  - 'docsy.dev/content/en/blog/**/*.md'
+  - 'docsy.dev/content/en/docs/_index.md'
+  - 'docsy.dev/content/en/docs/content/**/*.md'
+  - 'docsy.dev/content/en/docs/best-practices/**/*.md'
+  - 'docsy.dev/content/en/docs/get-started/other-options.md'
+  - 'docsy.dev/content/en/docs/language.md'
+  - 'docsy.dev/content/en/site/**/*.md'
+
 config:
   extends: .markdownlint.yaml

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
   "words": [
     "anchorize",
     "docset",
+    "docsets",
     "Docsy",
     "errorf",
     "Gantt",

--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -4,6 +4,9 @@
 !/content/en/blog/**/*.*
 !/content/en/docs/_index.md
 !/content/en/docs/content/**/*.*
+!/content/en/docs/best-practices/**/*.*
+!/content/en/docs/get-started/other-options.md
+!/content/en/docs/language.md
 !/content/en/site/**/*.*
 
 /layouts

--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -57,7 +57,7 @@ the section with a comment about what to do about the rest.
 
 Some Bootstrap changes will break your website's layout or functionality in
 obvious ways. This is the case for the
-[rename](https://getbootstrap.com/docs/5.2/migration/#utilities)[ of utility classes](https://getbootstrap.com/docs/5.2/migration/#utilities),
+[rename of utility classes](https://getbootstrap.com/docs/5.2/migration/#utilities),
 like `ml-1` and `pr-2`. Using regular-expression based search-and-replace over
 your project's custom layouts or doc-page inline HTML is a good way to tackle
 this. I've used regex like these:

--- a/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
+++ b/docsy.dev/content/en/blog/2023/bootstrap-5-migration.md
@@ -113,10 +113,8 @@ References:
 
 - [[BSv5] Row/col formatting breaks Docsy components #1466](https://github.com/google/docsy/issues/1466),
   in particular
-  - [[BSv5] Footer fixes: reset flex-shrink, and more·](https://github.com/google/docsy/pull/1373)
-    [Docsy PR](https://github.com/google/docsy/pull/1367)[ #1373](https://github.com/google/docsy/pull/1373)
-  - [[BSv5] Footer: drop flex-shrink tweak + other adjustments ·](https://github.com/google/docsy/pull/1523)
-    [Docsy PR](https://github.com/google/docsy/pull/1367)[ #1523](https://github.com/google/docsy/pull/1523)
+  - [[BSv5] Footer fixes: reset flex-shrink, and more · Docsy PR #1373](https://github.com/google/docsy/pull/1373)
+  - [[BSv5] Footer: drop flex-shrink tweak + other adjustments · Docsy PR #1523](https://github.com/google/docsy/pull/1523)
 - [Why are all col classes 'position: relative'? · Bootstrap v4 issue #25254](https://github.com/twbs/bootstrap/issues/25254)
 - [Why flex-shrink 0 for all columns? · Bootstrap discussion #37951](https://github.com/orgs/twbs/discussions/37951)
 
@@ -271,11 +269,10 @@ to the migration effort.
     [Docsy up to Bootstrap 5.3](https://github.com/google/docsy/issues/1528).
 
 _A version of this article originally appeared as the [CNCF blog][] post
-[Migrating Docsy to Bootstrap 5 ][original post]._
+[Migrating Docsy to Bootstrap 5][original post]._
 
 [cncf blog]: https://www.cncf.io/blog/
 [cncf-docsy]:
   https://www.cncf.io/blog/2023/01/19/fast-and-effective-tools-for-cncf-and-open-source-project-websites/
 [followup blog post]: /blog/2023/docsy-0.7/
-
-[original post]: {{% param canonical_url %}}
+[original post]: <{{% param canonical_url %}}>

--- a/docsy.dev/content/en/blog/2024/0.10.0.md
+++ b/docsy.dev/content/en/blog/2024/0.10.0.md
@@ -21,16 +21,14 @@ this Docsy version, review Hugo's deprecation notices and breaking changes since
 
 [0.123.0]: https://github.com/gohugoio/hugo/releases/tag/v0.123.0
 
-{{% alert title="Hugo version support reminder" %}}
-
-Each Docsy version officially **only** supports the Hugo version specified in
-the project's [package.json] entry for [hugo-extended]. Any other compatibility
-is on a best effort basis.
-
-[hugo-extended]: https://github.com/jakejarvis/hugo-extended
-[package.json]: https://github.com/google/docsy/blob/main/package.json
-
-{{% /alert %}}
+> [!NOTE] Hugo version support reminder
+>
+> Each Docsy version officially **only** supports the Hugo version specified in
+> the project's [package.json] entry for [hugo-extended]. Any other
+> compatibility is on a best effort basis.
+>
+> [hugo-extended]: https://github.com/jakejarvis/hugo-extended
+> [package.json]: https://github.com/google/docsy/blob/main/package.json
 
 A number of updates to this release were to address Hugo's deprecation notices.
 For the complete list, search for [0.10.0] release changes with "deprecat" in
@@ -56,33 +54,31 @@ if you're reading this post online, give dark mode a try!
 [Light/dark mode menu]: /docs/content/lookandfeel/#lightdark-mode-menu
 [User Guide]: http://localhost:1313/docs/
 
-{{% alert title="Important style changes" %}}
-
-The styling of the following shortcodes and page elements have been adjusted to
-ensure that they are compatible with light and dark modes.
-
-You'll needs to **revisit your styles if you customized the SCSS** associated
-with these shortcodes and elements.
-
-- [`alert`] ([#1908])
-- [`card`] ([#1922])
-- [`pageinfo`] ([#1915])
-- [Tabbed-pane] shortcodes ([#1920])
-
-The [search box styling][#1896] as well as the [doc-page left-nav][#1908] have
-had their styles adjusted as well.
-
-[#1896]: https://github.com/google/docsy/pull/1896
-[#1908]: https://github.com/google/docsy/pull/1908
-[#1915]: https://github.com/google/docsy/pull/1915
-[#1920]: https://github.com/google/docsy/pull/1920
-[#1922]: https://github.com/google/docsy/pull/1922
-[`alert`]: /docs/content/shortcodes/#alert
-[`card`]: /docs/content/shortcodes/#shortcode-card-programming-code
-[`pageinfo`]: /docs/content/shortcodes/#pageinfo
-[tabbed-pane]: /docs/content/shortcodes/#tabbed-panes
-
-{{% /alert %}}
+> [!NOTE] Important style changes
+>
+> The styling of the following shortcodes and page elements have been adjusted
+> to ensure that they are compatible with light and dark modes.
+>
+> You'll needs to **revisit your styles if you customized the SCSS** associated
+> with these shortcodes and elements.
+>
+> - [`alert`] ([#1908])
+> - [`card`] ([#1922])
+> - [`pageinfo`] ([#1915])
+> - [Tabbed-pane] shortcodes ([#1920])
+>
+> The [search box styling][#1896] as well as the [doc-page left-nav][#1908] have
+> had their styles adjusted as well.
+>
+> [#1896]: https://github.com/google/docsy/pull/1896
+> [#1908]: https://github.com/google/docsy/pull/1908
+> [#1915]: https://github.com/google/docsy/pull/1915
+> [#1920]: https://github.com/google/docsy/pull/1920
+> [#1922]: https://github.com/google/docsy/pull/1922
+> [`alert`]: /docs/content/shortcodes/#alert
+> [`card`]: /docs/content/shortcodes/#shortcode-card-programming-code
+> [`pageinfo`]: /docs/content/shortcodes/#pageinfo
+> [tabbed-pane]: /docs/content/shortcodes/#tabbed-panes
 
 ## Release details
 
@@ -97,12 +93,9 @@ Which Docsy improvements are on the horizon? For work items _tentatively_
 planned for the next release, see
 [Release 0.11.0 preparation (#1944)](https://github.com/google/docsy/issues/1944).
 
-{{% alert title="Vote" %}}
+> [!NOTE] Vote
+>
+> If you'd like a feature or fix to be considered for inclusion in an upcoming
+> release, remember to upvote (with a thumbs up) the associated issue or PR.
 
-If you'd like a feature or fix to be considered for inclusion in an upcoming
-release, remember to upvote (with a thumbs up) the associated issue or PR.
-
-{{% /alert %}}
-
-[CL@0.10.0]: /project/about/changelog/#v0.10.0
 [0.10.0]: https://github.com/google/docsy/releases/tag/v0.10.0

--- a/docsy.dev/content/en/blog/2024/0.9.0.md
+++ b/docsy.dev/content/en/blog/2024/0.9.0.md
@@ -189,10 +189,8 @@ specifically:
 
 [.td-heading-self-link]:
   https://github.com/chalin/docsy/blob/849dea0790bbaef5f4f71659824f44045afcd65e/assets/scss/_content.scss#L98
-[@deining]: https://github.com/deining
 [@jmooring]: https://github.com/jmooring
 [@sarahmaddox]: https://github.com/sarahmaddox
-[@yann-soubeyrand]: https://github.com/yann-soubeyrand
 [#138]: https://github.com/google/docsy/issues/138
 [#1460]: https://github.com/google/docsy/issues/1460
 [#1500]: https://github.com/google/docsy/pull/1500
@@ -213,8 +211,6 @@ specifically:
 [Hugo 0.112.0]: https://github.com/gohugoio/hugo/releases/tag/v0.112.0
 [language parameter]: /docs/language/#internationalization-bundles
 [Lisa]: https://github.com/LisaFC
-[mounts]:
-  https://gohugo.io/hugo-modules/configuration/#module-configuration-mounts
 [path_base_for_github_subdir]:
   /docs/content/repository-links/#path_base_for_github_subdir-optional
 [0.9.0]: https://github.com/google/docsy/releases/tag/v0.9.0

--- a/docsy.dev/content/en/blog/2024/year-in-review.md
+++ b/docsy.dev/content/en/blog/2024/year-in-review.md
@@ -25,7 +25,6 @@ Let’s dive into the development highlights from 2024 and take a peek at what
 lies ahead.
 
 [2024 priorities]: ../2023/priorities-for-2024/
-[GitHub dependents data]: https://github.com/google/docsy/network/dependents
 
 ## Release highlights
 
@@ -163,8 +162,6 @@ continue creating exceptional documentation together.
     [vote for your most-desired feature](https://github.com/google/docsy/issues).
 
 [Docsy dependents]: https://github.com/google/docsy/network/dependents
-[cncf-top]:
-  https://www.cncf.io/blog/2024/07/11/as-we-reach-mid-year-2024-a-look-at-cncf-linux-foundation-and-top-30-open-source-project-velocity/
 [gRPC (grpc.io#1389)]: https://github.com/grpc/grpc.io/issues/1389
 [Jaeger (jaegertracing#746)]:
   https://github.com/jaegertracing/documentation/issues/746

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -30,14 +30,12 @@ In this post you'll walk through the upgrade process for:
     the named Docsy versions. Later versions may work, but are not officially
     supported.
 
-{{% alert title="Note" color="info" %}}
-
-This post covers the common upgrade steps you're likely to encounter. Your
-project may include customizations that require additional adjustments. We
-recommend making these changes in a **separate branch** and **testing
-thoroughly** before deploying to production.
-
-{{% /alert %}}
+> [!NOTE]
+>
+> This post covers the common upgrade steps you're likely to encounter. Your
+> project may include customizations that require additional adjustments. We
+> recommend making these changes in a **separate branch** and **testing
+> thoroughly** before deploying to production.
 
 ## Procedure overview
 
@@ -122,20 +120,20 @@ structure as follows:
 
 - Move `_markup` one level up:
 
-  ```
+  ```text
   layouts/_default/_markup/  → layouts/_markup/
   ```
 
 - Add underscore prefixes to subfolders:
 
-  ```
+  ```text
   layouts/partials/     → layouts/_partials/
   layouts/shortcodes/   → layouts/_shortcodes/
   ```
 
 - Relocate and rename [taxonomy files](#taxonomy-files) (if applicable):
 
-  ```
+  ```text
   layouts/_default/taxonomy.html → layouts/term.html
   layouts/_default/terms.html    → layouts/taxonomy.html
   ```
@@ -213,7 +211,7 @@ If your project overrides Docsy `layouts/**/content.html` files:
 
 These are the affected files:
 
-```
+```text
 layouts/_td-content-after-header.html
 layouts/_td-content.html
 layouts/blog/_td-content.html

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -62,12 +62,15 @@ languages.
 
 ## {{% _param FA book "" %}} Documentation enhancements {#documentation-enhancements}
 
-### {{% _param NEW %}} Hugo Markdown-style alert support
+### {{% _param NEW %}} Hugo Markdown-style alert support {#alerts}
 
 Docsy 0.14.0 adds support and documentation for Hugo's native Markdown-style
 alert syntax. This provides an alternative to the traditional shortcode-based
 alerts, offering a more Markdown-native approach to creating alerts in your
 content.
+
+For details about the supported syntax, see
+[Hugo Markdown-style alert support](/docs/content/adding-content/#alerts).
 
 ### Documentation reorganization
 
@@ -195,7 +198,6 @@ our progress, see [Release 0.14.0 preparation (#2404)][#2404].
 
 [star-the-repo]: https://github.com/google/docsy
 [#2404]: https://github.com/google/docsy/issues/2404
-[#2431]: https://github.com/google/docsy/issues/2431
 
 ## References
 
@@ -215,7 +217,6 @@ Other references:
 
 [0.13.0]: /project/about/changelog/#v0.13.0
 [0.14.0]: https://github.com/google/docsy/releases/v0.14.0?no-link-check=1
-[alert]: /docs/content/shortcodes/#alert
 [CL@0.14.0]: /project/about/changelog/#v0.14.0
 [upgrade-0.13]: /blog/2025/0.13.0/
 [Upgrade to Docsy 0.13.0]: /blog/2025/0.13.0/

--- a/docsy.dev/content/en/docs/_index.md
+++ b/docsy.dev/content/en/docs/_index.md
@@ -5,16 +5,17 @@ menu: { main: { weight: 20 } }
 cSpell:ignore: vsoch
 ---
 
-[<span class="badge bg-primary text-bg-primary fs-6">v{{% param version %}}</span>
-][docsy-version]
+<!-- markdownlint-disable-next-line no-space-in-links -->
+
+[<span class="badge bg-primary text-bg-primary fs-6">v{{% param version %}}
+</span>][version]
 
 Welcome to the Docsy theme user guide for version [{{% param version
-%}}][docsy-version]! This guide shows you how to get started creating technical
+%}}][version]! This guide shows you how to get started creating technical
 documentation sites using Docsy, including site customization and how to use
 Docsy's blocks and templates.
 
-[docsy-version]:
-  <https://github.com/google/docsy/releases/v{{% param version %}}>
+[version]: <https://github.com/google/docsy/releases/v{{% param version %}}>
 
 ## What is Docsy?
 

--- a/docsy.dev/content/en/docs/best-practices/organizing-content.md
+++ b/docsy.dev/content/en/docs/best-practices/organizing-content.md
@@ -2,53 +2,73 @@
 title: Organizing Your Content
 weight: 9
 description: >
-  Optional guidance and recommendations on how to organize your documentation site.
+  Optional guidance and recommendations on how to organize your documentation
+  site.
 ---
 
-If you have a look at our [Example Site](https://example.docsy.dev/about/), you'll see that we've organized
-the Documentation section into a number of subsections, each with some recommendations about what you might put
-in that section.
+If you have a look at our [Example Site](https://example.docsy.dev/about/),
+you'll see that we've organized the Documentation section into a number of
+subsections, each with some recommendations about what you might put in that
+section.
 
 ## Do I need to use this structure?
 
-Absolutely not! The site structure in the Example Site was created to meet the needs of large docsets for large
-products with lots of features, potential tasks, and reference elements. For a simpler docset (like this one!),
-it's fine to just structure your docs around specific features that your users need to know about.  Even for larger
-documentation sets, you may find that the structure isn't useful "as is", or that you don't need to use all the
-section types.
+Absolutely not! The site structure in the Example Site was created to meet the
+needs of large docsets for large products with lots of features, potential
+tasks, and reference elements. For a simpler docset (like this one!), it's fine
+to just structure your docs around specific features that your users need to
+know about. Even for larger documentation sets, you may find that the structure
+isn't useful "as is", or that you don't need to use all the section types.
 
 We do recommend that (as we've done here) you provide at least:
 
-* An **Overview** of the product (either on the docs landing page or a separate Overview page) that tells the user
-  why they should be interested in your project.
-* A **Getting Started** page.
-* Some **Examples**.
+- An **Overview** of the product (either on the docs landing page or a separate
+  Overview page) that tells the user why they should be interested in your
+  project.
+- A **Getting Started** page.
+- Some **Examples**.
 
-You may also want to create some tasks/how-tos for your project's features. Feel free to copy this Docsy user guide
-site or even just the docs section instead if you like this simpler structure better.
+You may also want to create some tasks/how-tos for your project's features. Feel
+free to copy this Docsy user guide site or even just the docs section instead if
+you like this simpler structure better.
 
-{{% alert title="Tip" %}}
-If you want to copy this guide, be aware that its [source files](https://github.com/google/docsy/tree/main/docsy.dev) are *inside* the Docsy theme repo, and so it doesn't have its own `themes/` directory: instead, we run `hugo server --themesDir ../..` to use Docsy from its parent directory. You may want to either copy the site and [add a `themes/` directory with Docsy](/docs/get-started/other-options/#option-2-clone-the-docsy-theme), or just copy the `docs/` folder into your existing site's content root.
-{{% /alert %}}
+> [!TIP]
+>
+> If you want to copy this guide, be aware that its
+> [source files](https://github.com/google/docsy/tree/main/docsy.dev) are
+> _inside_ the Docsy theme repo, and so it doesn't have its own `themes/`
+> directory: instead, we run `hugo server --themesDir ../..` to use Docsy from
+> its parent directory. You may want to either copy the site and
+> [add a `themes/` directory with Docsy](/docs/get-started/other-options/#option-2-clone-the-docsy-theme),
+> or just copy the `docs/` folder into your existing site's content root.
 
-[Learn more about how Hugo and Docsy use folders and other files to organize your site](/docs/content/adding-content/#organizing-your-documentation).
+[Learn more](/docs/content/adding-content/#organizing-your-documentation) about
+how Hugo and Docsy use folders and other files to organize your site.
 
 ## Why this structure?
 
-We based the Example Site structure on our own experiences creating (and using) large documentation sets for
-different types of project and on user research carried out on some of our bigger sites. In user studies we saw that
-users cared most about and immediately looked for a Get Started or Getting Started section
-(so they could, well, get started), and some examples to explore and copy, so we made those into prominent top-level doc
-sections in our site. Users also wanted to find "recipes" that they could easily look up to perform specific tasks and
-put together to create their own applications or projects, so we suggest that you add this kind of content as Tasks.
-Other content types such as conceptual docs, reference docs, and end-to-end tutorials are less important for all doc sets,
-particularly for smaller projects. We emphasize in our Example Site that these sections are optional.
+We based the Example Site structure on our own experiences creating (and using)
+large documentation sets for different types of project and on user research
+carried out on some of our bigger sites. In user studies we saw that users cared
+most about and immediately looked for a Get Started or Getting Started section
+(so they could, well, get started), and some examples to explore and copy, so we
+made those into prominent top-level doc sections in our site. Users also wanted
+to find "recipes" that they could easily look up to perform specific tasks and
+put together to create their own applications or projects, so we suggest that
+you add this kind of content as Tasks. Other content types such as conceptual
+docs, reference docs, and end-to-end tutorials are less important for all doc
+sets, particularly for smaller projects. We emphasize in our Example Site that
+these sections are optional.
 
-We hope to improve the Example Site structure further as we learn more about how users interact with technical
-documentation, particularly for Open Source projects.
+We hope to improve the Example Site structure further as we learn more about how
+users interact with technical documentation, particularly for Open Source
+projects.
 
 ## Writing style guide
 
-This guide and the example site just address how to organize your documentation content into pages and sections. For some guidance on how to organize and write the content in each page, we recommend the
-[Google Developer Documentation Style Guide](https://developers.google.com/style/), particularly the
+This guide and the example site just address how to organize your documentation
+content into pages and sections. For some guidance on how to organize and write
+the content in each page, we recommend the
+[Google Developer Documentation Style Guide](https://developers.google.com/style/),
+particularly the
 [Style Guide Highlights](https://developers.google.com/style/highlights).

--- a/docsy.dev/content/en/docs/best-practices/site-guidance.md
+++ b/docsy.dev/content/en/docs/best-practices/site-guidance.md
@@ -21,9 +21,9 @@ generated site. For example a `{{</* ref "filename.md" */>}}` link in Hugo will
 actually find and automatically link to your file named `filename.md`.
 
 Note, however, that `ref` and `relref` links don't work with `_index` or `index`
-files (for example, this site's [content landing page](/docs/content/)):
-you'll need to use regular Markdown links to section landing or other index
-pages. Specify these links relative to the site's root URL, for example:
+files (for example, this site's [content landing page](/docs/content/)): you'll
+need to use regular Markdown links to section landing or other index pages.
+Specify these links relative to the site's root URL, for example:
 `/docs/content/`.
 
 [Learn more about linking](/docs/content/adding-content/#links).

--- a/docsy.dev/content/en/docs/content/adding-content.md
+++ b/docsy.dev/content/en/docs/content/adding-content.md
@@ -92,6 +92,7 @@ directory `content/en/amazing` and want one or more pages in that custom section
 to use Docsy's `docs` template, you add `type: docs` to the frontmatter of each
 page:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -124,6 +125,7 @@ description: >
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 Alternatively, create your own page template for your new section in your
 project's `layouts` directory based on one of the existing templates.
@@ -159,6 +161,7 @@ For example, for the `/news/` section, you can specify the following front
 matter in the index page which will change the type of the section and
 everything below it to "blog":
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -204,11 +207,13 @@ cascade:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 If you want to create a "docs" site, specifying something like the following in
 the top level `_index.md` will set all top level sections to be treated as
 "docs", except for "news":
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -266,6 +271,7 @@ cascade:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 Note the addition of `toc_root` here. Setting that to true for a section causes
 it to be treated as a separate part of the site, with its own left hand
@@ -286,6 +292,7 @@ frontmatter in
 
 For example, here's the frontmatter for this page:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -318,6 +325,7 @@ description: >
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 The minimum frontmatter you need to provide is a title: everything else is up to
 you! However, if you leave out the page weight, your
@@ -499,6 +507,7 @@ example.
 To display a simple bulleted list of links to the section's pages instead,
 specify `simple_list: true` in the landing page's frontmatter:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -525,10 +534,12 @@ weight: 20
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 To display no links at all, specify `no_list: true` in the landing page's
 frontmatter:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -555,6 +566,7 @@ weight: 20
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### Organizing your blog posts
 
@@ -571,6 +583,7 @@ or `_index.html` landing page file specifying the category title for it to
 appear properly in the left nav and top-level blog landing page. Here's the
 index page for `releases`:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -597,10 +610,12 @@ weight: 20
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 To add author and date information to blog posts, add them to the page
 frontmatter:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -654,6 +669,7 @@ resources:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 If you've copied the example site and you don't want a blog section, or want to
 link to an external blog instead, just delete the `blog` subdirectory.
@@ -699,6 +715,7 @@ automatically filled in with the project name and community links specified in
 resources that help them get involved in your project. The same links are also
 added by default to your site footer.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -817,6 +834,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 If you're creating your own site and want to add a page using this template, add
 a `/community/_index.md` file in your content root directory. If you've copied
@@ -955,6 +973,7 @@ sitemap:
 To override any of these values for a given page, specify it in page
 frontmatter:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -994,6 +1013,7 @@ sitemap:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 To learn more about configuring sitemaps, see [Sitemap Templates][].
 
@@ -1006,7 +1026,6 @@ To learn more about configuring sitemaps, see [Sitemap Templates][].
 [GFM]: https://github.github.com/gfm/
 [Goldmark]: https://github.com/yuin/goldmark
 [Look and Feel]: /docs/content/lookandfeel/
-[Prettier]: https://prettier.io
 [render hooks]: https://gohugo.io/render-hooks/introduction/
 [shortcodes]: https://gohugo.io/content-management/shortcodes/
 [Sitemap Templates]: https://gohugo.io/templates/sitemap-template/

--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -2,7 +2,7 @@
 title: Diagrams and Formulae
 weight: 11
 description: Add generated diagrams and scientific formulae to your site.
-cSpell:ignore: goldmark linenos mhchem
+cSpell:ignore: docsy gatsby goldmark linenos markmap mhchem plantuml
 ---
 
 Docsy has built-in support for a number of diagram creation and typesetting
@@ -74,10 +74,11 @@ The probability of getting \(k\) heads when flipping \(n\) coins is:
 \tag*{(1)}  P(E) = {n \choose k} p^k (1-p)^{n-k}
 ```
 
-{{% alert title="Tip" %}} This
-[wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides in-depth
-information about typesetting mathematical formulae using the \(\LaTeX\)
-typesetting system. {{% /alert %}}
+> [!TIP]
+>
+> This [wiki page](https://en.wikibooks.org/wiki/LaTeX/Mathematics) provides
+> in-depth information about typesetting mathematical formulae using the
+> \(\LaTeX\) typesetting system.
 
 ### Activating KaTeX support
 
@@ -213,22 +214,20 @@ of \(\KaTeX\) is automatically enabled when you author a `math` code block on
 your page or when you add a mathematical formulae to your page using one of the
 passthrough delimiter pairs defined above.
 
-{{% alert title="Passthrough for selected sections" %}}
-
-For very large sites, you might want to restrict the passthrough to selected
-sections. Do so by placing the passthrough hook in the section's `_markup`
-folder. For example:
-
-- `layouts/docs/_markup/render-passthrough.html` - hook is active for all docs
-  pages, but not for other sections such as the blog.
-- [layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html] -
-  hook is active for this page of the user guide only, which is how we actually
-  have it setup.
+> [!NOTE] Passthrough for selected sections
+>
+> For very large sites, you might want to restrict the passthrough to selected
+> sections. Do so by placing the passthrough hook in the section's `_markup`
+> folder. For example:
+>
+> - `layouts/docs/_markup/render-passthrough.html` - hook is active for all docs
+>   pages, but not for other sections such as the blog.
+> - [layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html] -
+>   hook is active for this page of the user guide only, which is how we
+>   actually have it setup.
 
 [layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html]:
   https://github.com/google/docsy/blob/main/layouts/docs/content/diagrams-and-formulae/_markup/render-passthrough.html
-
-{{% /alert %}}
 
 ### Display of Chemical Equations and Physical Units
 
@@ -253,6 +252,7 @@ More complex equations can be displayed on their own line using the block
 delimiters defined:
 
 <!-- cSpell:ignore tetrahydroxozincate mchem -->
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 ````markdown
 \[
@@ -277,11 +277,13 @@ Both standard syntax and `chem` block renders to the same equation:
 \tag*{(2)} \ce{Zn^2+  <=>[+ 2OH-][+ 2H+]  $\underset{\text{amphoteric hydroxide}}{\ce{Zn(OH)2 v}}$  <=>[+ 2OH-][+ 2H+]  $\underset{\text{tetrahydroxozincate}}{\ce{[Zn(OH)4]^2-}}$}
 \]
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
-{{% alert title="Note" %}} The
-[manual](https://mhchem.github.io/MathJax-mhchem/) for mchem's input syntax
-provides in-depth information about typesetting chemical formulae and physical
-units using the `mhchem` tool. {{% /alert %}}
+> [!NOTE]
+>
+> The [manual](https://mhchem.github.io/MathJax-mhchem/) for mchem's input
+> syntax provides in-depth information about typesetting chemical formulae and
+> physical units using the `mhchem` tool.
 
 Use of `mhchem` is not limited to the authoring of chemical equations. By using
 the included `\pu` command, pretty looking physical units can be written with
@@ -324,7 +326,7 @@ For example, the following defines a sequence diagram:
 
 <!-- cSpell:ignore autonumber -->
 
-````
+````markdown
 ```mermaid
 sequenceDiagram
     autonumber
@@ -431,7 +433,7 @@ See the
 for a list of defaults that can be overridden.
 
 Settings can also be overridden on a per-diagram basis by making use of a
-[frontmatter config](https://mermaid.js.org/config/theming.html#customizing-themes-with-themevariables)
+[front matter config](https://mermaid.js.org/config/theming.html#customizing-themes-with-themevariables)
 block at the start of the diagram definition.
 
 ## UML Diagrams with PlantUML
@@ -449,7 +451,7 @@ Diagrams are defined using a simple and intuitive language.
 
 The following example shows a use case diagram:
 
-````
+````markdown
 ```plantuml
 participant participant as Foo
 actor       actor       as Foo1
@@ -517,6 +519,9 @@ params:
 
 Other optional settings are:
 
+<!-- markdownlint-disable no-bare-urls -->
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -561,6 +566,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ## MindMap support with MarkMap
 
@@ -569,7 +575,9 @@ text definitions to MindMap in the browser.
 
 For example, the following defines a simple MindMap:
 
-````
+<!-- markdownlint-disable code-fence-style -->
+<!-- prettier-ignore -->
+~~~~markdown
 ```markmap
 # markmap
 
@@ -596,7 +604,9 @@ For example, the following defines a simple MindMap:
     ```
 - KaTeX - $x = {-b \pm \sqrt{b^2-4ac} \over 2a}$
 ```
-````
+~~~~
+
+<!-- markdownlint-restore -->
 
 Automatically renders to:
 
@@ -669,10 +679,11 @@ Hover over the image below and click edit to instantly start working with it.
 Clicking the `Save` button will cause the edited diagram to be exported using
 the same filename and filetype, and downloaded to your browser.
 
-{{%alert title="Note" %}} If you're creating a new diagram, be sure to
-`File -> Export` in either `svg` or `png` format (`svg` is usually the best
-choice) and ensure the `Include a copy of my diagram` is selected so it can be
-edited again later. {{%/alert%}}
+> [!NOTE]
+>
+> If you're creating a new diagram, be sure to `File -> Export` in either `svg`
+> or `png` format (`svg` is usually the best choice) and ensure the
+> `Include a copy of my diagram` is selected so it can be edited again later.
 
 As the diagram data is transported via the browser, the diagrams.net server does
 not need to access the content on your Docsy server directly at all.

--- a/docsy.dev/content/en/docs/content/feedback.md
+++ b/docsy.dev/content/en/docs/content/feedback.md
@@ -22,48 +22,42 @@ You will need an **analytics ID** for your website before proceeding
 "analytics ID" in this guide). If you don't have one, see the **How to get
 started** section of [Introducing Google Analytics 4 (GA4)][ga4-intro].
 
-{{% alert title="Tip" %}}
-
-Your project's **analytics ID** is a string that starts with `G-` (a GA4
-measurement ID) or `UA-` (a universal analytics property ID).
-
-{{% /alert %}}
+> [!TIP]
+>
+> Your project's **analytics ID** is a string that starts with `G-` (a GA4
+> measurement ID) or `UA-` (a universal analytics property ID).
 
 ### Setup
 
 Enable Google Analytics by adding your project's analytics ID to the site
 configuration file. For details, see [Configure Google Analytics][].
 
-{{% alert title="Deprecation note and warning" color="warning" %}}
-
 <!-- Remove this warning once the Hugo docs have been updated to include it. -->
 
-While you can configure your project's analytics ID by setting either the
-top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,
-**`googleAnalytics` was [deprecated in Hugo 0.120.0][v0.120.0]** and will be
-removed in a future release.
-
-**Do not define both parameters,** otherwise this can result in [unexpected
-behavior][]. For details, see [Is services.googleAnalytics.id an alias for
-googleAnalytics][alias-discussion].
+> [!WARNING] Deprecation note and warning
+>
+> While you can configure your project's analytics ID by setting either the
+> top-level `googleAnalytics` config parameter or `services.googleAnalytics.id`,
+> **`googleAnalytics` was [deprecated in Hugo 0.120.0][v0.120.0]** and will be
+> removed in a future release.
+>
+> **Do not define both parameters,** otherwise this can result in [unexpected
+> behavior][#921]. For details, see [Is services.googleAnalytics.id an alias for
+> googleAnalytics][alias-discussion].
 
 [alias-discussion]:
   https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469
-[unexpected behavior]: https://github.com/google/docsy/issues/921
+[#921]: https://github.com/google/docsy/issues/921
 [v0.120.0]: https://github.com/gohugoio/hugo/releases/tag/v0.120.0
 
-{{% /alert %}}
-
-{{% alert title="Production-only feature!" %}}
-
-Analytics are enabled _only_ for **production** builds (called "environments" in
-Hugo terminology). For information about Hugo environments and how to set them,
-see the following [discussion][].
+> [!NOTE] Production-only feature!
+>
+> Analytics are enabled _only_ for **production** builds (called "environments"
+> in Hugo terminology). For information about Hugo environments and how to set
+> them, see the following [discussion][].
 
 [discussion]:
   https://discourse.gohugo.io/t/what-does-setting-hugo-env-to-production-do/24669/2
-
-{{% /alert %}}
 
 ## User Feedback
 
@@ -78,7 +72,7 @@ of every documentation page, as shown in Figure 1.
 </figure>
 
 After clicking **Yes** the user should see a response like Figure 2. You can
-[configure] the response text in your project's [configuration file].
+[configure] the response text in your project's [configuration file][].
 
 <figure>
   <img src="/images/yes.png"
@@ -114,18 +108,15 @@ page, it's more reasonable to believe that your users find code samples at the
 top of pages helpful. The scientific method, applied to technical writing, in
 other words!
 
-### Setup
+### Setup {#user-feedback-setup}
 
-{{% alert title="Version note" color=warning %}}
+> [!WARNING] Version note
+>
+> As of Docsy version [0.8.0], feedback will be enabled whether
+> `site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
+> case where analytics is configured outside of Docsy.
 
-As of Docsy version [0.8.0], feedback will be enabled whether
-`site.Config.Services.GoogleAnalytics.ID` is set or not. This supports the use
-case where analytics is configured outside of Docsy.
-
-[0.8.0]: /project/about/changelog/#v0.8.0
-
-{{% /alert %}}
-
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 
 1.  Open your project's Hugo configuration file.
@@ -180,6 +171,8 @@ params:
 
 3.  Save the edits to your configuration file.
 
+<!-- markdownlint-restore -->
+
 By default, Docsy emits an event value of 100 when a user clicks "yes". You can
 change this value by setting `params.ui.feedback.max_value` to a positive
 integer. Docsy uses 0 for "no" events.
@@ -188,14 +181,10 @@ integer. Docsy uses 0 for "no" events.
 
 Page feedback is reported to Google Analytics through [events].
 
-{{% alert title="Version note" color=warning %}}
-
-As of Docsy version [0.8.0], page feedback is reported as custom `page_helpful`
-events, rather than `click` events.
-
-[0.8.0]: /project/about/changelog/#v0.8.0
-
-{{% /alert %}}
+> [!WARNING] Version note
+>
+> As of Docsy version [0.8.0], page feedback is reported as custom
+> `page_helpful` events, rather than `click` events.
 
 This section assumes basic familiarity with Google Analytics. For example, you
 should know how to check pageviews over a certain time range and navigate
@@ -320,17 +309,17 @@ Add more meta tags as needed to your project's copy of the `head-end.html`
 partial. For details, see
 [Customizing templates](lookandfeel/#customizing-templates).
 
+[0.8.0]: /project/about/changelog/#v0.8.0
 [Configure Google Analytics]:
   https://gohugo.io/templates/embedded/#configure-google-analytics
 [ga4-intro]: https://support.google.com/analytics/answer/1042508
 [Google Analytics]: https://analytics.google.com/analytics/web/
-[gtag.js]: https://support.google.com/analytics/answer/10220869
 [hugo-ga]: https://gohugo.io/templates/embedded/#google-analytics
 [embedded templates]: https://gohugo.io/templates/embedded/
 [page-description.html]:
   https://github.com/google/docsy/blob/main/layouts/_partials/page-description.html
 [site `params`]: https://gohugo.io/variables/site/#the-siteparams-variable
 [summary]: https://gohugo.io/content-management/summaries/
-[configure]: #setup-1
+[configure]: #setup
 [configuration file]:
   https://gohugo.io/getting-started/configuration/#configuration-file

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -3,6 +3,11 @@ title: Look and Feel
 date: 2017-01-05
 weight: 2
 description: Customize colors, fonts, code highlighting, and more for your site.
+params:
+  BringYourOwnLightDarkModeMenuAlertTitle: >-
+    <i class='fa-solid fa-exclamation-triangle pe-1'></i> Bring your own
+    light/dark mode menu <span class='badge text-bg-warning fs-6
+    float-end'>EXPERIMENTAL</span>
 # prettier-ignore
 cSpell:ignore: anotherclass autoprefixing baseof blockscover docsy lightdark monokai myclass onedark wordmark FOUC
 ---
@@ -52,13 +57,11 @@ place them inside your project's `assets/scss/` folder:
   https://github.com/google/docsy/blob/main/assets/scss/_variables_project_after_bs.scss
 [bs_var]: https://github.com/twbs/bootstrap/blob/v5.3.3/scss/_variables.scss
 
-{{% alert title="Tip" %}}
-
-PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in
-server mode (it is a little slow), so Chrome is the recommended choice for
-development.
-
-{{% /alert %}}
+> [!TIP]
+>
+> PostCSS (autoprefixing of CSS browser-prefixes) is not enabled when running in
+> server mode (it is a little slow), so Chrome is the recommended choice for
+> development.
 
 ## Colors and color themes
 
@@ -148,16 +151,15 @@ You can adjust dark-mode support as follows:
     that the have good color-contrast. Learn
     [how to pick colors with good color-contrast](#pick-good-color-contrast).
 
-{{% alert title="Terminology note" color=info %}}
-
-In Bootstrap, a color **mode** refers to a switchable presentation of the site
-(e.g., light or dark) from the user's point of view, implemented through CSS
-variable overrides activated via `data-bs-theme`.
-
-Whereas a color **theme** refers to the semantic color palette (primary,
-secondary, success, etc.) defined in SCSS and used by components and utilities.
-
-{{% /alert %}}
+> [!INFO] Terminology note
+>
+> In Bootstrap, a color **mode** refers to a switchable presentation of the site
+> (e.g., light or dark) from the user's point of view, implemented through CSS
+> variable overrides activated via `data-bs-theme`.
+>
+> Whereas a color **theme** refers to the semantic color palette (primary,
+> secondary, success, etc.) defined in SCSS and used by components and
+> utilities.
 
 [FOUC]: https://en.wikipedia.org/wiki/Flash_of_unstyled_content
 
@@ -216,22 +218,21 @@ dark mode theme customization file and import it in your project's
 [Chroma for code highlighting]: #code-highlighting-with-chroma
 [Light/dark code styles]: #lightdark-code-styles
 
-{{% alert title="EXPERIMENTAL" color="info" %}}
+<!-- markdownlint-disable no-blanks-blockquote -->
 
-This feature is experimental. We're releasing this early to so that projects can
-try out this approach and provide feedback on its usefulness and convenience.
+> [!CAUTION] EXPERIMENTAL
+>
+> This feature is experimental. We're releasing this early to so that projects
+> can try out this approach and provide feedback on its usefulness and
+> convenience.
 
-{{% /alert %}}
-
-{{% alert title="Note" %}}
-
-Light/dark color themes, only affect documentation pages, and white [blocks
-shortcodes][]. Other block shortcodes with fixed text and background colors are
-not affected by light/dark color mode changes.
-
-[blocks shortcodes]: shortcodes/#shortcode-blocks
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Light/dark color themes, only affect documentation pages, and white [blocks
+> shortcodes][blocks]. Other block shortcodes with fixed text and background
+> colors are not affected by light/dark color mode changes.
+>
+> [blocks]: shortcodes/#shortcode-blocks
 
 [Generate syntax highlighter CSS]:
   https://gohugo.io/content-management/syntax-highlighting/#generate-syntax-highlighter-css
@@ -527,27 +528,23 @@ params:
 
 {{% /tab %}} {{< /tabpane >}}
 
-{{% alert title="<i class='fa-solid fa-exclamation-triangle pe-1'></i> Bring your own light/dark mode menu <span class='badge text-bg-warning fs-6 float-end'>EXPERIMENTAL</span>" color=warning %}}
-
-If you would like to use your own light/dark mode menu implementation instead of
-Docsy's default implementation:
-
-1. Set `params.ui.showLightDarkModeMenu` to `"enable-only (experimental)"`. This
-   will enable base dark-mode functionality (such as full CSS, no-flash support)
-   without Docsy's menu.
-
-2. Add your menu code to in the [layouts/_partials/theme-toggler.html] partial
-   file, thus overriding Docsy's default implementation.
-
-[layouts/_partials/theme-toggler.html]:
-  https://github.com/google/docsy/blob/main/layouts/_partials/theme-toggler.html
-
-This feature is experimental. It may be removed and/or changed in
-backwards-incompatible ways in a future releases.
-
-{{% /alert %}}
+> [!CAUTION] {{% _param BringYourOwnLightDarkModeMenuAlertTitle %}}
+>
+> If you would like to use your own light/dark mode menu implementation instead
+> of Docsy's default implementation:
+>
+> 1. Set `params.ui.showLightDarkModeMenu` to `"enable-only (experimental)"`.
+>    This will enable base dark-mode functionality (such as full CSS, no-flash
+>    support) without Docsy's menu.
+> 2. Add your menu code to in the [layouts/_partials/theme-toggler.html] partial
+>    file, thus overriding Docsy's default implementation.
+>
+> This feature is experimental. It may be removed and/or changed in
+> backwards-incompatible ways in a future releases.
 
 [dark mode]: https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode
+[layouts/_partials/theme-toggler.html]:
+  https://github.com/google/docsy/blob/main/layouts/_partials/theme-toggler.html
 [search box]: /docs/content/search/
 
 ### Translucent over cover images
@@ -610,17 +607,15 @@ without the need to wrap the table in a `<div>`. It does, however, mean that all
 your tables have `display` set to `block`. If you don't want this, you can
 create your own custom styles for tables.
 
-{{% alert title="Note" %}}
-
-Our table styling goes against the [Bootstrap recommendation to _wrap_
-tables][wrap-tables] with `.table-responsive` &mdash; however, we think letting
-users create responsive tables with just Markdown table syntax is more
-convenient.
+> [!NOTE]
+>
+> Our table styling goes against the [Bootstrap recommendation to _wrap_
+> tables][wrap-tables] with `.table-responsive` &mdash; however, we think
+> letting users create responsive tables with just Markdown table syntax is more
+> convenient.
 
 [wrap-tables]:
   https://getbootstrap.com/docs/5.3/content/tables/#responsive-tables
-
-{{% /alert %}}
 
 To render a table without Docsy styling, apply the `.td-initial` class to the
 table. From the resulting `<table>` style base, it is easier to apply your own

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -142,17 +142,14 @@ The menu is visible in the navbar for all screen sizes. By default, the current
 site language name is shown. On narrow displays, this is replaced by the
 language code.
 
-{{% alert title="Legacy UX" color="info" %}}
-
-Prior to Docsy 0.13.0, the language selector menu could also be visible from the
-left sidebar, and its visibility in the navbar depended on the screen size. For
-details, including ways to restore the legacy behavior, see [Language menu
-visibility][].
-
-[Language menu visibility]: /blog/2025/0.13.0/#language-menu-visibility
-[Multi-language support]: /docs/language/
-
-{{% /alert %}}
+> [!INFO] Legacy UX
+>
+> Prior to Docsy 0.13.0, the language selector menu could also be visible from
+> the left sidebar, and its visibility in the navbar depended on the screen
+> size. For details, including ways to restore the legacy behavior, see
+> [Language menu visibility][lmv].
+>
+> [lmv]: /blog/2025/0.13.0/#language-menu-visibility
 
 To style the language menu, apply your custom CSS to `.td-navbar__lang-menu`.
 
@@ -446,13 +443,14 @@ function
 [relref](https://gohugo.io/functions/relref/ 'External link to official Hugo Docs').
 If `relref` can't find a unique page in your site, Hugo throws a error message.
 
-{{% alert title="Note" %}} Although all generated menu and landing page links
-based on your placeholder file are set according to the parameters `manualLink`
-or `manualLinkRelref`, Hugo still generates a regular HTML site page for the
-file, albeit one with no generated links to it. To avoid confusion if users
-accidentally land on a generated placeholder page, we recommend specifying the
-URL for the external link in the normal content and / or page description of the
-page. {{% /alert %}}
+> [!NOTE]
+>
+> Although all generated menu and landing page links based on your placeholder
+> file are set according to the parameters `manualLink` or `manualLinkRelref`,
+> Hugo still generates a regular HTML site page for the file, albeit one with no
+> generated links to it. To avoid confusion if users accidentally land on a
+> generated placeholder page, we recommend specifying the URL for the external
+> link in the normal content and / or page description of the page.
 
 ### Section as sidebar root (EXPERIMENTAL) {#sidebar-root}
 
@@ -610,13 +608,11 @@ viewport (configured via `rootMargin`).
 
   {{% /tab %}} {{< /tabpane >}}
 
-  {{% alert title="Smooth scrolling issue" color=info %}}
-
-  We previously enabled ScrollSpy's smooth scrolling, but it interfered with
-  hash updates in the browser URL and in-page navigation, so it is disabled by
-  default. For details see PR [#2291].
-
-  {{% /alert %}}
+> [!INFO] Smooth scrolling issue
+>
+> We previously enabled ScrollSpy's smooth scrolling, but it interfered with
+> hash updates in the browser URL and in-page navigation, so it is disabled by
+> default. For details see PR [#2291].
 
 #### Advanced ScrollSpy customization
 
@@ -624,18 +620,18 @@ For advanced customization, such as adjusting `threshold`, override
 [layouts/_partials/td/scrollspy-attr.txt]. For ScrollSpy configuration details,
 see [ScrollSpy].
 
-{{% alert title="Note" %}}
-
-ScrollSpy determines the active TOC entry using the browser's
-[IntersectionObserver API][], including its configurable [rootMargin]. Because
-of how these thresholds work, there can be brief moments while a user is
-scrolling when **no** heading is highlighted, especially when headings are close
-together or when the active region is small. For more details, see [ScrollSpy
-options][] and the discussion in [Bootstrap issue #34958][bs-34958].
-
-[bs-34958]: https://github.com/twbs/bootstrap/issues/34958
-
-{{% /alert %}}
+> [!NOTE]
+>
+> ScrollSpy determines the active TOC entry using the browser's
+> [IntersectionObserver API][], including its configurable [rootMargin]. Because
+> of how these thresholds work, there can be brief moments while a user is
+> scrolling when **no** heading is highlighted, especially when headings are
+> close together or when the active region is small. For more details, see
+> [ScrollSpy options][ss-opt] and the discussion in [Bootstrap issue
+> #34958][bs-34958].
+>
+> [bs-34958]: https://github.com/twbs/bootstrap/issues/34958
+> [ss-opt]: https://getbootstrap.com/docs/5.3/components/scrollspy/#options
 
 [cascade]: https://gohugo.io/content-management/front-matter/#cascade-1
 [IntersectionObserver API]:
@@ -646,8 +642,6 @@ options][] and the discussion in [Bootstrap issue #34958][bs-34958].
 [ScrollSpy]: https://getbootstrap.com/docs/5.3/components/scrollspy/
 [rootmargin]:
   https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin
-[ScrollSpy options]:
-  https://getbootstrap.com/docs/5.3/components/scrollspy/#options
 
 ## Breadcrumb navigation
 
@@ -749,3 +743,4 @@ defined in [layouts/_partials/td/render-heading.html].
 [hook]: https://gohugo.io/templates/render-hooks/
 [menu]: https://gohugo.io/content-management/menus/
 [menus]: https://gohugo.io/content-management/menus/
+[Multi-language support]: /docs/language/

--- a/docsy.dev/content/en/docs/content/print.md
+++ b/docsy.dev/content/en/docs/content/print.md
@@ -55,6 +55,7 @@ To disable showing the the table of contents in the printable view, set the
 `disable_toc` param to `true`, either in the page front matter, or in
 `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane langEqualsHeader=true >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -105,6 +106,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ## Layout hooks
 

--- a/docsy.dev/content/en/docs/content/repository-links.md
+++ b/docsy.dev/content/en/docs/content/repository-links.md
@@ -1,9 +1,10 @@
 ---
 title: Repository Links and other page information
 linkTitle: Repo links and page info
-weight: 9
 description:
   Help your users interact with page source and view page-source information.
+cSpell:ignore: docsy lastmod
+weight: 9
 ---
 
 The Docsy
@@ -48,6 +49,7 @@ metadata.
 The URL for your site's source repository. This is used to generate the **Edit
 this page**, **Create child page**, and **Create documentation issue** links.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -68,6 +70,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### `github_subdir` (optional)
 
@@ -102,6 +105,7 @@ Specify a value here if you have a separate project repo and you'd like your
 users to be able to create issues against your project from the relevant docs.
 The **Create project issue** link appears only if this is set.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -122,6 +126,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### `github_branch` (optional)
 
@@ -156,6 +161,7 @@ come from another repo, such as a [git submodule][]. Add settings like these to
 the **section's index page** so that the repository links for all pages in that
 section refer to the originating repo:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -191,6 +197,7 @@ cascade:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 As an example, consider a page at the path
 `content/some-section/subpath/some-page.md` with `github_branch` globally set to
@@ -217,6 +224,7 @@ cascade:
 ---
 ```
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -248,15 +256,19 @@ cascade:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
-{{% alert title="Tip" %}} Please note that the YAML code fragment makes use of
-[Yaml anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/).
-Use of Yaml anchors is optional, but it helps keep the settings
-[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). {{% /alert %}}
+> [!TIP]
+>
+> Notice that the YAML code fragment makes use of
+> [Yaml anchor](https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/).
+> Use of Yaml anchors is optional, but it helps keep the settings
+> [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
 The `path_base_for_github_subdir` setting is a regular expression, so you can
 use it even if you have a site with [multiple languages][] for example:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -283,11 +295,13 @@ path_base_for_github_subdir: content/\w+/some-section
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 In situations where a page originates from a file under a different name, you
 can specify `from` and `to` path-rename settings. Here's an example where an
 index file is named `README.md` in the originating repo:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -328,19 +342,19 @@ path_base_for_github_subdir:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### `github_url` (optional)
 
-{{% alert title="Deprecation note" color="warning" %}} This setting is
-deprecated. Use [path_base_for_github_subdir][] instead.
-
-[path_base_for_github_subdir]: #path_base_for_github_subdir-optional
-
-{{% /alert %}}
+> [!WARNING] Deprecation note
+>
+> This setting is deprecated. Use
+> [path_base_for_github_subdir](#path_base_for_github_subdir-optional) instead.
 
 Specify a value for this **in your page metadata** to set a specific edit URL
 for this page, as in the following example:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -367,6 +381,7 @@ github_url: https://github.com/some-username/another-repo/edit/main/README.md
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 This can be useful if you have page source files in multiple Git repositories,
 or require a non-GitHub URL. Pages using this value have **Edit this page**
@@ -399,13 +414,11 @@ defined by the following table:
 Of course, you can also use these classes to give repository links unique styles
 for your project.
 
-{{% alert title="Version note" color=warning %}}
-
-Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
-
-[v0.9.0]: /project/about/changelog/#v0.9.0
-
-{{% /alert %}}
+> [!WARNING] Version note
+>
+> Class names using the `--KIND` suffix were deprecated as of [v0.9.0].
+>
+> [v0.9.0]: /project/about/changelog/#v0.9.0
 
 ## Last-modified page metadata
 

--- a/docsy.dev/content/en/docs/content/search.md
+++ b/docsy.dev/content/en/docs/content/search.md
@@ -27,13 +27,11 @@ search box also displays at the top of the sidebar in the left navigation pane,
 which you can disable if you prefer, or if you're using a search option that
 only works with the top search box.
 
-{{% alert title="You can only enable a single search option at a time" color=warning %}}
-
-If you accidentally enable more than one search option in your project
-configuration file, you will get a warning at build time, and undetermined
-behavior when serving your site.
-
-{{% /alert %}}
+> [!WARNING] You can only enable a single search option at a time
+>
+> If you accidentally enable more than one search option in your project
+> configuration file, you will get a warning at build time, and undetermined
+> behavior when serving your site.
 
 ## Disabling the sidebar search box
 
@@ -91,20 +89,18 @@ as otherwise your site won't be crawled and indexed.
       **Advanced** - **Websearch Settings**. In the **Link Target** field, type
       "\_parent". Click **Save** to save your changes.
 
-{{% alert title="Tip" %}}
-
-Your site search results should show up within a couple of days. If it takes
-longer than that, you can manually request that your site is indexed by
-[submitting a sitemap through the Google Search Console](https://support.google.com/webmasters/answer/183668?hl=en).
-
-{{% /alert %}}
+> [!TIP]
+>
+> Your site search results should show up within a couple of days. If it takes
+> longer than that, you can manually request that your site is indexed by
+> [submitting a sitemap through the Google Search Console](https://support.google.com/webmasters/answer/183668?hl=en).
 
 ### Adding the search page
 
 Once you have your search engine set up, you can add the feature to your site:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
-
 1.  Ensure you have a Markdown file in `content/en/search.md` (and one per other
     languages if needed) to display your search results. It only needs a title
     and `layout: search`, as in the following example:
@@ -139,7 +135,6 @@ layout: search
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 [params]
-# Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "011737558837375720776:fsdu1nryfng"
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
@@ -155,6 +150,7 @@ params:
 {{< /tab >}}
     {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### Disabling GCSE search
 
@@ -169,15 +165,13 @@ As an alternative to GCSE, you can use
 [Algolia DocSearch](https://docsearch.algolia.com), which is free for public
 documentation sites. Docsy supports **Algolia DocSearch v3**.
 
-{{% alert title="Algolia v2 is deprecated" %}}
-
-Docsy previously supported Algolia DocSearch v2, which is now deprecated. If you
-are an existing Algolia DocSearch v2 user and want to use the latest Docsy
-version, follow the
-[migration instructions](https://docsearch.algolia.com/docs/v3/migrating-from-v2)
-in the DocSearch documentation to update your DocSearch code snippet.
-
-{{% /alert %}}
+> [!NOTE] Algolia v2 is deprecated
+>
+> Docsy previously supported Algolia DocSearch v2, which is now deprecated. If
+> you are an existing Algolia DocSearch v2 user and want to use the latest Docsy
+> version, follow the
+> [migration instructions](https://docsearch.algolia.com/docs/v3/migrating-from-v2)
+> in the DocSearch documentation to update your DocSearch code snippet.
 
 ### Sign up for Algolia DocSearch
 
@@ -292,15 +286,13 @@ params:
 Once you've completed these steps, local search is enabled for your site and
 results appear in a drop down when you use the search box.
 
-{{% alert title="Tip" %}}
-
-If you're [testing this locally](/docs/deployment/#serving-your-site-locally)
-using Hugo’s local server functionality, you need to build your
-`offline-search-index.xxx.json` file first by running `hugo`. If you have the
-Hugo server running while you build `offline-search-index.xxx.json`, you may
-need to stop the server and restart it in order to see your search results.
-
-{{% /alert %}}
+> [!TIP]
+>
+> If you're [testing this locally](/docs/deployment/#serving-your-site-locally)
+> using Hugo’s local server functionality, you need to build your
+> `offline-search-index.xxx.json` file first by running `hugo`. If you have the
+> Hugo server running while you build `offline-search-index.xxx.json`, you may
+> need to stop the server and restart it in order to see your search results.
 
 ### Changing the summary length of the local search results
 
@@ -311,7 +303,6 @@ You can customize the summary length by setting `offlineSearchSummaryLength` in
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
-#Enable offline search with Lunr.js
 [params]
 offlineSearch = true
 offlineSearchSummaryLength = 200
@@ -337,6 +328,7 @@ params:
 You can customize the maximum result count by setting `offlineSearchMaxResults`
 in `hugo.toml`/`hugo.yaml`/`hugo.json`.
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -360,6 +352,7 @@ params:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### Changing the width of the local search results popover
 
@@ -380,6 +373,7 @@ If you want to limit the width, add the following scss into
 To exclude pages from local search results, add `exclude_search: true` to the
 the frontmatter of each page:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -406,6 +400,7 @@ exclude_search: true
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 ### Custom search
 

--- a/docsy.dev/content/en/docs/content/shortcodes/includes/installation.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/includes/installation.md
@@ -1,10 +1,9 @@
-**Installation**
+## Installation
 
-{{% alert title="Note" %}} Check system compatibility before proceeding.
-{{% /alert %}}
+> [!IMPORTANT]
+>
+> Check system compatibility before proceeding.
 
 1.  Download the installation files.
-
 1.  Run the installation script `sudo sh install.sh`
-
 1.  Test that your installation was successfully completed.

--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -11,8 +11,11 @@ resources:
 params:
   message: Hello, world!
 # prettier-ignore
-cSpell:ignore: cardpane docsy imgproc pageinfo petstore Bjørn Pedersen swaggerui grayscale Picea tryautoheight readfile domsignal
+cSpell:ignore: cardpane docsy imgproc pageinfo petstore Bjørn Pedersen swaggerui grayscale Picea tryautoheight readfile domsignal buildcondition
 ---
+
+<!-- markdownlint-disable blanks-around-fence line-length -->
+<!-- markdownlint-capture -->
 
 Rather than writing all your site pages from scratch, Hugo lets you define and
 use [shortcodes](https://gohugo.io/content-management/shortcodes/). These are
@@ -75,10 +78,10 @@ but is included here for completeness.
 | Parameter    | Default                        | Description                           |
 | ------------ | ------------------------------ | ------------------------------------- |
 | title        |                                | The main display title for the block. |
-| image_anchor |                                |
+| image_anchor |                                |                                       |
 | height       |                                | See above.                            |
 | color        |                                | See above.                            |
-| byline       | Byline text on featured image. |
+| byline       | Byline text on featured image. |                                       |
 
 To set the background image, place an image with the word "background" in the
 name in the page's [Page Bundle](/docs/content/adding-content/#page-bundles).
@@ -87,9 +90,11 @@ cover block is
 [`featured-background.jpg`](https://github.com/google/docsy-example/tree/main/content/en),
 in the same directory.
 
-{{% alert title="Tip" %}} If you also include the word **featured** in the image
-name, e.g. `my-featured-background.jpg`, it will also be used as the Twitter
-Card image when shared. {{% /alert %}}
+> [!TIP]
+>
+> If you also include the word **featured** in the image name, e.g.
+> `my-featured-background.jpg`, it will also be used as the Twitter Card image
+> when shared.
 
 For available icons, see
 [Font Awesome](https://fontawesome.com/icons?d=gallery&m=free).
@@ -171,9 +176,16 @@ section. It's meant to be used in combination with the other blocks shortcodes.
 | --------- | ------- | ----------- |
 | color     | info    | See above.  |
 
-## Shortcode helpers
+## Helpers shortcodes
 
-### alert
+### `alert`
+
+> [!NOTE] Alerts in markdown syntax!
+>
+> As of Docsy [0.14.0][0.14.0-alerts], you can write alerts in markdown. For
+> details, see [Alerts](/docs/content/adding-content/#alerts).
+>
+> [0.14.0-alerts]: /blog/2026/0.14.0/#alerts
 
 Use the **alert** shortcode to display notices and warnings. The shortcode
 renders a [Bootstrap alert component][bs-alert]. It can be used with Markdown
@@ -244,6 +256,7 @@ example below from breaking all the rest of the page. DO NOT remove it.
 
 <div class="td-max-width-on-larger-screens">
 
+<!-- markdownlint-disable no-empty-links -->
 <!-- prettier-ignore -->
 - The following note is part of this list item:
   {{% alert title="Celebrate!" color=success %}}
@@ -262,7 +275,9 @@ example below from breaking all the rest of the page. DO NOT remove it.
 [bs-alert]: https://getbootstrap.com/docs/5.3/components/alerts/
 [link definition]: # 'A link definition defined outside the alert body.'
 
-### pageinfo
+<!-- markdownlint-restore -->
+
+### `pageinfo`
 
 The **pageinfo** shortcode creates a text box that you can use to add banner
 information for a page: for example, letting users know that the page contains
@@ -287,7 +302,7 @@ This is placeholder content
 | --------- | ------- | ------------------------------------------------------------- |
 | color     | primary | One of the theme colors, eg `primary`, `info`, `warning` etc. |
 
-### imgproc
+### `imgproc`
 
 The **imgproc** shortcode finds an image in the current
 [Page Bundle](/docs/content/adding-content/#page-bundles) and scales it given a
@@ -313,6 +328,7 @@ situations need a way to attribute the author or licensor. You can add metadata
 to your page resources in the page front matter. The `byline` param is used by
 convention in this theme:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -347,6 +363,7 @@ resources:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 | Parameter | Description                                                                                                                                                         |
 | --------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -354,7 +371,7 @@ resources:
 |         2 | Command. One of `Fit`, `Resize`, `Fill` or `Crop`. See [Image Processing Methods](https://gohugo.io/content-management/image-processing/#image-processing-methods). |
 |         3 | Processing options, e.g. `400x450 r180`. See [Image Processing Options](https://gohugo.io/content-management/image-processing/#image-processing-options).           |
 
-### swaggerui
+### `swaggerui`
 
 You can place the `swaggerui` shortcode anywhere inside a page with the
 [`swagger` layout](https://github.com/google/docsy/tree/main/layouts/swagger);
@@ -363,6 +380,7 @@ YAML or JSON file as source. This file can be hosted anywhere you like, for
 example in your site's root
 [`/static` folder](/docs/content/adding-content/#adding-static-content).
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Front matter:" disabled=true />}}
@@ -398,15 +416,17 @@ description: Reference for the Pet Store API
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 You can customize Swagger UI's look and feel by overriding Swagger's CSS in
 `themes/docsy/assets/scss/_swagger.scss`.
 
-{{% alert title="Warning" color="warning" %}} This shortcode relies on
-JavaScript libraries hosted on unpkg. Make sure that you can access unpkg from
-your network when building or loading your site. {{% /alert %}}
+> [!WARNING]
+>
+> This shortcode relies on JavaScript libraries hosted on unpkg. Make sure that
+> you can access unpkg from your network when building or loading your site.
 
-### redoc
+### `redoc`
 
 The `redoc` shortcode uses the open-source
 [Redoc](https://github.com/Redocly/redoc) tool to render reference API
@@ -431,10 +451,12 @@ description: Reference for the Pet Store API
 }
 ```
 
-### iframe
+### `iframe`
 
 With this shortcode you can embed external content into a Docsy page as an
-inline frame (`iframe`) - see: https://www.w3schools.com/tags/tag_iframe.asp
+inline frame ([iframe]).
+
+[iframe]: https://www.w3schools.com/tags/tag_iframe.asp
 
 | Parameter     | Default                                                                                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | ------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -448,24 +470,22 @@ inline frame (`iframe`) - see: https://www.w3schools.com/tags/tag_iframe.asp
 | class         |                                                                                                       | Optional parameter to set the classes of the iframe.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | sub           | Your browser cannot display embedded frames. You can access the embedded page via the following link: | The text displayed (in addition to the embedded URL) if the user's browser can't display embedded frames.                                                                                                                                                                                                                                                                                                                                                                                                |
 
-{{% alert title="Warning" color="warning" %}}
-
-You can only embed external content from a server when its `X-Frame-Options` is
-not set or if it specifically allows embedding for your site. For details, see
-[X-Frame-Options]
-
-There are several tools you can use to check if a website can be embedded via
-iframe, such as [domsignal.com/x-frame-options-test]. Be aware that when this
-test says "Couldn’t find the X-Frame-Options header in the response headers."
-you **CAN** embed it, but when the test says "Great! X-Frame-Options header was
-found in the HTTP response headers as highlighted below.", you **CANNOT** -
-unless it has been explicitly enabled for your site.
+> [!WARNING]
+>
+> You can only embed external content from a server when its `X-Frame-Options`
+> is not set or if it specifically allows embedding for your site. For details,
+> see [X-Frame-Options].
+>
+> There are several tools you can use to check if a website can be embedded via
+> iframe, such as [domsignal.com/x-frame-options-test]. Be aware that when this
+> test says "Couldn’t find the X-Frame-Options header in the response headers."
+> you **CAN** embed it, but when the test says "Great! X-Frame-Options header
+> was found in the HTTP response headers as highlighted below.", you
+> **CANNOT** - unless it has been explicitly enabled for your site.
 
 [X-Frame-Options]:
   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
 [domsignal.com/x-frame-options-test]: https://domsignal.com/x-frame-options-test
-
-{{% /alert %}}
 
 ## Tabbed panes
 
@@ -475,6 +495,8 @@ the same problem, and how to solve it in different programming languages. As an
 example, the tabbed pane below shows the language-specific variants of the
 famous `Hello world!` program one usually writes first when learning a new
 programming language:
+
+<!-- markdownlint-disable no-missing-space-atx blanks-around-headings no-bare-urls single-h1 -->
 
 <!-- prettier-ignore-start -->
 <!-- cSpell:ignore cout println stdio stdlib endl -->
@@ -623,7 +645,7 @@ following named parameters, all of which are optional:
 - **`header`**: defines the tab's header text. When omitted it defaults to text
   of the form "Tab _n_". You can omit the parameter name if it is the only tab
   parameter:
-  ```
+  ```go-html-template
   {{</* tab "My tab header" */>}} … {{</* /tab */>}}
   ```
 - **`lang`**: code-block language for code tabs
@@ -645,10 +667,12 @@ and _textual_ representation:
 - If the contents of your tabs should be rendered as text with different styles
   and optional images, specify `text=true` as parameter of your `tab`:
 
-> **Reminder**: If your content is markdown, use the percent sign `%` as
-> delimiter for your `tab` shortcode, like this:
+> [!NOTE] Reminder
 >
-> ```
+> If your content is markdown, use the percent sign `%` as delimiter for your
+> `tab` shortcode, like this:
+>
+> ```go-html-template
 > {{%/* tab */%}} Your \*\*markdown\*\* content {{%/* /tab */%}}
 > ```
 
@@ -704,6 +728,8 @@ This code translates to the left card shown below, showing the lyrics of John
 Lennon's famous song `Imagine`. A second explanatory card element to the right
 indicates and explains the individual components of a card:
 
+<!-- markdownlint-disable -->
+
 {{% cardpane %}}
 {{< card header="**Imagine**" title="Artist and songwriter: John Lennon" subtitle="Co-writer: Yoko Ono" footer="![SignatureJohnLennon](https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Firma_de_John_Lennon.svg/320px-Firma_de_John_Lennon.svg.png 'Signature John Lennon')" >}}
 Imagine there's no heaven, It's easy if you try<br/> No hell below us, above us
@@ -725,6 +751,8 @@ as outermost delimiter of your `card` shortcode, your markup should look like
 content, use square brackets `<>` as outermost delimiters:
 `{{</* card */>}}Your <b>HTML</b> content{{</* /card */>}}` {{% /card %}}
 {{% /cardpane %}}
+
+<!-- markdownlint-restore -->
 
 While the main content of the card is taken from the inner markup of the `card`
 shortcode, the optional elements `footer`, `header`, `title`, and `subtitle` are
@@ -751,6 +779,7 @@ int main(void)
 
 This code translates to the card shown below:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< card code=true header="**C**" lang="C" highlight="" >}}
 #include <stdio.h>
@@ -763,6 +792,7 @@ int main(void)
 }
 {{< /card >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 <br/>If called with parameter `code=true`, the `card` shortcode can optionally
 hold the named parameters `lang` and/or `highlight`. The values of these
@@ -819,16 +849,12 @@ contents:
 ```go-html-template
 ## Installation
 
-{{%/* alert title="Note" color="primary" */%}}
-Check system compatibility before proceeding.
-{{%/* /alert */%}}
+> [!IMPORTANT]
+>
+> Check system compatibility before proceeding.
 
 1.  Download the installation files.
-
-1.  Run the installation script
-
-    `sudo sh install.sh`
-
+1.  Run the installation script `sudo sh install.sh`
 1.  Test that your installation was successfully completed.
 ```
 
@@ -867,11 +893,11 @@ additional parameters:
 ```go-html-template
 To create a new pipeline, follow the next steps:
 
-1.  Create a configuration file `config.yaml`:
+1. Create a configuration file `config.yaml`:
 
-    {{</* readfile file="includes/config.yaml" code="true" lang="yaml" */>}}
+   {{</* readfile file="includes/config.yaml" code="true" lang="yaml" */>}}
 
-1.  Apply the file to your cluster `kubectl apply config.yaml`
+1. Apply the file to your cluster `kubectl apply config.yaml`
 ```
 
 This code automatically reads the content of `includes/config.yaml` and inserts
@@ -881,16 +907,18 @@ it into the document. The rendered text looks like this:
 
 To create a new pipeline, follow the next steps:
 
-1.  Create a configuration file `config.yaml`:
+1. Create a configuration file `config.yaml`:
 
-    {{< readfile file="includes/config.yaml" code="true" lang="yaml" >}}
+   {{< readfile file="includes/config.yaml" code="true" lang="yaml" >}}
 
-1.  Apply the file to your cluster `kubectl apply config.yaml`
+1. Apply the file to your cluster `kubectl apply config.yaml`
 
 ---
 
-{{% alert title="Warning" color="warning" %}} You must use `{{</* */>}}`
-delimiters for the code highlighting to work correctly. {{% /alert %}}
+> [!WARNING]
+>
+> You must use `{{</* */>}}` delimiters for the code highlighting to work
+> correctly.
 
 The `file` parameter is the relative path to the file. Only relative paths under
 the parent file's working directory are supported.

--- a/docsy.dev/content/en/docs/content/versioning.md
+++ b/docsy.dev/content/en/docs/content/versioning.md
@@ -6,6 +6,8 @@ description: >-
   Customize navigation and banners for multiple versions of your docs.
 ---
 
+<!-- markdownlint-disable blanks-around-headings no-bare-urls single-h1 -->
+
 Depending on your project's releases and versioning, you may want to let your
 users access previous versions of your documentation. How you deploy the
 previous versions is up to you. This page describes the Docsy features that you

--- a/docsy.dev/content/en/docs/deployment/_index.md
+++ b/docsy.dev/content/en/docs/deployment/_index.md
@@ -54,20 +54,19 @@ Then follow the instructions in [Host on Netlify](https://gohugo.io/hosting-and-
    If you don't want your site to be indexed by search engines, you can add an environment flag to your build command to specify a non-`production` environment, as described in [Build environments and indexing](#build-environments-and-indexing).
 1. Click **Deploy site**.
 
-{{% alert title="Note" %}}
-Netlify uses your site repo's `package.json` file to install any JavaScript dependencies (like `postcss`) before building your site. If you haven't just copied our example site's version of this file, make sure that you've specified all our [prerequisites](/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).
-
-For example, if you want to use a version of `postcss-cli` later than version 8.0.0, you need to ensure that your `package.json` also specifies `postcss` separately:
-
-```
-  "devDependencies": {
-    "autoprefixer": "^10.4.19",
-    "postcss-cli": "^11.0.0",
-    "postcss": "^8.4.38"
-  }
-```
-
-{{% /alert %}}
+> [!NOTE]
+>
+> Netlify uses your site repo's `package.json` file to install any JavaScript dependencies (like `postcss`) before building your site. If you haven't just copied our example site's version of this file, make sure that you've specified all our [prerequisites](/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).
+>
+> For example, if you want to use a version of `postcss-cli` later than version 8.0.0, you need to ensure that your `package.json` also specifies `postcss` separately:
+>
+> ```
+>   "devDependencies": {
+>     "autoprefixer": "^10.4.19",
+>     "postcss-cli": "^11.0.0",
+>     "postcss": "^8.4.38"
+>   }
+> ```
 
 Alternatively, you can follow the same instructions but specify your **Deploy settings** in a [`netlify.toml` file](https://docs.netlify.com/configure-builds/file-based-configuration/) in your repo rather than in the **Deploy settings** page. You can see an example of this in the [Docsy theme repo](https://github.com/google/docsy/blob/main/netlify.toml) (though note that the build command here is a little unusual because the Docsy user guide is *inside* the theme repo).
 
@@ -81,9 +80,9 @@ The Docsy example site repo provides a [workflow file](https://github.com/google
 
 Before deploying on GitHub Pages, make sure that you've pushed your site source to your chosen GitHub repo, following any setup instructions in [Using the theme](/docs/get-started/docsy-as-module).
 
-{{% alert title="Correct baseURL setting" %}}
-Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '…'` command line parameter or inside your your `hugo.toml`/`hugo.yaml`/`hugo.json` configuration file. When deploying to GitHub pages your `baseURL` needs to be set to `https://<USERNAME>.github.io/<repository_name>`, otherwise your site layout will be broken.
-{{% /alert %}}
+> [!NOTE] Correct baseURL setting
+>
+> Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '…'` command line parameter or inside your your `hugo.toml`/`hugo.yaml`/`hugo.json` configuration file. When deploying to GitHub pages your `baseURL` needs to be set to `https://<USERNAME>.github.io/<repository_name>`, otherwise your site layout will be broken.
 
 1. With GitHub Pages, a site is published to the branch `gh-pages` and served from there by default. You must create this branch first, either in the GitHub web interface or via command line (at the root of your local repo clone):
 
@@ -273,12 +272,12 @@ deployment:
 
 For more information about the Hugo `deploy` command, including command line options, see this [synopsis](https://gohugo.io/commands/hugo_deploy). In particular, you may find the `--maxDeletes int` option or the `--force` option (which forces upload of all files) useful.
 
-{{% alert title="Automated deployment with GitHub actions" %}}
-If the source of your site lives in a GitHub repository, you can use [GitHub Actions](https://docs.github.com/en/actions) to deploy the site to your S3 bucket as soon as you commit changes to your GitHub repo. Setup of this workflow is described in this [blog post](https://capgemini.github.io/development/Using-GitHub-Actions-and-Hugo-Deploy-to-Deploy-to-AWS/).
-{{% /alert %}}
+> [!NOTE] Automated deployment with GitHub actions
+>
+> If the source of your site lives in a GitHub repository, you can use [GitHub Actions](https://docs.github.com/en/actions) to deploy the site to your S3 bucket as soon as you commit changes to your GitHub repo. Setup of this workflow is described in this [blog post](https://capgemini.github.io/development/Using-GitHub-Actions-and-Hugo-Deploy-to-Deploy-to-AWS/).
 
-{{% alert title="Handling aliases" %}}
-If you are using [aliases](https://gohugo.io/content-management/urls/#aliases) for URL management, you should have a look at this [blog post](https://blog.cavelab.dev/2021/10/hugo-aliases-to-s3-redirects/). It explains how to turn aliases into proper `301` redirects when using Amazon S3.
-{{% /alert %}}
+> [!NOTE] Handling aliases
+>
+> If you are using [aliases](https://gohugo.io/content-management/urls/#aliases) for URL management, you should have a look at this [blog post](https://blog.cavelab.dev/2021/10/hugo-aliases-to-s3-redirects/). It explains how to turn aliases into proper `301` redirects when using Amazon S3.
 
 If S3 does not meet your needs, consider AWS [Amplify Console](https://aws.amazon.com/amplify/console/). This is a more advanced continuous deployment (CD) platform with built-in support for the Hugo static site generator. A [starter](https://gohugo.io/hosting-and-deployment/hosting-on-aws-amplify/) can be found in Hugo's official docs.

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -62,10 +62,10 @@ As the Docsy example site repo is a [template repository](https://github.blog/20
     git clone https://github.com/me-at-github/my-new-site.git
     ```
 
-{{% alert title="Note" %}}
-Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227) inside your `hugo.toml` slightly, for example by adding a proxy to use when downloading remote modules.
-You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
-{{% /alert %}}
+> [!NOTE]
+>
+> Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227) inside your `hugo.toml` slightly, for example by adding a proxy to use when downloading remote modules.
+> You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 
 Now you can make local edits and test your copied site locally with Hugo.
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -64,10 +64,10 @@ cd  my-new-site
 
 This will create a minimal site structure, containing the folders `archetypes`, `content`, `data`, `layouts`, `static`, and `themes` and a configuration file (default: `hugo.toml`).
 
-{{% alert title="Tip" %}}
-In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
-If you are using hugo 0.110 or above, consider renaming your `config.toml` to `hugo.toml`!
-{{% /alert %}}
+> [!TIP]
+>
+> In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
+> If you are using hugo 0.110 or above, consider renaming your `config.toml` to `hugo.toml`!
 
 ### Import the Docsy theme module as a dependency of your site
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -6,6 +6,8 @@ cSpell:ignore: docsy gohugo hugo myproject
 weight: 2
 ---
 
+<!-- markdownlint-disable no-blanks-blockquote -->
+
 If you don't want to use
 [Docsy as a Hugo Module](/docs/get-started/docsy-as-module/) (for example if you
 do not want to install Go) but still don't want to copy the theme files into
@@ -106,8 +108,9 @@ If you have Node installed already, check your version of Node. For example:
 node -v
 ```
 
-Install or upgrade your version of Node to the **active [LTS release][]**. We recommend
-using **[nvm][]** to manage your Node installation (Linux command shown):
+Install or upgrade your version of Node to the **active [LTS release][]**. We
+recommend using **[nvm]** to manage your Node installation (Linux command
+shown):
 
 ```sh
 nvm install --lts
@@ -119,16 +122,12 @@ To build or update your site's CSS resources, you'll also need
 [PostCSS](https://postcss.org/). Install it using the Node package manager,
 `npm`.
 
-{{% alert title="IMPORTANT: Check your Node version" color="warning" %}}
-
-The PostCSS package installed by some older versions of Node is incompatible
-with Docsy. Check your version of Node against the **active [LTS release][]** and
-upgrade, if necessary. For details, see [Node: Get the latest LTS release][latest-lts].
-
-[lts release]: https://nodejs.org/en/about/releases/
-[latest-lts]: #node-get-the-latest-lts-release
-
-{{% /alert %}}
+> [!IMPORTANT] IMPORTANT: Check your Node version
+>
+> The PostCSS package installed by some older versions of Node is incompatible
+> with Docsy. Check your version of Node against the **active [LTS release][]**
+> and upgrade, if necessary. For details, see
+> [Node: Get the latest LTS release](#node-get-the-latest-lts-release).
 
 From your project root, run this command:
 
@@ -181,13 +180,11 @@ your project's root directory:
     echo 'theme: docsy' >> hugo.yaml
     ```
 
-    {{% alert title="Tip" %}}
-
-    As of Hugo 0.110.0, the default config base
-    filename was changed to `hugo.*` from `config.*`. If you are using hugo
-    0.110 or above, consider renaming your `config.*` to `hugo.*`.
-
-    {{% /alert %}}
+    > [!TIP]
+    >
+    > As of Hugo 0.110.0, the default config base filename was changed to
+    > `hugo.*` from `config.*`. If you are using hugo 0.110 or above, consider
+    > renaming your `config.*` to `hugo.*`.
 
 3.  Get Docsy dependencies:
 
@@ -195,7 +192,7 @@ your project's root directory:
     (cd themes/docsy && npm install)
     ```
 
-    > **Important**: read the [Docsy NPM install side-effect] note.
+    > [!IMPORTANT] **Important**: read the [Docsy NPM install side-effect] note.
 
 4.  (Optional but recommended) To avoid having to repeat the previous step every
     time you update Docsy, consider adding [NPM scripts][] like the following to
@@ -241,7 +238,7 @@ cd docsy
 npm install
 ```
 
-> **Important**: read the [Docsy NPM install side-effect] note.
+> [!IMPORTANT] **Important**: read the [Docsy NPM install side-effect][] note.
 
 To work from the development version of Docsy (not recommended unless, for
 example, you plan to upstream changes to Docsy), omit the
@@ -273,21 +270,17 @@ You can use Docsy as an NPM module as follows:
     npm install --save-dev google/docsy#semver:{{% param version %}} --omit=peer
     ```
 
-    {{% alert title="Hugo-module compatibility" color="warning" %}}
+    > [!WARNING] Hugo-module compatibility
+    >
+    > Installing Docsy using NPM creates an empty `github.com` sibling folder.
+    > For details, see
+    > [Docsy NPM install side-effect](#docsy-npm-install-side-effect).
 
-    Installing
-    Docsy using NPM creates an empty `github.com` sibling folder. For details,
-    see [Docsy NPM install side-effect](#docsy-npm-install-side-effect).
-
-    {{% /alert %}}
-
-    {{% alert title="Hugo install tip" %}}
-
-    You can install Docsy's
-    officially supported version of [Hugo using NPM](#hugo-extended-npm) at the
-    same time as Docsy. Just omit the `--omit` flag from the command above.
-
-    {{% /alert %}}
+    > [!TIP] Hugo install tip
+    >
+    > You can install Docsy's officially supported version of
+    > [Hugo using NPM](#hugo-extended-npm) at the same time as Docsy. Just omit
+    > the `--omit` flag from the command above.
 
 3.  Build or serve your new site using the usual Hugo commands, specifying the
     path to the Docsy theme files. For example, build your site as follows:
@@ -298,23 +291,21 @@ You can use Docsy as an NPM module as follows:
     ...
     ```
 
-    {{% alert title="Error: failed to load modules" color="warning" %}}
-
-    If Hugo reports the following error when building your site ([#2116]):
-
-    ```
-    Error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in ".../myproject/node_modules/github.com/FortAwesome/Font-Awesome" ...
-    ```
-
-    Then run the following command and try again:
-
-    ```sh
-    npm rebuild
-    ```
-
-    [#2116]: https://github.com/google/docsy/issues/2116
-
-    {{% /alert %}}
+    > [!WARNING] Error: failed to load modules
+    >
+    > If Hugo reports the following error when building your site ([#2116]):
+    >
+    > ```text
+    > Error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in ".../myproject/node_modules/github.com/FortAwesome/Font-Awesome" ...
+    > ```
+    >
+    > Then run the following command and try again:
+    >
+    > ```sh
+    > npm rebuild
+    > ```
+    >
+    > [#2116]: https://github.com/google/docsy/issues/2116
 
 As an alternative to specifying a `themesDir`, on some platforms, you can
 instead create a symbolic link to the Docsy theme directory as follows (Linux
@@ -329,27 +320,25 @@ popd
 
 ## Docsy NPM install side-effect
 
-{{% alert title="Important" color=warning %}}
-
-As of Docsy version [0.8.0], running `npm install` inside the Docsy theme
-directory will create a sibling folder named `github.com`, for example:
-
-```console
-$ ls themes
-docsy                   github.com
-```
-
-This is a workaround necessary to support Docsy's use as a single [Hugo module]
-([#1120]) in the context of projects _not_ using Hugo modules. The `github.com`
-folder is created via Docsy's `postinstall` script. To disable this behavior,
-set the environment variable `DOCSY_MKDIR_HUGO_MOD_SKIP=1` before running NPM
-install.
-
-[#1120]: https://github.com/google/docsy/issues/1120
-[0.8.0]: /project/about/changelog/#v0.8.0
-[hugo module]: /docs/get-started/docsy-as-module/
-
-{{% /alert %}}
+> [!NOTE]
+>
+> As of Docsy version [0.8.0], running `npm install` inside the Docsy theme
+> directory will create a sibling folder named `github.com`, for example:
+>
+> ```console
+> $ ls themes
+> docsy                   github.com
+> ```
+>
+> This is a workaround necessary to support Docsy's use as a single [Hugo
+> module][hm] ([#1120]) in the context of projects _not_ using Hugo modules. The
+> `github.com` folder is created via Docsy's `postinstall` script. To disable
+> this behavior, set the environment variable `DOCSY_MKDIR_HUGO_MOD_SKIP=1`
+> before running NPM install.
+>
+> [#1120]: https://github.com/google/docsy/issues/1120
+> [0.8.0]: /project/about/changelog/#v0.8.0
+> [hm]: /docs/get-started/docsy-as-module/
 
 [Docsy NPM install side-effect]: #docsy-npm-install-side-effect
 

--- a/docsy.dev/content/en/docs/language.md
+++ b/docsy.dev/content/en/docs/language.md
@@ -17,6 +17,7 @@ have its own language-specific configuration. For example, the [Docsy example]
 site config specifies that it provides content in English, Norwegian, and
 Persian. The default language is English:
 
+<!-- markdownlint-disable -->
 <!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
@@ -92,6 +93,7 @@ languages:
 {{< /tab >}}
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
+<!-- markdownlint-restore -->
 
 Any setting not defined in a `[languages]` block will fall back to the global
 value for that setting: so, for example, the content directory used for the site
@@ -104,29 +106,32 @@ text, and add your [content](/docs/content/adding-content/) as usual. See the
 [Hugo Docs](https://gohugo.io/content-management/multilingual) on multi-language
 support for more information.
 
-{{% alert title="Attention (only when using Docsy as hugo module)" color="warning" %}}
+<!-- markdownlint-disable no-blanks-blockquote -->
 
-If you have a multi language installation, ensure that the section `[languages]`
-inside your
-[configuration file](https://gohugo.io/getting-started/configuration/#configuration-file)
-is declared **before** the section `[module]` with the module imports. Otherwise
-you will run into trouble!
+> [!WARNING] Attention (only when using Docsy as hugo module)
+>
+> If you have a multi language installation, ensure that the section
+> `[languages]` inside your
+> [configuration file](https://gohugo.io/getting-started/configuration/#configuration-file)
+> is declared **before** the section `[module]` with the module imports.
+> Otherwise you will run into trouble!
 
-{{% /alert %}}
-
-{{% alert title="Tip" %}}
-
-If there's any possibility your site might be translated into other languages,
-consider creating your site with your content in a language-specific
-subdirectory, as it means you don't need to move it if you add another language.
-
-{{% /alert %}}
+> [!TIP]
+>
+> If there's any possibility your site might be translated into other languages,
+> consider creating your site with your content in a language-specific
+> subdirectory, as it means you don't need to move it if you add another
+> language.
 
 For adding multiple language versions of other site elements such as button
 text, see the [internationalization bundles](#internationalization-bundles)
 section below.
 
+<!-- markdownlint-disable heading-increment -->
+
 ### Right-to-left languages
+
+<!-- markdownlint-restore -->
 
 Docsy supports top-down Right-To-Left (RTL) languages such as Persian through
 [Bootstrap's RTL feature][bs-rtl], which uses [RTLCSS].
@@ -149,12 +154,12 @@ example].
 
 ## Selecting a language from the language menu
 
-If you configure more than one language in your [configuration
-file](https://gohugo.io/getting-started/configuration/#configuration-file), the
-Docsy theme adds a language drop down to the navbar. Selecting
-a language takes the user to the translated version of the current page, or the
-home page for the given language. For details, see [Adding a language
-menu](/docs/content/navigation/#language-menu).
+If you configure more than one language in your
+[configuration file](https://gohugo.io/getting-started/configuration/#configuration-file),
+the Docsy theme adds a language drop down to the navbar. Selecting a language
+takes the user to the translated version of the current page, or the home page
+for the given language. For details, see
+[Adding a language menu](/docs/content/navigation/#language-menu).
 
 ## Internationalization bundles
 
@@ -169,9 +174,10 @@ then open a
 [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
 to contribute your translation to the Docsy community.
 
-{{% alert title="Hugo Tip" %}} Run `hugo server --printI18nWarnings` when doing
-translation work, as it will give you warnings on what strings are missing.
-{{% /alert %}}
+> [!TIP] Hugo Tip
+>
+> Run `hugo server --printI18nWarnings` when doing translation work, as it will
+> give you warnings on what strings are missing.
 
 ### Create custom UI strings
 

--- a/docsy.dev/content/en/docs/updating/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/updating/convert-site-to-module.md
@@ -1,9 +1,7 @@
 ---
-title: "Migrate to Hugo Modules"
-linkTitle: "Migrate to Hugo Modules"
+title: Migrate to Hugo Modules
 weight: 3
-description: >
-  Convert an existing site to use Docsy as a Hugo Module
+description: Convert an existing site to use Docsy as a Hugo Module
 ---
 
 ## TL;DR: Conversion for the impatient expert
@@ -158,14 +156,17 @@ module:
 You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 Depending on your environment you may need to tweak them slightly, for example by adding a proxy to use when downloading remote modules.
 
-{{% alert title="Tip" %}}
-In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
-If you are using hugo 0.110 or above, we recommend renaming your `config.toml` to `hugo.toml`!
-{{% /alert %}}
+> [!TIP]
+>
+> In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
+> If you are using hugo 0.110 or above, we recommend renaming your `config.toml`
+> to `hugo.toml`!
 
-{{% alert title="Attention" color="warning" %}}
-If you have a multi language installation, please make sure that the section `[languages]` inside your `hugo.toml` is declared before the section `[module]` with the module imports. Otherwise you will run into trouble!
-{{% /alert %}}
+> [!CAUTION]
+>
+> If you have a multi-language installation, make sure that the section
+> `[languages]` inside your `hugo.toml` is declared before the section
+> `[module]` with the module imports. Otherwise you will run into trouble!
 
 ### Check validity of your configuration settings
 
@@ -181,17 +182,17 @@ github.com/google/docsy@v{{% param "version" %}} github.com/FortAwesome/Font-Awe
 
 Make sure that three lines with dependencies `docsy`, `bootstrap` and `Font-Awesome` are listed. If not, please double check your config settings.
 
-{{% alert title="Tip" %}}
-In order to clean up your module cache, issue the command `hugo mod clean`
-
-```bash
-hugo mod clean
-hugo: collected modules in 995 ms
-hugo: cleaned module cache for "github.com/FortAwesome/Font-Awesome"
-hugo: cleaned module cache for "github.com/google/docsy"
-hugo: cleaned module cache for "github.com/twbs/bootstrap"
-```
-{{% /alert %}}
+> [!TIP]
+>
+> In order to clean up your module cache, issue the command `hugo mod clean`
+>
+> ```bash
+> hugo mod clean
+> hugo: collected modules in 995 ms
+> hugo: cleaned module cache for "github.com/FortAwesome/Font-Awesome"
+> hugo: cleaned module cache for "github.com/google/docsy"
+> hugo: cleaned module cache for "github.com/twbs/bootstrap"
+> ```
 
 ## Clean up your repository
 
@@ -224,6 +225,7 @@ You are now ready to commit your changes to your repository:
 git commit -m "Removed docsy git submodule"
 ```
 
-{{% alert title="Attention" color="warning" %}}
-Be careful when using the `rm -rf` command, make sure that you don't inadvertently delete any productive data files!
-{{% /alert %}}
+> [!CAUTION]
+>
+> Be careful when using the `rm -rf` command, make sure that you don't
+> inadvertently delete any productive data files!

--- a/docsy.dev/content/en/docs/updating/updating-hugo-module.md
+++ b/docsy.dev/content/en/docs/updating/updating-hugo-module.md
@@ -21,20 +21,18 @@ hugo mod get -u github.com/google/docsy
 Hugo automatically pulls in the latest theme version. That's it, your update is
 done!
 
-{{% alert title="Tip" %}}
-
-If you want to set your module to a certain version inside the Docsy theme repo,
-simply specify the name of the tag representing this version when updating your
-theme, for example:
-
-```bash
-hugo mod get -u github.com/google/docsy@v{{% param "version" %}}
-```
-
-Instead of a version tag, you can also specify a commit hash, for example:
-
-```bash
-hugo mod get -u github.com/google/docsy@6c8a3afe
-```
-
-{{% /alert %}}
+> [!TIP]
+>
+> If you want to set your module to a certain version inside the Docsy theme repo,
+> simply specify the name of the tag representing this version when updating your
+> theme, for example:
+>
+> ```bash
+> hugo mod get -u github.com/google/docsy@v{{% param "version" %}}
+> ```
+>
+> Instead of a version tag, you can also specify a commit hash, for example:
+>
+> ```bash
+> hugo mod get -u github.com/google/docsy@6c8a3afe
+> ```

--- a/docsy.dev/content/en/docs/updating/updating-submodules.md
+++ b/docsy.dev/content/en/docs/updating/updating-submodules.md
@@ -8,9 +8,11 @@ description: >
 
 If you aren't using Hugo Modules, depending on how you chose to install Docsy on your existing site, use one of the following two procedures to update your theme.
 
-{{% alert title="Tip" %}}
-If you intend to update your site, consider [converting your site to Hugo Modules](/docs/updating/convert-site-to-module/). After conversion, it's even simpler to update Docsy!
-{{% /alert %}}
+> [!TIP]
+>
+> If you intend to update your site, consider
+> [converting your site to Hugo Modules](/docs/updating/convert-site-to-module/).
+>After conversion, it's even simpler to update Docsy!
 
 ## Update your Docsy submodule
 
@@ -21,7 +23,7 @@ If you are using the [Docsy theme as a submodule](/docs/get-started/other-option
     ```bash
     git submodule update --remote
     ```
-    
+
 1. Add and then commit the change to your project:
 
     ```bash

--- a/docsy.dev/content/en/project/implementation/scrollspy-patch.md
+++ b/docsy.dev/content/en/project/implementation/scrollspy-patch.md
@@ -6,15 +6,13 @@ description:
 
 <span class="badge bg-info text-bg-info">As of Docsy 0.13.0</span>
 
-{{% alert title="Summary" color="info" %}}
-
-Docsy 0.13.0 includes a **runtime patch** for Bootstrap [ScrollSpy] that fixes a
-bug affecting pages with heading IDs that aren't valid CSS selectors. The patch
-ensures that [active TOC entry
-tracking][Active TOC entry tracking with ScrollSpy] works reliably for all
-pages.
-
-{{% /alert %}}
+> [!INFO] Summary
+>
+> Docsy 0.13.0 includes a **runtime patch** for Bootstrap [ScrollSpy] that fixes a
+> bug affecting pages with heading IDs that aren't valid CSS selectors. The patch
+> ensures that [active TOC entry
+> tracking][Active TOC entry tracking with ScrollSpy] works reliably for all
+> pages.
 
 ## Problem
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+30-g3396c03",
+  "version": "0.14.0-dev+32-gba7d0ec",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2390, by updating our docs to use the new syntax
- Converts all shortcode alert calls to Hugo Markdown syntax, except for those examples illustrating the alert shortcode.
- Runs markdown linter on all files that Prettier runs over
- Fixes linter issues

**Preview** e.g.: https://deploy-preview-2457--docsydocs.netlify.app/docs/get-started/other-options/, this page has _lots_ of alerts, and all were converted.