### PR TITLE
Add new Norwegian translations for UI and alerts

### DIFF
--- a/i18n/no.yaml
+++ b/i18n/no.yaml
@@ -1,3 +1,10 @@
+# Alert labels
+caution: Forsiktig
+important: Viktig
+note: Merknad
+tip: Tips
+warning: Advarsel
+
 # UI strings. Buttons and similar.
 ui_pager_prev: Forrige
 ui_pager_next: Neste
@@ -6,6 +13,9 @@ ui_search: Søk på nettstedet…
 
 # Used in sentences such as "Posted in News"
 ui_in: i
+
+# Used in sentences such as "All Tags"
+ui_all: alle
 
 # Footer text
 footer_all_rights_reserved: Alle rettigheter er reservert
@@ -49,3 +59,13 @@ community_how_to: >-
   Du kan finne ut hvordan du bidrar til {{ .Site.Title }} i vår
 community_guideline: >-
   Retningslinjer for bidrag
+
+# Feedback
+feedback_title: Tilbakemelding
+feedback_question: Var denne siden nyttig?
+feedback_positive: Ja
+feedback_negative: Nei
+
+# Table of contents
+toc_on_this_page: På denne siden
+toc_top_of_page: Toppen av siden

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+72-gc3035f02",
+  "version": "0.14.0-dev+73-g7cc86a3e",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2390
- Adds key/value pairs for alert labels and feedback
- We use Norwegian in Goldydocs, the main Docsy example site. It'll be nice to have all the labels.