### PR TITLE
Refactor blocks/cover and pageinfo shortcodes

### DIFF
--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -286,7 +286,7 @@ feature.
 
 ```go-template
 {{%/* pageinfo color="info" */%}}
-This is placeholder content.
+This is _placeholder content_ :heart:
 {{%/* /pageinfo */%}}
 ```
 
@@ -294,13 +294,13 @@ Renders to:
 
 {{% pageinfo color="info" %}}
 
-This is placeholder content
+This is _placeholder content_ :heart:
 
 {{% /pageinfo %}}
 
-| Parameter | Default | Description                                                   |
-| --------- | ------- | ------------------------------------------------------------- |
-| color     | primary | One of the theme colors, eg `primary`, `info`, `warning` etc. |
+| Parameter | Default | Description                                                    |
+| --------- | ------- | -------------------------------------------------------------- |
+| color     | primary | One of the theme colors, eg `primary`, `info`, `warning`, etc. |
 
 ### `imgproc`
 

--- a/layouts/_shortcodes/blocks/cover.html
+++ b/layouts/_shortcodes/blocks/cover.html
@@ -1,4 +1,3 @@
-{{ $_hugo_config := `{ "version": 1 }` -}}
 {{ $blockID := printf "td-cover-block-%d" .Ordinal -}}
 {{ $promo_image := (.Page.Resources.ByType "image").GetMatch "**background*" -}}
 {{ $logo_image := (.Page.Resources.ByType "image").GetMatch "**logo*" -}}
@@ -9,12 +8,12 @@
 {{ $height := .Get "height" | default "max" -}}
 
 {{ with $promo_image -}}
-{{ $promo_image_big := . -}}
-{{ $promo_image_small := . -}}
-{{ if ne $promo_image.MediaType.SubType "svg" -}}
-  {{ $promo_image_big = .Fill (printf "1920x1080 %s" $image_anchor) -}}
-  {{ $promo_image_small = .Fill (printf "960x540 %s" $image_anchor) -}}
-{{ end -}}
+  {{ $promo_image_big := . -}}
+  {{ $promo_image_small := . -}}
+  {{ if ne $promo_image.MediaType.SubType "svg" -}}
+    {{ $promo_image_big = .Fill (printf "1920x1080 %s" $image_anchor) -}}
+    {{ $promo_image_small = .Fill (printf "960x540 %s" $image_anchor) -}}
+  {{ end -}}
 <link rel="preload" as="image" href="{{ $promo_image_small.RelPermalink }}" media="(max-width: 1200px)">
 <link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
 <style>
@@ -30,19 +29,27 @@
 {{ end -}}
 
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height -}}
-  {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
-  {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}">
+    {{ if not .Site.Params.ui.navbar_translucent_over_cover_disable }} js-td-cover
+    {{- end }} td-overlay td-overlay--dark -bg-{{ $col_id }}" {{/**/ -}}
+>
   <div class="col-12">
     <div class="container td-overlay__inner">
       <div class="text-center">
-        {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-4">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
-        {{ with .Get "subtitle" }}<p class="display-2 text-uppercase mb-0">{{ . | html }}</p>{{ end }}
+        {{ with .Get "title" -}}
+          <h1 class="display-1 mt-0 mt-md-5 pb-4">
+            {{- $title := . -}}
+            {{ with $logo_image -}}
+              {{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) -}}
+              <img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">
+            {{- end -}}
+            {{ $title | html -}}
+          </h1>
+        {{ end -}}
+        {{ with .Get "subtitle" -}}
+          <p class="display-2 text-uppercase mb-0">{{ . | html }}</p>
+        {{ end -}}
         <div class="pt-3 lead">
-          {{ if eq .Page.File.Ext "md" }}
-              {{ .Inner | markdownify }}
-          {{ else }}
-              {{ .Inner | htmlUnescape | safeHTML }}
-          {{ end }}
+          {{ .Inner -}}
         </div>
       </div>
     </div>

--- a/layouts/_shortcodes/pageinfo.html
+++ b/layouts/_shortcodes/pageinfo.html
@@ -1,4 +1,3 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
 {{ $color := .Get "color" | default "primary" }}
 <div class="pageinfo pageinfo-{{ $color }}">
 {{ .Inner }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+65-gbf7c497",
+  "version": "0.14.0-dev+66-g24c01d2",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #939 for `blocks/cover` and `pageinfo`
- Closes #1400 by superseding it. This PR offers a simpler solution.
- `blocks/cover`: drops the test for the page's file extension, and drops the use of markdownify. Let's the Markdown processor handle markdown content
- **Preview**:
  - https://deploy-preview-2480--docsydocs.netlify.app/about/
  - https://deploy-preview-2480--docsydocs.netlify.app/docs/content/shortcodes/#pageinfo

Only non-whitespace change to the generated site files is due to the updated text in the UG's shortcodes page:

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'buildDate' -- ':(exclude)*.xml' ':(exclude)**_print*' ':(exclude)**xx*') | grep ^diff 
diff --git a/docs/content/shortcodes/index.html b/docs/content/shortcodes/index.html
```