### PR TITLE
Navbar styling fixes and updated documentation

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -15,6 +15,7 @@
     "hugo",
     "isset",
     "markdownify",
+    "navbars",
     "nvmrc",
     "Occitan",
     "refcache",

--- a/assets/js/base.js
+++ b/assets/js/base.js
@@ -32,33 +32,23 @@ limitations under the License.
         return element.offset().top + element.outerHeight();
     }
 
-    // Bootstrap Fixed Header
-    $(function() {
-        var promo = $(".js-td-cover");
-        if (!promo.length) {
-            return
-        }
+    // Navbar transparency over cover images
+    $(function () {
+      const promo = $('.js-td-cover');
+      if (!promo.length) return;
+      const navbar = $('.js-navbar-scroll');
+      if (!navbar.length) return;
 
-        var promoOffset = bottomPos(promo);
-        var navbarOffset = $('.js-navbar-scroll').offset().top;
+      const threshold = Math.ceil(navbar.outerHeight());
 
-        var threshold = Math.ceil($('.js-navbar-scroll').outerHeight());
-        if ((promoOffset - navbarOffset) < threshold) {
-            $('.js-navbar-scroll').addClass('navbar-bg-onscroll');
-        }
+      function adjustNavbarTransparency() {
+        const promoOffset = bottomPos(promo);
+        const navbarOffset = navbar.offset().top;
+        navbar.toggleClass('td-navbar-transparent', (promoOffset - navbarOffset) >= threshold);
+      }
 
-
-        $(window).on('scroll', function() {
-            var navtop = $('.js-navbar-scroll').offset().top - $(window).scrollTop();
-            var promoOffset = bottomPos($('.js-td-cover'));
-            var navbarOffset = $('.js-navbar-scroll').offset().top;
-            if ((promoOffset - navbarOffset) < threshold) {
-                $('.js-navbar-scroll').addClass('navbar-bg-onscroll');
-            } else {
-                $('.js-navbar-scroll').removeClass('navbar-bg-onscroll');
-                $('.js-navbar-scroll').addClass('navbar-bg-onscroll--fade');
-            }
-        });
+      adjustNavbarTransparency();
+      $(window).on('scroll', adjustNavbarTransparency);
     });
 
         // Navbar overflow detection with scroll indicators

--- a/assets/scss/td/_nav.scss
+++ b/assets/scss/td/_nav.scss
@@ -1,32 +1,25 @@
 //
 // Main navbar
 //
-// cSpell:ignore onscroll
 
-.td-navbar-cover {
-  @include media-breakpoint-up(md) {
-    background: transparent !important;
-
-    .nav-link {
-      text-shadow: 1px 1px 2px $dark;
-    }
-  }
-
-  &.navbar-bg-onscroll .nav-link {
-    text-shadow: none;
-  }
-}
-
-.navbar-bg-onscroll {
-  background: $primary !important;
-  opacity: inherit;
-}
+$td-navbar-bg-color: var(--bs-body-bg) !default;
 
 .td-navbar {
   @extend .navbar;
   @extend .navbar-expand;
 
-  background: $primary;
+  --td-navbar-bg-color: #{$td-navbar-bg-color};
+  --td-navbar-backdrop-filter: none;
+  --td-navbar-border-bottom: 1px solid var(--bs-border-color);
+
+  // To ensure that all child elements (such as form inputs) can inherit the
+  // right (light/dark) body color we set it explicitly here:
+  color: var(--bs-body-color);
+
+  background-color: var(--td-navbar-bg-color);
+  backdrop-filter: var(--td-navbar-backdrop-filter);
+  border-bottom: var(--td-navbar-border-bottom);
+
   min-height: 4rem;
   margin: 0;
   z-index: 32;
@@ -111,9 +104,11 @@
         &-text {
           display: none;
         }
+
         &-code {
           display: inline;
         }
+
         &::before {
           padding-right: 0;
         }
@@ -136,6 +131,21 @@
   }
 }
 
+.td-navbar-cover {
+  transition:
+    background-color 0.3s ease,
+    backdrop-filter 0.3s ease,
+    border-bottom 0.3s ease;
+
+  &.td-navbar-transparent {
+    @include media-breakpoint-up(md) {
+      --td-navbar-bg-color: transparent;
+      --td-navbar-backdrop-filter: blur(8px);
+      --td-navbar-border-bottom: none;
+    }
+  }
+}
+
 // Icons
 #main_navbar {
   li i {
@@ -147,6 +157,7 @@
       min-width: 1em;
     }
   }
