### PR TITLE
Reformat and clarify Docsy 'Get Started' pages

### DIFF
--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -5,7 +5,7 @@
 !/content/en/docs/_index.md
 !/content/en/docs/content/**/*.*
 !/content/en/docs/best-practices/**/*.*
-!/content/en/docs/get-started/other-options.md
+!/content/en/docs/get-started/**/*.*
 !/content/en/docs/language.md
 !/content/en/project/**/*.*
 

--- a/docsy.dev/content/en/docs/get-started/_index.md
+++ b/docsy.dev/content/en/docs/get-started/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: Get started
 weight: 2
@@ -10,24 +9,52 @@ description:
 sidebar_root_for: self
 ---
 
-As you saw in our introduction, Docsy is a [Hugo](https://gohugo.io) theme, which means that if you want to use Docsy, you need to set up your website source so that the Hugo static site generator can find and use the Docsy theme files when building your site. The simplest way to do this is to copy and edit our example site, though we also provide instructions for adding the Docsy theme manually to new or existing sites.
+As you saw in our introduction, Docsy is a [Hugo](https://gohugo.io) theme,
+which means that if you want to use Docsy, you need to set up your website
+source so that the Hugo static site generator can find and use the Docsy theme
+files when building your site. The simplest way to do this is to copy and edit
+our example site, though we also provide instructions for adding the Docsy theme
+manually to new or existing sites.
 
-If you want to build and test your site locally you also need to be able to run Hugo itself, either by installing it and any other required dependencies, or by using our provided Docker container.
+If you want to build and test your site locally you also need to be able to run
+Hugo itself, either by installing it and any other required dependencies, or by
+using our provided Docker container.
 
-This page describes Docsy's installation options and helps you choose the appropriate setup guide to get started.
+This page describes Docsy's installation options and helps you choose the
+appropriate setup guide to get started.
 
 ## Installation options
 
-Hugo offers multiple options for using themes, all of which are supported by Docsy.
+Hugo offers multiple options for using themes, all of which are supported by
+Docsy.
 
-* **Adding the theme as a Hugo Module**: [Hugo Modules](https://gohugo.io/hugo-modules/) are the simplest and latest way to use Hugo themes. Hugo uses the modules mechanism to pull in the theme files from the main Docsy repo at your chosen revision, and it's easy to keep the theme up to date in your site. Our [example site](https://github.com/google/docsy-example) uses Docsy as a Hugo Module.
-* **Adding the theme as a Git submodule**: Adding the theme as a [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) also lets Hugo use the theme files from their own repo, though is more complicated to maintain than the Hugo modules approach. This is the approach used in older versions of the Docsy example site and is still supported.
-* **Cloning the theme files**: If you don't want Hugo to have to get the theme files from an external repo (for example, if you want to customize and maintain your own copy of the theme directly, or your deployment choice requires you to include a copy of the theme in your repository), you can clone the files directly into your site source.
+- **Adding the theme as a Hugo Module**:
+  [Hugo Modules](https://gohugo.io/hugo-modules/) are the simplest and latest
+  way to use Hugo themes. Hugo uses the modules mechanism to pull in the theme
+  files from the main Docsy repo at your chosen revision, and it's easy to keep
+  the theme up to date in your site. Our
+  [example site](https://github.com/google/docsy-example) uses Docsy as a Hugo
+  Module.
+- **Adding the theme as a Git submodule**: Adding the theme as a
+  [Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) also lets
+  Hugo use the theme files from their own repo, though is more complicated to
+  maintain than the Hugo modules approach. This is the approach used in older
+  versions of the Docsy example site and is still supported.
+- **Cloning the theme files**: If you don't want Hugo to have to get the theme
+  files from an external repo (for example, if you want to customize and
+  maintain your own copy of the theme directly, or your deployment choice
+  requires you to include a copy of the theme in your repository), you can clone
+  the files directly into your site source.
 
 ## Migration and backward compatibility
 
-If you have an existing site that uses Docsy as a Git submodule, and you would like to update it to use Hugo Modules, follow our [migration guide](/docs/updating/convert-site-to-module/). If you're not ready to migrate yet, don't worry! Your site will continue to work as usual.
+If you have an existing site that uses Docsy as a Git submodule, and you would
+like to update it to use Hugo Modules, follow our
+[migration guide](/docs/updating/convert-site-to-module/). If you're not ready
+to migrate yet, don't worry! Your site will continue to work as usual.
 
 ## Setup guides
 
-Follow the setup guide for your chosen approach. If you're new to Docsy and not sure which guide to follow, we recommend following the Use Docsy as a Hugo Module guide as a simple and easily maintained option.
+Follow the setup guide for your chosen approach. If you're new to Docsy and not
+sure which guide to follow, we recommend following the Use Docsy as a Hugo
+Module guide as a simple and easily maintained option.

--- a/docsy.dev/content/en/docs/get-started/basic-configuration.md
+++ b/docsy.dev/content/en/docs/get-started/basic-configuration.md
@@ -1,21 +1,34 @@
 ---
-title: "Basic site configuration"
-linkTitle: "Basic site configuration"
+title: Basic site configuration
 date: 2021-12-08T09:22:27+01:00
 weight: 4
-description: >
-  Basic configuration for new Docsy sites.
+description: Basic configuration for new Docsy sites.
+cSpell:ignore: Goldydocs
 ---
 
-Site-wide configuration details and parameters are defined in your project's [configuration file] (`hugo.toml` or `config.toml`). These include your chosen Hugo theme (Docsy, of course!), project name, community links, Google Analytics configuration, and Markdown parser parameters. See the examples with comments in [`hugo.yaml` in the example project](https://github.com/google/docsy-example/blob/main/hugo.yaml) for how to add this information. **We recommend copying this hugo.yaml and editing it even if you’re just using the theme and not copying the entire Docsy example site**, as it includes default values for many parameters that you need to set for your site to build correctly.
+Site-wide configuration details and parameters are defined in your project's
+[configuration file] (`hugo.toml` or `config.toml`). These include your chosen
+Hugo theme (Docsy, of course!), project name, community links, Google Analytics
+configuration, and Markdown parser parameters. See the examples with comments in
+[`hugo.yaml` in the example project](https://github.com/google/docsy-example/blob/main/hugo.yaml)
+for how to add this information. **We recommend copying this hugo.yaml and
+editing it even if you’re just using the theme and not copying the entire Docsy
+example site**, as it includes default values for many parameters that you need
+to set for your site to build correctly.
 
-You may want to remove or customize some defaults of the copied `hugo.toml` file straight away:
+You may want to remove or customize some defaults of the copied `hugo.toml` file
+straight away:
 
 ## Internationalization
 
-The copied `hugo.toml` file defines content in English, Norwegian and Farsi. You can find out more about how Docsy supports multi-language content in [Multi-language support](/docs/language/).
+The copied `hugo.toml` file defines content in English, Norwegian and Farsi. You
+can find out more about how Docsy supports multi-language content in
+[Multi-language support](/docs/language/).
 
-If you don't intend to translate your site, you can remove the language switcher by removing the following lines from `hugo.toml`:
+If you don't intend to translate your site, you can remove the language switcher
+by removing the following lines from `hugo.toml`:
+
+<!-- cSpell:disable -->
 
 ```toml
 [languages.no]
@@ -37,21 +50,30 @@ time_format_default = "2006.01.02"
 time_format_blog = "2006.01.02"
 ```
 
+<!-- cSpell:enable -->
+
 ## Search
 
-By default, the Docsy example site uses its own [Google Custom Search Engine](https://cse.google.com/cse/all). To disable this site search, delete or comment out the following lines:
+By default, the Docsy example site uses its own
+[Google Custom Search Engine](https://cse.google.com/cse/all). To disable this
+site search, delete or comment out the following lines:
 
 ```
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 gcs_engine_id = "..."
 ```
 
-To use your own Custom Search Engine, set `gcs_engine_id` to your search engine ID. For details, see [Configure search with a Google Custom Search Engine](/docs/content/search/#configure-search-with-a-google-custom-search-engine).
+To use your own Custom Search Engine, set `gcs_engine_id` to your search engine
+ID. For details, see
+[Configure search with a Google Custom Search Engine](/docs/content/search/#configure-search-with-a-google-custom-search-engine).
 
 ## What's next?
 
-* [Add content and customize your site](/docs/content/)
-* Get some ideas from our [Example Site](https://github.com/google/docsy-example) and other [Examples](/docs/examples/).
-* [Publish your site](/docs/deployment/).
+- [Add content and customize your site](/docs/content/)
+- Get some ideas from our
+  [Example Site](https://github.com/google/docsy-example) and other
+  [Examples](/docs/examples/).
+- [Publish your site](/docs/deployment/).
 
-[configuration file]: https://gohugo.io/getting-started/configuration/#configuration-file
+[configuration file]:
+  https://gohugo.io/getting-started/configuration/#configuration-file

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/_index.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/_index.md
@@ -1,6 +1,5 @@
 ---
-title: "Use Docsy as a Hugo Module"
-linkTitle: "Use Docsy as a Hugo Module"
+title: Use Docsy as a Hugo Module
 weight: 1
 date: 2021-12-08T10:33:16+01:00
 description: >
@@ -8,15 +7,35 @@ description: >
 sidebar_root_for: children
 ---
 
-[Hugo modules](https://gohugo.io/hugo-modules/) are the simplest and latest way to use Hugo themes like Docsy when building a website. Hugo uses the modules mechanism to pull in the theme files from the main Docsy repo at your chosen revision, and it’s easy to keep the theme up to date in your site. Our example site uses Docsy as a Hugo module.
+[Hugo modules](https://gohugo.io/hugo-modules/) are the simplest and latest way
+to use Hugo themes like Docsy when building a website. Hugo uses the modules
+mechanism to pull in the theme files from the main Docsy repo at your chosen
+revision, and it’s easy to keep the theme up to date in your site. Our example
+site uses Docsy as a Hugo module.
 
-To find out about other setup approaches, see our [Get started](/docs/get-started/) overview. If you want to migrate an existing Docsy site to use Hugo Modules, see our [migration guide](/docs/updating/convert-site-to-module/).
+To find out about other setup approaches, see our
+[Get started](/docs/get-started/) overview. If you want to migrate an existing
+Docsy site to use Hugo Modules, see our
+[migration guide](/docs/updating/convert-site-to-module/).
 
 ## Setup options with Hugo Modules
 
 To use Docsy as a Hugo Module, you have a couple of options:
 
-*   **Copy and edit the source for the [Docsy example site](https://github.com/google/docsy-example).** This approach gives you a skeleton structure for your site, with top-level and documentation sections and templates that you can modify as necessary. The example site uses Docsy as a Hugo Module.
-*   **Build your own site using the Docsy theme.** Specify the [Docsy theme](https://github.com/google/docsy) like any other [Hugo theme](https://gohugo.io/themes/) when creating or updating your site. With this option, you'll get Docsy look and feel, navigation, and other features, but you'll need to specify your own site structure. 
+- **Copy and edit the source for the
+  [Docsy example site](https://github.com/google/docsy-example).** This approach
+  gives you a skeleton structure for your site, with top-level and documentation
+  sections and templates that you can modify as necessary. The example site uses
+  Docsy as a Hugo Module.
+- **Build your own site using the Docsy theme.** Specify the
+  [Docsy theme](https://github.com/google/docsy) like any other
+  [Hugo theme](https://gohugo.io/themes/) when creating or updating your site.
+  With this option, you'll get Docsy look and feel, navigation, and other
+  features, but you'll need to specify your own site structure.
 
-If you're a beginner, we recommend that you get started by copying our example site. If you're already familiar with Hugo or want a very different site structure, you can follow our guide to start a site from scratch, which gives you maximum flexibility at the cost of higher implementation effort. In both cases you need to follow our prerequisites guide to make sure that you have installed Hugo and all necessary dependencies.
+If you're a beginner, we recommend that you get started by copying our example
+site. If you're already familiar with Hugo or want a very different site
+structure, you can follow our guide to start a site from scratch, which gives
+you maximum flexibility at the cost of higher implementation effort. In both
+cases you need to follow our prerequisites guide to make sure that you have
+installed Hugo and all necessary dependencies.

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -1,15 +1,23 @@
 ---
-title: "Create a new site: start with a prepopulated site"
-linkTitle: "Start with a prepopulated site"
+title: 'Create a new site: start with a prepopulated site'
+linkTitle: 'Start with a prepopulated site'
 date: 2021-12-08T09:21:54+01:00
 weight: 2
 description: >
-  Create a new Hugo site by using a clone of the Docsy example site as your starting point.
+  Create a new Hugo site by using a clone of the Docsy example site as your
+  starting point.
 ---
 
-The simplest way to create a new Docsy site is to use the source of the [Docsy example site](https://github.com/google/docsy-example) as starting point. This approach gives you a skeleton structure for your site, with top-level and documentation sections and templates that you can modify as necessary. The example site automatically pulls in the Docsy theme as a [Hugo Module](https://gohugo.io/hugo-modules/), so it's easy to [keep up to date](/docs/updating/updating-hugo-module/).
+The simplest way to create a new Docsy site is to use the source of the
+[Docsy example site](https://github.com/google/docsy-example) as starting point.
+This approach gives you a skeleton structure for your site, with top-level and
+documentation sections and templates that you can modify as necessary. The
+example site automatically pulls in the Docsy theme as a
+[Hugo Module](https://gohugo.io/hugo-modules/), so it's easy to
+[keep up to date](/docs/updating/updating-hugo-module/).
 
-If you prefer to create a site from scratch, follow the instructions in Start a site from scratch.
+If you prefer to create a site from scratch, follow the instructions in Start a
+site from scratch.
 
 ## TL;DR: Setup for the impatient expert
 
@@ -21,22 +29,30 @@ cd  my-new-site
 hugo server
 ```
 
-You now can preview your new site in your browser at [http://localhost:1313](http://localhost:1313/).
+You now can preview your new site in your browser at
+[http://localhost:1313](http://localhost:1313/).
 
 ## Detailed Setup instructions
 
 ### Clone the Docsy example site
 
-The [Example Site](https://example.docsy.dev) gives you a good starting point for building your docs site and is
-pre-configured to automatically pull in the Docsy theme as a Hugo Module.
-There are two different routes to get a local clone of the example site:
+The [Example Site](https://example.docsy.dev) gives you a good starting point
+for building your docs site and is pre-configured to automatically pull in the
+Docsy theme as a Hugo Module. There are two different routes to get a local
+clone of the example site:
 
-* If you want to create a local copy only, choose option 1.
-* If you have a GitHub account and want to create a GitHub repo for your site go for option 2.
+- If you want to create a local copy only, choose option 1.
+- If you have a GitHub account and want to create a GitHub repo for your site go
+  for option 2.
 
 #### Option 1: Using the command line (local copy only)
 
-If you want  to use a remote repository other than GitHub (such as [GitLab](https://gitlab.com), [BitBucket](https://bitbucket.org/), [AWS CodeCommit](https://aws.amazon.com/codecommit/), [Gitea](https://gitea.io/)) or if you don't want a remote repo at all, simply make a local working copy of the example site directly using `git clone`. As last parameter, give your chosen local repo name (here: `my-new-site`):
+If you want to use a remote repository other than GitHub (such as
+[GitLab](https://gitlab.com), [BitBucket](https://bitbucket.org/),
+[AWS CodeCommit](https://aws.amazon.com/codecommit/),
+[Gitea](https://gitea.io/)) or if you don't want a remote repo at all, simply
+make a local working copy of the example site directly using `git clone`. As
+last parameter, give your chosen local repo name (here: `my-new-site`):
 
 ```bash
 git clone --depth 1 --branch v{{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
@@ -44,48 +60,64 @@ git clone --depth 1 --branch v{{% param "version" %}} https://github.com/google/
 
 #### Option 2: Using the GitHub UI (local copy + associated GitHub repo)
 
-As the Docsy example site repo is a [template repository](https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/), creating your own remote GitHub clone of this Docsy example site repo is quite easy:
+As the Docsy example site repo is a
+[template repository](https://github.blog/2019-06-06-generate-new-repositories-with-repository-templates/),
+creating your own remote GitHub clone of this Docsy example site repo is quite
+easy:
 
-1. Go to the repo of the [Docsy example site](https://github.com/google/docsy-example).
+1. Go to the repo of the
+   [Docsy example site](https://github.com/google/docsy-example).
 
-1. Use the dropdown for switching branches/tags to change to the latest released tag `v{{% param "version" %}}`.
+1. Use the dropdown for switching branches/tags to change to the latest released
+   tag `v{{% param "version" %}}`.
 
-1. Click the button **Use this template** and select the option `Create a new repository` from the dropdown.
+1. Click the button **Use this template** and select the option
+   `Create a new repository` from the dropdown.
 
-1. Chose a name for your new repository (e.g. `my-new-site`) and type it in the **Repository name** field. You can also add an optional **Description**.
+1. Chose a name for your new repository (e.g. `my-new-site`) and type it in the
+   **Repository name** field. You can also add an optional **Description**.
 
-1. Click **Create repository from template** to create your new repository. Congratulations, you just created your remote Github clone which now serves as starting point for your own site!
+1. Click **Create repository from template** to create your new repository.
+   Congratulations, you just created your remote Github clone which now serves
+   as starting point for your own site!
 
-1. Make a local copy of your newly created GitHub repository by using `git clone`, giving your repo's web URL as last parameter.
+1. Make a local copy of your newly created GitHub repository by using
+   `git clone`, giving your repo's web URL as last parameter.
 
-    ```bash
-    git clone https://github.com/me-at-github/my-new-site.git
-    ```
+   ```bash
+   git clone https://github.com/me-at-github/my-new-site.git
+   ```
 
 > [!NOTE]
 >
-> Depending on your environment you may need to tweak the [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227) inside your `hugo.toml` slightly, for example by adding a proxy to use when downloading remote modules.
-> You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
+> Depending on your environment you may need to tweak the
+> [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227)
+> inside your `hugo.toml` slightly, for example by adding a proxy to use when
+> downloading remote modules. You can find details of what these configuration
+> settings do in the
+> [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
 
 Now you can make local edits and test your copied site locally with Hugo.
 
 ### Preview your site
 
-To build and preview your site locally, switch to the root of your cloned project and use hugo's `server` command:
+To build and preview your site locally, switch to the root of your cloned
+project and use hugo's `server` command:
 
 ```bash
 cd my-new-site
 hugo server
 ```
 
-Preview your site in your browser at: [http://localhost:1313](http://localhost:1313/).
-Thanks to Hugo's live preview, you can immediately see the effect of changes that you are making to the source files of your local repo.
-Use `Ctrl + c` to stop the Hugo server whenever you like.
-[See the known issues on MacOS](/docs/get-started/known_issues/#macos).
+Preview your site in your browser at:
+[http://localhost:1313](http://localhost:1313/). Thanks to Hugo's live preview,
+you can immediately see the effect of changes that you are making to the source
+files of your local repo. Use `Ctrl + c` to stop the Hugo server whenever you
+like. [See the known issues on MacOS](/docs/get-started/known_issues/#macos).
 
 ## What's next?
 
-* Add some [basic configuration](/docs/get-started/basic-configuration/)
-* [Edit existing content and add more pages](/docs/content/)
-* [Customize your site](/docs/content/lookandfeel/)
-* [Publish your site](/docs/deployment/).
+- Add some [basic configuration](/docs/get-started/basic-configuration/)
+- [Edit existing content and add more pages](/docs/content/)
+- [Customize your site](/docs/content/lookandfeel/)
+- [Publish your site](/docs/deployment/).

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -6,17 +6,26 @@ description: >
   Prerequisites for building a site with Docsy as a Hugo Module.
 ---
 
-This page describes the prerequisites for building a site that uses Docsy as a Hugo Module.
+This page describes the prerequisites for building a site that uses Docsy as a
+Hugo Module.
 
 ## Install Hugo
 
-You need a [recent **extended** version](https://github.com/gohugoio/hugo/releases) (version 0.146.0 or later) of [Hugo](https://gohugo.io/) to do local builds and previews of sites (like this one) that use Docsy. If you install from the release page, make sure to get the `extended` Hugo version, which supports [SCSS](https://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html); you may need to scroll down the list of releases to see it.
+You need a
+[recent **extended** version](https://github.com/gohugoio/hugo/releases)
+(version 0.146.0 or later) of [Hugo](https://gohugo.io/) to do local builds and
+previews of sites (like this one) that use Docsy. If you install from the
+release page, make sure to get the `extended` Hugo version, which supports
+[SCSS](https://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html); you
+may need to scroll down the list of releases to see it.
 
 For comprehensive Hugo documentation, see [gohugo.io](https://gohugo.io).
 
 ### On Linux
 
-Be careful using `sudo apt-get install hugo`, as it [doesn't get you the `extended` version for all Debian/Ubuntu versions](https://gohugo.io/getting-started/installing/#debian-and-ubuntu), and may not be up-to-date with the most recent Hugo version.
+Be careful using `sudo apt-get install hugo`, as it
+[doesn't get you the `extended` version for all Debian/Ubuntu versions](https://gohugo.io/getting-started/installing/#debian-and-ubuntu),
+and may not be up-to-date with the most recent Hugo version.
 
 If you've already installed Hugo, check your version:
 
@@ -24,12 +33,17 @@ If you've already installed Hugo, check your version:
 hugo version
 ```
 
-If the result is `v0.146.0` or earlier, or if you don't see `Extended`, you'll need to install the latest version. You can see a complete list of Linux installation options in [Install Hugo](https://gohugo.io/getting-started/installing/#linux). The following shows you how to install Hugo from the release page:
+If the result is `v0.146.0` or earlier, or if you don't see `Extended`, you'll
+need to install the latest version. You can see a complete list of Linux
+installation options in
+[Install Hugo](https://gohugo.io/getting-started/installing/#linux). The
+following shows you how to install Hugo from the release page:
 
 1.  Go to the [Hugo releases](https://github.com/gohugoio/hugo/releases) page.
 2.  In the most recent release, scroll down until you find a list of
     **Extended** versions.
-3.  Download the latest extended version (`hugo_extended_0.1XX_Linux-64bit.tar.gz`).
+3.  Download the latest extended version
+    (`hugo_extended_0.1XX_Linux-64bit.tar.gz`).
 4.  Create a new directory:
 
     ```bash
@@ -52,21 +66,27 @@ If the result is `v0.146.0` or earlier, or if you don't see `Extended`, you'll n
 
 ### On macOS
 
-Install Hugo using [Brew](https://gohugo.io/getting-started/installing/#homebrew-macos).
+Install Hugo using
+[Brew](https://gohugo.io/getting-started/installing/#homebrew-macos).
 
 ### As an `npm` module
 
-You can install Hugo as an `npm` module using [`hugo-bin`](https://www.npmjs.com/package/hugo-bin). This adds `hugo-bin` to your `node_modules` folder and adds the dependency to your `package.json` file.  To install the extended version of Hugo:
+You can install Hugo as an `npm` module using
+[`hugo-bin`](https://www.npmjs.com/package/hugo-bin). This adds `hugo-bin` to
+your `node_modules` folder and adds the dependency to your `package.json` file.
+To install the extended version of Hugo:
 
 ```bash
 npm install hugo-extended --save-dev
 ```
 
-See the [`hugo-bin` documentation](https://www.npmjs.com/package/hugo-bin) for usage details.
+See the [`hugo-bin` documentation](https://www.npmjs.com/package/hugo-bin) for
+usage details.
 
 ## Install Go language
 
-Hugo's commands for module management require that the Go programming language is installed on your system. Check whether `go` is already installed:
+Hugo's commands for module management require that the Go programming language
+is installed on your system. Check whether `go` is already installed:
 
 ```console
 $ go version
@@ -75,41 +95,58 @@ go version go1.25.6
 
 Ensure that you are using version 1.12 or higher.
 
-If the `go` language is not installed on your system yet or if you need to upgrade, go to the [download area](https://go.dev/dl/) of the Go website, choose the installer for your system architecture and execute it. Afterwards, check for a successful installation.
-
+If the `go` language is not installed on your system yet or if you need to
+upgrade, go to the [download area](https://go.dev/dl/) of the Go website, choose
+the installer for your system architecture and execute it. Afterwards, check for
+a successful installation.
 
 ## Install Git VCS client
 
-Hugo's commands for module management require that the `git` client is installed on your system. Check whether `git` is already present in your system:
+Hugo's commands for module management require that the `git` client is installed
+on your system. Check whether `git` is already present in your system:
 
 ```console
 $ git version
 git version 2.52.0
 ```
 
-If no `git` client is installed on your system yet, go to the [Git website](https://git-scm.com/), download the installer for your system architecture and execute it. Afterwards, check for a successful installation.
+If no `git` client is installed on your system yet, go to the
+[Git website](https://git-scm.com/), download the installer for your system
+architecture and execute it. Afterwards, check for a successful installation.
 
 ## Install PostCSS
 
-To build or update your site's CSS resources, you also need [`PostCSS`](https://postcss.org/) to create the final assets. If you need to install it, you must have a recent version of [NodeJS](https://nodejs.org/en/) installed on your machine so you can use `npm`, the Node package manager. By default `npm` installs tools under the directory where you run [`npm install`](https://docs.npmjs.com/cli/v10/commands/npm-install#description):
+To build or update your site's CSS resources, you also need
+[`PostCSS`](https://postcss.org/) to create the final assets. If you need to
+install it, you must have a recent version of [NodeJS](https://nodejs.org/en/)
+installed on your machine so you can use `npm`, the Node package manager. By
+default `npm` installs tools under the directory where you run
+[`npm install`](https://docs.npmjs.com/cli/v10/commands/npm-install#description):
 
 ```bash
 npm install -D autoprefixer
 npm install -D postcss-cli
 ```
 
-Starting in [version 8 of `postcss-cli`](https://github.com/postcss/postcss-cli/blob/master/CHANGELOG.md), you must also separately install `postcss`:
+Starting in
+[version 8 of `postcss-cli`](https://github.com/postcss/postcss-cli/blob/master/CHANGELOG.md),
+you must also separately install `postcss`:
 
 ```bash
 npm install -D postcss
 ```
 
-Note that versions of `PostCSS` later than 5.0.1 will not load `autoprefixer` if installed [globally](https://flaviocopes.com/npm-packages-local-global/), you must use a local install.
-
+Note that versions of `PostCSS` later than 5.0.1 will not load `autoprefixer` if
+installed [globally](https://flaviocopes.com/npm-packages-local-global/), you
+must use a local install.
 
 ## Install/Upgrade Node.js
 
-To ensure you can properly build your site beyond executing `hugo server`, you must have the [latest long term support (LTS) Version](https://nodejs.org/en/about/releases/) of Node.js. If you do not have the latest LTS version, you may see the one of following errors:
+To ensure you can properly build your site beyond executing `hugo server`, you
+must have the
+[latest long term support (LTS) Version](https://nodejs.org/en/about/releases/)
+of Node.js. If you do not have the latest LTS version, you may see the one of
+following errors:
 
 ```
 Error: Error building site: POSTCSS: failed to transform "scss/main.css" (text/css): Unexpected identifier
@@ -132,7 +169,8 @@ SyntaxError: Unexpected identifier
 
 ## What's next?
 
-With all prerequisites installed, choose how to start off with your new Hugo site
+With all prerequisites installed, choose how to start off with your new Hugo
+site
 
-* [Start with a prepopulated site (for beginners)](/docs/get-started/docsy-as-module/example-site-as-template/)
-* [Start site from scratch (for experts)](/docs/get-started/docsy-as-module/start-from-scratch/)
+- [Start with a prepopulated site (for beginners)](/docs/get-started/docsy-as-module/example-site-as-template/)
+- [Start site from scratch (for experts)](/docs/get-started/docsy-as-module/start-from-scratch/)

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -1,20 +1,31 @@
 ---
-title: "Create a new site: Start a new site from scratch"
-linkTitle: "Start a site from scratch"
+title: 'Create a new site: Start a new site from scratch'
+linkTitle: Start a site from scratch
 date: 2021-12-08T09:21:54+01:00
 weight: 3
 description: >
   Create a new Hugo site from scratch with Docsy as a Hugo Module
+cSpell:ignore: batchfile docsy
 ---
 
-The simplest approach to creating a Docsy site is [copying our example site](/docs/get-started/docsy-as-module/example-site-as-template/). However, if you're an experienced Hugo user or the site structure of our example site doesn't meet your needs, you may prefer to create a new site from scratch. With this option, you'll get Docsy look and feel, navigation, and other features, but you'll need to specify your own site structure.
+The simplest approach to creating a Docsy site is
+[copying our example site](/docs/get-started/docsy-as-module/example-site-as-template/).
+However, if you're an experienced Hugo user or the site structure of our example
+site doesn't meet your needs, you may prefer to create a new site from scratch.
+With this option, you'll get Docsy look and feel, navigation, and other
+features, but you'll need to specify your own site structure.
 
-These instructions give you a minimum file structure for your site project only, so that you build and extend your actual site step by step. The first step is adding the Docsy theme as a [Hugo Module](https://gohugo.io/hugo-modules/) to your site. If needed, you can easily [update](/docs/updating/) the module to the latest revision from the Docsy GitHub repo.
+These instructions give you a minimum file structure for your site project only,
+so that you build and extend your actual site step by step. The first step is
+adding the Docsy theme as a [Hugo Module](https://gohugo.io/hugo-modules/) to
+your site. If needed, you can easily [update](/docs/updating/) the module to the
+latest revision from the Docsy GitHub repo.
 
 ## TL;DR: Setup for the impatient expert
 
 At your command prompt, run the following:
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="CLI:" disabled=true />}}
 {{< tab header="Unix shell"  lang="Bash" >}}
@@ -45,39 +56,49 @@ path = "github.com/google/docsy") >> hugo.toml
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
-
-You now can preview your new site inside your browser at [http://localhost:1313](http://localhost:1313/).
+You now can preview your new site inside your browser at
+[http://localhost:1313](http://localhost:1313/).
 
 ## Detailed Setup instructions
 
-Specifying the [Docsy theme](https://github.com/google/docsy) as Hugo Module for your minimal site gives you all the theme-y goodness, but you'll need to specify your own site structure.
+Specifying the [Docsy theme](https://github.com/google/docsy) as Hugo Module for
+your minimal site gives you all the theme-y goodness, but you'll need to specify
+your own site structure.
 
 ### Create your new skeleton project
 
-To create a new Hugo site project and then add the Docsy theme as a Hugo module, run the following commands from your project's root directory.
+To create a new Hugo site project and then add the Docsy theme as a Hugo module,
+run the following commands from your project's root directory.
 
 ```bash
 hugo new site my-new-site
 cd  my-new-site
 ```
 
-This will create a minimal site structure, containing the folders `archetypes`, `content`, `data`, `layouts`, `static`, and `themes` and a configuration file (default: `hugo.toml`).
+This will create a minimal site structure, containing the folders `archetypes`,
+`content`, `data`, `layouts`, `static`, and `themes` and a configuration file
+(default: `hugo.toml`).
 
 > [!TIP]
 >
 > In Hugo 0.110.0 the default config base filename was changed to `hugo.toml`.
-> If you are using hugo 0.110 or above, consider renaming your `config.toml` to `hugo.toml`!
+> If you are using hugo 0.110 or above, consider renaming your `config.toml` to
+> `hugo.toml`!
 
 ### Import the Docsy theme module as a dependency of your site
 
-Only sites that are Hugo Modules themselves can import other modules. To turn your site into a Hugo Module, run the following commands in your newly created site directory:
+Only sites that are Hugo Modules themselves can import other modules. To turn
+your site into a Hugo Module, run the following commands in your newly created
+site directory:
 
 ```bash
 hugo mod init github.com/me/my-new-site
 ```
 
-This creates two new files, `go.mod` for the module definitions and `go.sum` which holds the checksums for module verification.
+This creates two new files, `go.mod` for the module definitions and `go.sum`
+which holds the checksums for module verification.
 
 Next declare the Docsy theme module as a dependency for your site.
 
@@ -89,8 +110,10 @@ This command adds the `docsy` theme module to your definition file `go.mod`.
 
 ### Add theme module configuration settings
 
-Add the settings in the following snippet at the end of your site's [configuration file] (default: `hugo.toml`) and save the file.
+Add the settings in the following snippet at the end of your site's
+[configuration file] (default: `hugo.toml`) and save the file.
 
+<!-- prettier-ignore-start -->
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml"  lang="toml" >}}
@@ -100,7 +123,7 @@ Add the settings in the following snippet at the end of your site's [configurati
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.73.0"
+    min = "{{% param "hugoMinVersion" %}}"
   [[module.imports]]
     path = "github.com/google/docsy"
     disable = false
@@ -110,7 +133,7 @@ module:
   proxy: direct
   hugoVersion:
     extended: true
-    min: 0.73.0
+    min: {{% param "hugoMinVersion" %}}
   imports:
     - path: github.com/google/docsy
       disable: false
@@ -121,7 +144,7 @@ module:
     "proxy": "direct",
     "hugoVersion": {
       "extended": true,
-      "min": "0.73.0"
+      "min": "{{% param "hugoMinVersion" %}}"
     },
     "imports": [
       {
@@ -133,9 +156,12 @@ module:
 }
 {{< /tab >}}
 {{< /tabpane >}}
+<!-- prettier-ignore-end -->
 
-You can find details of what these configuration settings do in the [Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
-Depending on your environment you may need to tweak them slightly, for example by adding a proxy to use when downloading remote modules.
+You can find details of what these configuration settings do in the
+[Hugo modules documentation](https://gohugo.io/hugo-modules/configuration/#module-config-top-level).
+Depending on your environment you may need to tweak them slightly, for example
+by adding a proxy to use when downloading remote modules.
 
 ### Preview your site
 
@@ -145,15 +171,27 @@ To build and preview your site locally:
 hugo server
 ```
 
-By default, your site will be available at [http://localhost:1313](http://localhost:1313/). When encountering problems, have a look at the [known issues](/docs/get-started/known_issues/#macos) on MacOS.
+By default, your site will be available at
+[http://localhost:1313](http://localhost:1313/). When encountering problems,
+have a look at the [known issues](/docs/get-started/known_issues/#macos) on
+MacOS.
 
-You may get Hugo errors for missing parameters and values when you try to build your site. This is usually because you're missing default values for some configuration settings that Docsy uses - once you add them your site should build correctly. You can find out how to add configuration in [Basic site configuration](/docs/get-started/basic-configuration/) - we recommend copying the example site configuration even if you're creating a site from scratch as it provides defaults for many required configuration parameters.
+You may get Hugo errors for missing parameters and values when you try to build
+your site. This is usually because you're missing default values for some
+configuration settings that Docsy uses - once you add them your site should
+build correctly. You can find out how to add configuration in
+[Basic site configuration](/docs/get-started/basic-configuration/) - we
+recommend copying the example site configuration even if you're creating a site
+from scratch as it provides defaults for many required configuration parameters.
 
 ## What's next?
 
-* Add some [basic configuration](/docs/get-started/basic-configuration/)
-* [Add content and customize your site](/docs/content/)
-* Get some ideas from our [Example Site](https://github.com/google/docsy-example) and other [Examples](/docs/examples/).
-* [Publish your site](/docs/deployment/).
+- Add some [basic configuration](/docs/get-started/basic-configuration/)
+- [Add content and customize your site](/docs/content/)
+- Get some ideas from our
+  [Example Site](https://github.com/google/docsy-example) and other
+  [Examples](/docs/examples/).
+- [Publish your site](/docs/deployment/).
 
-[configuration file]: https://gohugo.io/getting-started/configuration/#configuration-file
+[configuration file]:
+  https://gohugo.io/getting-started/configuration/#configuration-file

--- a/docsy.dev/content/en/docs/get-started/known_issues.md
+++ b/docsy.dev/content/en/docs/get-started/known_issues.md
@@ -1,27 +1,30 @@
 ---
-title: "Known issues"
-linkTitle: "Known issues"
+title: Known issues
 date: 2021-12-08T09:22:27+01:00
 weight: 4
-description: >
-  Known issues when installing Docsy theme.
+description: Known issues when installing Docsy theme.
 ---
 
-The following issues are know on [MacOS](#macos) and on [Windows Subsystem for Linux](#windows-subsystem-for-linux-wsl):
+The following issues are know on [MacOS](#macos) and on
+[Windows Subsystem for Linux](#windows-subsystem-for-linux-wsl):
 
 ### MacOS
 
 #### Errors: `too many open files` or `fatal error: pipe failed`
 
-By default, MacOS permits a small number of open File Descriptors. For larger sites, or when you're simultaneously running multiple applications,
-you might receive one of the following errors when you run [`hugo server`](https://gohugo.io/commands/hugo_server/) to preview your site locally:
+By default, MacOS permits a small number of open File Descriptors. For larger
+sites, or when you're simultaneously running multiple applications, you might
+receive one of the following errors when you run
+[`hugo server`](https://gohugo.io/commands/hugo_server/) to preview your site
+locally:
 
-* POSTCSS v7 and earlier:
+- POSTCSS v7 and earlier:
 
   ```
   ERROR 2020/04/14 12:37:16 Error: listen tcp 127.0.0.1:1313: socket: too many open files
   ```
-* POSTCSS v8 and later:
+
+- POSTCSS v8 and later:
 
   ```
   fatal error: pipe failed
@@ -37,9 +40,10 @@ To temporarily allow more open files:
    sudo launchctl limit maxfiles
    ```
 
-2. Increase the limit to `65535` files by running the following commands. If your site has fewer files, you can set choose to set lower soft (`65535`) and 
-   hard (`200000`) limits. 
-   
+2. Increase the limit to `65535` files by running the following commands. If
+   your site has fewer files, you can set choose to set lower soft (`65535`) and
+   hard (`200000`) limits.
+
    ```shell
    sudo launchctl limit maxfiles 65535 200000
    ulimit -n 65535
@@ -47,9 +51,10 @@ To temporarily allow more open files:
    sudo sysctl -w kern.maxfilesperproc=65535
    ```
 
-Note that you might need to set these limits for each new shell. 
+Note that you might need to set these limits for each new shell.
 [Learn more about these limits and how to make them permanent](https://www.google.com/search?q=mac+os+launchctl+limit+maxfiles+site%3Aapple.stackexchange.com&oq=mac+os+launchctl+limit+maxfiles+site%3Aapple.stackexchange.com).
 
 ### Windows Subsystem for Linux (WSL)
 
-If you're using WSL, ensure that you're running `hugo` on a Linux mount of the filesystem, rather than a Windows one, otherwise you may get unexpected errors.
+If you're using WSL, ensure that you're running `hugo` on a Linux mount of the
+filesystem, rather than a Windows one, otherwise you may get unexpected errors.

--- a/docsy.dev/content/en/docs/get-started/quickstart-docker.md
+++ b/docsy.dev/content/en/docs/get-started/quickstart-docker.md
@@ -1,11 +1,10 @@
-
 ---
-title: "Deploy Docsy inside a Docker container"
-linkTitle: "Deploy Docsy inside a Docker container"
+title: Deploy Docsy inside a Docker container
 weight: 3
 date: 2018-07-30
 description: >
   Instructions on how to setup and run a local Docsy site with Docker.
+cSpell:ignore: docsy
 ---
 
 We provide a Docker image that you can use to run and test your Docsy site
@@ -13,10 +12,10 @@ locally, without having to install all Docsy's dependencies.
 
 ## Install the prerequisites
 
-1. On Mac and Windows, download and install [Docker
-   Desktop](https://www.docker.com/get-started).  On Linux, install [Docker
-   engine](https://docs.docker.com/engine/install/) and [Docker
-   compose](https://docs.docker.com/compose/install/).
+1. On Mac and Windows, download and install
+   [Docker Desktop](https://www.docker.com/get-started). On Linux, install
+   [Docker engine](https://docs.docker.com/engine/install/) and
+   [Docker compose](https://docs.docker.com/compose/install/).
 
    The installation may require you to reboot your computer for the changes to
    take effect.
@@ -25,14 +24,14 @@ locally, without having to install all Docsy's dependencies.
 
 ## Create your repository from the docsy-example template
 
-The docsy-example repository provides a basic site structure that you can use
-as starting point to create your own documentation.
+The docsy-example repository provides a basic site structure that you can use as
+starting point to create your own documentation.
 
-1. Use the [docsy-example template](https://github.com/google/docsy-example)
-   to [create your own repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
+1. Use the [docsy-example template](https://github.com/google/docsy-example) to
+   [create your own repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
 
-1. Download the code to your local machine by [cloning your newly created
-   repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
+1. Download the code to your local machine by
+   [cloning your newly created repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
 
 1. Change your working directory to the newly created folder:
 
@@ -43,8 +42,8 @@ as starting point to create your own documentation.
 ## Build and run the container
 
 The docsy-example repository includes a
-[Dockerfile](https://docs.docker.com/engine/reference/builder/) that you can
-use to run your site.
+[Dockerfile](https://docs.docker.com/engine/reference/builder/) that you can use
+to run your site.
 
 1. Build the docker image:
 
@@ -76,6 +75,7 @@ To cleanup your system and delete the container image follow the next steps.
 
 ## What's next?
 
-* Learn about [basic setup and configurations for Docsy](/docs/get-started/basic-configuration/).
-* [Add content and customize your site](/docs/content/)
-* [Publish your site](/docs/deployment/).
+- Learn about
+  [basic setup and configurations for Docsy](/docs/get-started/basic-configuration/).
+- [Add content and customize your site](/docs/content/)
+- [Publish your site](/docs/deployment/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+70-g6399194a",
+  "version": "0.14.0-dev+71-gb1b03b95",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
No content change except for the use of `{{% param "hugoMinVersion" %}}` in `docs/get-started/docsy-as-module/start-from-scratch.md` instead of hard-coded values

**Preview**: https://deploy-preview-2488--docsydocs.netlify.app/docs/get-started/docsy-as-module/start-from-scratch/