### PR TITLE
Address Hugo deprecation msg related to mounts

### DIFF
--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -175,7 +175,9 @@ module:
     # Placeholder language used to demo multilingual support
     - source: content/en
       target: content
-      lang: xx
+      sites:
+        matrix:
+          languages: ['xx']
 
 mediaTypes:
   font/woff:

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -8,7 +8,7 @@
     "_check:links--warn": "npm run _check:links || (echo; echo 'WARNING: see link-checker output for issues.'; echo)",
     "_check:links": "make --keep-going check-links",
     "_commit:public": "HASH=$(git rev-parse --short main); cd public && git add -A && git commit --allow-empty -m \"Site at $HASH\"",
-    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_hugo-dev": "npm run _hugo -- --logLevel info -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
     "_postbuild": "npm run _check:links--warn",
     "_refcache:prune-4xx": "node scripts/prune-refcache-4xx.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+34-ga600e53",
+  "version": "0.14.0-dev+35-g95c6a2d",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2431
- NPM script changes so that Hugo prints deprecation msgs when building the website
- Addresses the deprecation message by fixing the docsy.dev mount config:
  > INFO  deprecated: module.mounts.lang was deprecated in Hugo v0.153.0 and will be removed in a future release. Replaced by the more powerful 'sites.matrix' setting, see https://gohugo.io/configuration/module/#mounts
- There are no changes to generated site files (mod timestamp).