### PR TITLE
Add nested `sidebar_root_for` to docs

### DIFF
--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/_index.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/_index.md
@@ -5,6 +5,7 @@ weight: 1
 date: 2021-12-08T10:33:16+01:00
 description: >
   Learn how to get started with Docsy by using the theme as a Hugo Module.
+sidebar_root_for: children
 ---
 
 [Hugo modules](https://gohugo.io/hugo-modules/) are the simplest and latest way to use Hugo themes like Docsy when building a website. Hugo uses the modules mechanism to pull in the theme files from the main Docsy repo at your chosen revision, and it’s easy to keep the theme up to date in your site. Our example site uses Docsy as a Hugo module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+59-g7bcae61",
+  "version": "0.14.0-dev+60-gb3cb2a7",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Prep for #2475

**Preview**: https://deploy-preview-2476--docsydocs.netlify.app/docs/get-started/docsy-as-module/installation-prerequisites/

| Expected sidebar | Actual sidebar |
|--------|--------|
| <img width="295" height="175" alt="image" src="https://github.com/user-attachments/assets/d743c77f-dfaa-47fe-b339-1a9f70ed1da9" /> | <img width="297" height="203" alt="image" src="https://github.com/user-attachments/assets/6acf8cfe-0912-4e74-8c00-adf24166b0e2" /> | 