+
   .alert {
     background-color: inherit;
     padding: 0;
@@ -226,6 +237,7 @@ nav.foldable-nav {
     font-size: 1em;
     color: var(--bs-secondary-color);
     transition: all 0.5s;
+
     &:hover {
       transform: rotate(90deg);
     }

--- a/assets/scss/td/_search.scss
+++ b/assets/scss/td/_search.scss
@@ -42,15 +42,12 @@
     }
 
     &.form-control:focus {
-      border-color: tint-color($primary, 95%);
-      box-shadow: 0 0 0 2px tint-color($primary, 40%);
-      color: var(--bs-body-color);
+      color: inherit;
     }
 
     // Styling adjustments for the navbar
     @at-root {
       .td-navbar & {
-        border: none;
         color: inherit;
 
         @include placeholder {

--- a/assets/scss/td/_sidebar-tree.scss
+++ b/assets/scss/td/_sidebar-tree.scss
@@ -156,7 +156,7 @@
   }
 
   &__search {
-    padding: 1rem 0;
+    padding: 1.5rem 0;
   }
 
   &__inner {

--- a/docsy.dev/assets/scss/_styles_project.scss
+++ b/docsy.dev/assets/scss/_styles_project.scss
@@ -2,3 +2,33 @@
 @import 'td/code-dark';
 @import 'td/gcs-search-dark';
 @import 'local/blog';
+
+//
+// Color tuning for the Docsy website
+//
+
+// For dark navbars, use primary bg color by default (i.e., on mobile)
+@include color-mode(dark) {
+  &.td-navbar-cover {
+    --td-navbar-bg-color: #{$primary};
+    --td-navbar-border-bottom: none;
+
+    // Illustration of tinted transparent background color on desktop:
+    @include media-breakpoint-up(md) {
+      &.td-navbar-transparent {
+        $rgba-primary: rgba($primary, 0.25);
+        --td-navbar-bg-color: #{$rgba-primary};
+      }
+    }
+  }
+}
+
+// Add a border between the footer and page content for pages with dark content
+// in general (like the homepage), or in dark mode.
+.td-home,
+.td-section,
+.td-page {
+  .td-footer {
+    border-top: 1px solid var(--bs-border-color);
+  }
+}

--- a/docsy.dev/content/en/_index.md
+++ b/docsy.dev/content/en/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Docsy
 description: A Hugo theme for creating great technical documentation sites
+params:
+  ui: { navbar_theme: dark}
 ---
 
 {{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" %}}

--- a/docsy.dev/content/en/about/index.md
+++ b/docsy.dev/content/en/about/index.md
@@ -2,6 +2,8 @@
 title: About Docsy
 linkTitle: About
 menu: {main: {weight: 10}}
+params:
+  ui: { navbar_theme: dark}
 ---
 
 {{% blocks/cover title="About Docsy" height="auto" %}}

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -8,7 +8,7 @@ author: >-
 message: Hello, world!
 body_class: release-highlights published-draft-post
 tags: [release]
-cSpell:ignore: Chalin pageinfo docsy gohugoio subrepo lookandfeel
+cSpell:ignore: Chalin pageinfo docsy gohugoio subrepo lightdark lookandfeel
 ---
 
 {{% card header="Highlights" %}}
@@ -40,6 +40,8 @@ Docsy [0.14.0] comes with the following notable features and improvements:
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} How you [customize Swagger](#swagger-scss) UI's look
     and feel changes.
+  - {{% _param BREAKING %}} Default [Navbar styles](#navbar) and how you
+    customize them changes.
   - {{% _param BREAKING %}} [Hugo 0.153+ upgrade](#hugo) introduces breaking
     changes
 - Review changes to internal files:
@@ -72,6 +74,53 @@ and how to customize the appearance of alerts, see [Alerts][].
 
 [alert shortcode]: /docs/content/shortcodes/#alert
 [Alerts]: /docs/content/adding-content/#alerts
+
+## {{% _param BREAKING %}} Navbar style improvements {#navbar}
+
+Prior to 0.14.0, the [navbar] element always used a [dark color theme][],
+regardless of the site's color theme or the active color mode. This restriction
+has been removed:
+
+- [Light/dark color theme][] is now configurable both site-wide and per page.
+
+The default navbar style now matches the base page style, offering a clean and
+consistent look and feel.[^navbar-bg-color]
+
+Learn more:
+
+- Default navbar style: [Navbar]
+- Navbar customization options: [Customizing the navbar][]
+
+[^navbar-bg-color]:
+    Prior to 0.14.0, the navbar background was set to the primary color.
+
+**Action may be required** to update your project in the following areas:
+
+- {{% _param BREAKING %}} Navbar theme now follows the page theme (default
+  `light`), instead of always forcing `dark`. Set `params.ui.navbar_theme` to
+  `dark` to restore the old behavior. [Details][navbar-lightdark-theme].
+
+- Review your project's navbar style overrides. The new style design, SCSS and
+  CSS variables may simplify your [customization][Customizing the navbar].
+
+- Review [_nav.html][] if your project overrides it.
+
+- Internal [navbar cover-image translucency][] class changes (update your custom
+  styles targeting these classes if present):
+  - `.td-navbar-transparent` replaces `.navbar-bg-on-scroll` (used with
+    `.td-navbar-cover`)
+  - `.navbar-bg-onscroll--fade` has been dropped: it was not used by Docsy, and
+    the transition effect is now handled by `.td-navbar-cover`
+
+[_nav.html]:
+  https://github.com/google/docsy/blob/main/layouts/_partials/navbar.html
+[Customizing the navbar]: /docs/content/lookandfeel/#navbar-customization
+[dark color theme]: /docs/content/lookandfeel/#lightdark-color-feature
+[Light/dark color theme]: /docs/content/lookandfeel/#navbar-lightdark-theme
+[navbar]: /docs/content/lookandfeel/#navbar
+[navbar-lightdark-theme]: /docs/content/lookandfeel/#navbar-lightdark-theme
+[navbar cover-image translucency]:
+  /docs/content/lookandfeel/#customize-over-cover
 
 ## Improved separation of project and internal SCSS files {#improved-scss-soc}
 
@@ -147,7 +196,7 @@ file.
 For details about style customizations, see [Project style files][] and
 [Advanced style customization][].
 
-## {{% _param BREAKING %}} Swagger UI style customization {#swagger-scss}
+### {{% _param BREAKING %}} Swagger UI style customization {#swagger-scss}
 
 Prior to 0.14.0, the Docsy User Guide incorrectly recommended overriding
 `_swagger.scss` to customize [Swagger UI][] styles. Docsy's internal SCSS files

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -9,7 +9,7 @@ params:
     light/dark mode menu <span class='badge text-bg-warning fs-6
     float-end'>EXPERIMENTAL</span>
 # prettier-ignore
-cSpell:ignore: anotherclass autoprefixing baseof blockscover docsy lightdark monokai myclass onedark wordmark FOUC
+cSpell:ignore: anotherclass autoprefixing baseof blockscover docsy lightdark monokai myclass onedark rgba wordmark FOUC
 ---
 
 By default, a site using Docsy has the theme's default fonts, colors, and
@@ -148,31 +148,48 @@ To learn how to modify maps, see [Maps and loops][] and [Adding theme colors][].
 [variable defaults]:
   https://getbootstrap.com/docs/5.3/customize/sass/#variable-defaults
 
-### Light/dark color modes
+### Light/dark color theme and mode support {#lightdark-color-feature}
 
-Docsy enables **light and dark** color modes through Bootstrap's [color modes][]
-feature.
+Docsy supports light and dark color _themes_ and color mode selection through
+Bootstrap's [color modes][] feature.
 
-You can adjust dark-mode support as follows:
+What is the difference between a color theme and a color mode as used in Docsy?
 
-- **Docsy ships with dark mode support**, offering a good user experience (UX)
-  for site visitors through the following features:
-  - Docsy includes **complete CSS** styles for (both light mode and) dark mode
-    **by default**, so your site can automatically switch between light and dark
-    modes based on system settings or user preference.
+- A color _theme_ is a semantic color palette (primary, secondary, success,
+  etc.) defined in SCSS and used by components and utilities.
+- A color _mode_ is a switchable presentation of the site (light or dark) from
+  the user's point of view, implemented through CSS variable overrides
+  (activated via `data-bs-theme`).
 
-  - But, if you prefer, you can **disable** dark mode entirely, see
-    [How to disable dark mode](#how-to-disable-dark-mode).
+The next section explains how to enable light/dark color themes and color mode
+selection.
 
-  - **No dark-mode flashes**: By default, Docsy adds page header content (like
-    meta tags, inline styles, and an early-loading script) to avoid or generally
-    prevent _Flashes Of Unstyled Content_ ([FOUC]) when pages load.[^FOUC-alt]
+## Light/dark color modes
 
-    [^FOUC-alt]:
-        Also referred to as "Flash of incorrect theme" and, humorously, [_Flash
-        of inAccurate coloR Theme_][FART] (FART).
+Docsy enables **light and dark** color mode selection, and the underlying color
+theme support, through Bootstrap's [color modes][] feature. All sites are in
+light mode by default, whether or not you choose to enable dark mode for your
+project.
 
-    [FART]: https://css-tricks.com/flash-of-inaccurate-color-theme-fart/
+Docsy ships with dark mode support, offering a good user experience (UX) for
+site visitors through the following features:
+
+- **Complete CSS** styles for both light and dark themes _by default_, so your
+  site can automatically switch between light and dark modes based on system
+  settings or user preference.
+
+- But, if you prefer, you can **disable** dark mode entirely, see
+  [How to disable dark mode](#how-to-disable-dark-mode).
+
+- **No dark-mode flashes**: By default, Docsy adds page header content (like
+  meta tags, inline styles, and an early-loading script) to avoid or generally
+  prevent _Flashes Of Unstyled Content_ ([FOUC]) when pages load.[^FOUC-alt]
+
+  [^FOUC-alt]:
+      Also referred to as "Flash of incorrect theme" and, humorously, [_Flash of
+      inAccurate coloR Theme_][FART] (FART).
+
+  [FART]: https://css-tricks.com/flash-of-inaccurate-color-theme-fart/
 
 - **Light/dark-mode menu**: Enable Docsy's
   [light/dark-mode menu](#lightdark-mode-menu) in the [navbar](#navbar) to allow
@@ -191,19 +208,26 @@ You can adjust dark-mode support as follows:
     that the have good color-contrast. Learn
     [how to pick colors with good color-contrast](#pick-good-color-contrast).
 
-> [!INFO] Terminology note
->
-> In Bootstrap, a color **mode** refers to a switchable presentation of the site
-> (e.g., light or dark) from the user's point of view, implemented through CSS
-> variable overrides activated via `data-bs-theme`.
->
-> Whereas a color **theme** refers to the semantic color palette (primary,
-> secondary, success, etc.) defined in SCSS and used by components and
-> utilities.
-
 [FOUC]: https://en.wikipedia.org/wiki/Flash_of_unstyled_content
 
-#### How to disable dark mode
+### Choosing themes or color modes for your site
+
+To help you decide whether to support light, dark, or both themes on your site,
+see:
+
+- [The Designer’s Guide to Dark Mode Accessibility][], January 2026
+- [Dark Mode vs Light Mode: The Complete UX Guide for 2025][], August 2025
+- [Dark and Light Mode: A Simple Guide for Web Design and Development][], May
+  2025
+
+[The Designer’s Guide to Dark Mode Accessibility]:
+  https://www.accessibilitychecker.org/blog/dark-mode-accessibility/
+[Dark Mode vs Light Mode: The Complete UX Guide for 2025]:
+  https://altersquare.io/dark-mode-vs-light-mode-the-complete-ux-guide-for-2025/
+[Dark and Light Mode: A Simple Guide for Web Design and Development]:
+  https://www.accessibilityfirst.at/posts/dark-and-light-mode-a-simple-guide-for-web-design-and-development
+
+### How to disable dark mode
 
 Docsy, like Bootstrap, ships with CSS support for light and dark [color modes][]
 by default.
@@ -223,7 +247,7 @@ To [disable dark mode][] entirely:
   https://getbootstrap.com/docs/5.3/customize/color-modes/#building-with-sass
 [site configuration]: https://gohugo.io/configuration/introduction/
 
-#### How to pick colors with good color-contrast (EXPERIMENTAL) {#pick-good-color-contrast}
+### How to pick colors with good color-contrast (EXPERIMENTAL) {#pick-good-color-contrast}
 
 Getting dark-mode theme colors to have proper contrast can be tricky. Docsy
 provides [_color-adjustments-dark.scss] as an example of theme color
@@ -499,6 +523,111 @@ files with your own.
 
 ## Navbar
 
+By default, a Docsy site has a navbar that appears at the top of every page.
+
+### Default look and feel
+
+Docsy’s navbar styles are designed mobile-first.
+
+#### On mobile
+
+On **mobile**, the default navbar:
+
+- Uses the page’s (light/dark) body text and background colors to ensure that
+  navbar elements (like links, menus, and the search box) render correctly
+  across [light/dark color modes](#lightdark-color-modes).
+- Has an opaque background color.
+- Scrolls with the page content.
+
+#### On desktop
+
+On **desktop** (`md` breakpoint and up), the default appearance is the same,
+except that the navbar is fixed to the top of the viewport.
+
+##### Translucent over cover images {#default-over-cover}
+
+In addition, on desktop, when a page contains a [blocks/cover] (typically used
+for hero images on the home page), Docsy makes the navbar translucent while the
+cover is visible by adding the classes `td-navbar-cover td-navbar-transparent`
+to the navbar. For an example, see the [About Docsy][] page. This initial
+translucent setting ensures that the hero image is maximally visible. Once the
+user has scrolled past the cover (hero image), the navbar reverts to its default
+(opaque) style.
+
+[About Docsy]: https://www.docsy.dev/about/
+[blocks/cover]: /docs/content/shortcodes/#blockscover
+
+### Customizing the navbar {#navbar-customization}
+
+#### Background color/opacity {#navbar-background}
+
+To change the navbar background color/opacity across your site, override the
+SCSS variable `$td-navbar-bg-color` in your [project’s variables file][].
+
+For example, to set the navbar background color to the primary color:
+
+```scss
+$td-navbar-bg-color: $primary;
+```
+
+To set the navbar background color to a slightly translucent primary color use:
+
+```scss
+$td-navbar-bg-color: rgba($primary, 0.15);
+```
+
+> [!NOTE]- CSS variable implementation details
+>
+> Docsy uses the following CSS custom properties **internally** to style the
+> navbar: `--td-navbar-bg-color`, `--td-navbar-backdrop-filter`, and
+> `--td-navbar-border-bottom`. These can be overridden for advanced
+> customization. For an example, see the User Guide's [project
+> styles][ug-project-styles]. For the base styles, see [_nav.scss].
+
+[ug-project-styles]:
+  https://github.com/google/docsy/blob/main/docsy.dev/assets/scss/_styles_project.scss
+
+#### Setting the navbar light/dark color theme {#navbar-lightdark-theme}
+
+Whether it is your chosen site design, or you want more contrast between the
+navbar and the page background (especially over a cover image), you can set the
+navbar theme to `dark` by adding `params.ui.navbar_theme: dark` to:
+
+- Your site config to apply this **site-wide**
+- Page [front matter `params`][] to apply this **per page**
+
+```yaml
+params:
+  ui:
+    navbar_theme: dark
+```
+
+[front matter `params`]:
+  https://gohugo.io/content-management/front-matter/#front-matter-parameters
+
+Internally, this adds `data-bs-theme="dark"` to the navbar, triggering
+Bootstrap's dark theme. This affects the default colors of navbar and all its
+child elements such as links, menus, and the search box.
+
+#### Translucent over cover images {#customize-over-cover}
+
+When a page contains a [blocks/cover], the navbar is styled with
+`td-navbar-cover`. While the navbar is over the cover, it is styled with
+`td-navbar-transparent` as well, which sets the background color to transparent
+and applies a blur effect (once the user has scrolled past the cover, the
+`td-navbar-transparent` class is removed).
+
+This translucent effect can sometimes make the text of navbar items difficult to
+read due to the lack of contrast. Adjusting the navbar background color/opacity
+or blur can help. For an example, see the User Guide's [project
+styles][ug-project-styles].
+
+Alternatively, you can disable the “translucent over cover” behavior globally by
+setting `params.ui.navbar_translucent_over_cover_disable` to `true` in your
+[site configuration][].
+
+[project’s variables file]: #project-style-files
+
 ### Styling your project logo and name
 
 The default Docsy navbar (`.td-navbar`) displays your site identity, consisting
@@ -592,27 +721,6 @@ params:
 [layouts/_partials/theme-toggler.html]:
   https://github.com/google/docsy/blob/main/layouts/_partials/theme-toggler.html
 [search box]: /docs/content/search/
-
-### Translucent over cover images
-
-For pages containing a [blocks/cover][] shortcode, like most homepages, the
-navbar is translucent as long as the hero image hasn't scrolled up past the
-navbar. For an example, see the [About Docsy][] page. This initial translucent
-setting ensures that the hero image is maximally visible.
-
-After the hero image has scrolled past the navbar, the navbar's (opaque)
-background color is set -- usually to the site's [primary color][].
-
-The text of navbar entries can be difficult to read with some hero images. In
-these cases, you can disable navbar translucency by setting the
-`params.ui.navbar_translucent_over_cover_disable` option to `true` in your
-site's [configuration file][].
-
-[About Docsy]: https://www.docsy.dev/about/
-[blocks/cover]: /docs/content/shortcodes/#blockscover
-[configuration file]:
-  https://gohugo.io/getting-started/configuration/#configuration-file
-[primary color]: #site-colors
 
 ## Alerts
 

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -19,6 +19,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:50.224696-05:00"
   },
+  "https://altersquare.io/dark-mode-vs-light-mode-the-complete-ux-guide-for-2025/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-26T11:28:02.434125-05:00"
+  },
   "https://analytics.google.com/analytics/web/": {
     "StatusCode": 200,
     "LastSeen": "2025-11-16T12:09:21.158712-05:00"
@@ -743,6 +747,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:40.153493-05:00"
   },
+  "https://github.com/google/docsy/blob/main/docsy.dev/assets/scss/_styles_project.scss": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-26T11:36:00.083389-05:00"
+  },
   "https://github.com/google/docsy/blob/main/docsy.dev/hugo.yaml": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:36.355089-05:00"
@@ -770,6 +778,10 @@
   "https://github.com/google/docsy/blob/main/layouts/_partials/hooks/head-end.html": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:42.311452-05:00"
+  },
+  "https://github.com/google/docsy/blob/main/layouts/_partials/navbar.html": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-26T11:28:00.611296-05:00"
   },
   "https://github.com/google/docsy/blob/main/layouts/_partials/page-description.html": {
     "StatusCode": 206,
@@ -1939,6 +1951,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:34.695461-05:00"
   },
+  "https://gohugo.io/content-management/front-matter/#front-matter-parameters": {
+    "StatusCode": 206,
+    "LastSeen": "2026-01-26T11:28:03.008807-05:00"
+  },
   "https://gohugo.io/content-management/front-matter/#target-specific-pages": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.983495-05:00"
@@ -2470,6 +2486,14 @@
   "https://v0-6.kubeflow.org/docs/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:35.192705-05:00"
+  },
+  "https://www.accessibilitychecker.org/blog/dark-mode-accessibility/": {
+    "StatusCode": 200,
+    "LastSeen": "2026-01-26T11:28:00.627399-05:00"
+  },
+  "https://www.accessibilityfirst.at/posts/dark-and-light-mode-a-simple-guide-for-web-design-and-development": {
+    "StatusCode": 200,
+    "LastSeen": "2026-01-26T11:28:02.358179-05:00"
   },
   "https://www.cloudpods.org": {
     "StatusCode": 206,

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -5,7 +5,8 @@
 {{ $baseURL := urls.Parse $.Site.Params.Baseurl -}}
 
 <nav class="td-navbar js-navbar-scroll
-            {{- if $cover }} td-navbar-cover {{- end }}" data-bs-theme="dark">
+      {{- if $cover }} td-navbar-cover td-navbar-transparent {{- end }}"
+      {{- if eq (.Param "ui.navbar_theme") "dark" }} data-bs-theme="dark" {{- end }}>
 <div class="td-navbar-container container-fluid flex-column flex-md-row">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
     {{- /**/ -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+62-g11bc51a",
+  "version": "0.14.0-dev+63-gd5132bf",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -32,6 +32,7 @@
     "ci:test": "npm run ci:prepare && npm run check && npm run test:website && npm run ci:post",
     "docsy.dev-install": "npm run _cd:docsy.dev -- npm install",
     "fix-and-test": "echo 'RUNNING most FIXES AND TESTS...'; npm run fix-for-test && npm run test:website",
+    "fix:format:diff": "npm run fix:format",
     "fix:format": "npm run -s _check:format -- --write && echo && npm run -s cd:docsy.dev fix:format",
     "fix:markdown": "npm run check:markdown -- --fix",
     "fix:version": "npm run set:package-version -- --id \"$(scripts/get-build-id.sh)\"",
@@ -42,6 +43,7 @@
     "postinstall": "npm run _mkdir:hugo-mod",
     "postupdate:dep": "npm run -s post-update",
     "postupdate:packages": "npm run -s post-update",
+    "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve": "npm run _cd:docsy.dev -- npm run serve",
     "set:package-version": "node scripts/set-package-version/index.mjs",
     "test:tooling": "node --test",


### PR DESCRIPTION
- Fixes #2413 by:
  - Setting useful style defaults, and dropping old text styles that made navbar text difficult to read
  - Explaining how to do further customization
- Contributes to #1655 by:
  - Making the navbar color theme configurable
  - Removing navbar text style customization
  - Removing search bar style customization (falling back to Bootstrap defaults)
- Contributes to #2404
- For an explanation of the changes made in this PR, see "Navbar style improvements" in the 0.14.0 blog post (of this PR)
- Housekeeping: added some helper NPM scripts

### Screenshots

### Mobile

<img width="375" height="668" alt="image" src="https://github.com/user-attachments/assets/ce3e96ad-03fa-450d-8dc2-03999596714b" />

---

### Docs

IMHO, this is more in line with recent techdocs trends

<img width="1318" height="993" alt="image" src="https://github.com/user-attachments/assets/83f4992c-bab9-4678-a33d-f2aafa98e289" />

---

### Cover

<img width="937" height="1068" alt="image" src="https://github.com/user-attachments/assets/b42fe5b6-8a35-4c5a-9d03-b14ed7cf17d1" />

---

<img width="934" height="1065" alt="image" src="https://github.com/user-attachments/assets/0c9e82d5-7627-43b9-b03d-b7f1b060f969" />

---

### Community

<img width="950" height="1026" alt="image" src="https://github.com/user-attachments/assets/86edaf17-6013-4e98-9e74-27978c32f77d" />

