### PR TITLE
Refactor extra and footer SCSS, add footer border

### DIFF
--- a/assets/scss/td/_footer.scss
+++ b/assets/scss/td/_footer.scss
@@ -1,0 +1,58 @@
+.td-footer {
+  --td-footer-border-top: 1px solid var(--bs-border-color);
+
+  @extend .td-box--dark;
+
+  min-height: 150px;
+  padding-top: map-get($spacers, 5);
+
+  @include media-breakpoint-down(lg) {
+    min-height: 200px;
+  }
+
+  /* &__left { } */
+
+  &__center {
+    @extend .small;
+    text-align: center;
+  }
+
+  &__right {
+    text-align: right;
+  }
+
+  &__about {
+    font-size: initial;
+  }
+
+  &__links {
+    &-list {
+      @extend .list-inline;
+      margin-bottom: 0;
+    }
+
+    &-item {
+      @extend .list-inline-item;
+      @include font-size(map-get($font-sizes, 4));
+
+      a {
+        color: inherit !important;
+      }
+    }
+  }
+
+  &__authors,
+  &__all_rights_reserved {
+    padding-left: map-get($spacers, 1);
+  }
+
+  &__all_rights_reserved {
+    display: none;
+  }
+}
+
+@include color-mode(dark) {
+  .td-footer {
+    border-top: var(--td-footer-border-top);
+  }
+}

--- a/assets/scss/td/extra/_index.scss
+++ b/assets/scss/td/extra/_index.scss
@@ -1,0 +1,4 @@
+// Experimental extra styles that projects can test run. These styles might
+// eventually be merged into the core Docsy theme.
+
+@import 'navbar';

--- a/assets/scss/td/extra/_navbar.scss
+++ b/assets/scss/td/extra/_navbar.scss
@@ -1,10 +1,4 @@
-// Experimental extra styles that projects can test run.
-// These styles might eventually be merged into the core Docsy theme.
-
-// ------------------------------------------------------------
-// Navbar
-// ------------------------------------------------------------
-// Use underline decoration for active and hover nav-link states.
+// Navbar styles: use underline decoration for active and hover nav-link states.
 
 .td-navbar {
   .nav-link {

--- a/assets/scss/td/main.scss
+++ b/assets/scss/td/main.scss
@@ -17,12 +17,13 @@
 @import '../variables_project_after_bs';
 
 @import 'support/utilities';
-@import 'colors';
-@import 'table';
-@import 'boxes';
 @import 'blog';
+@import 'boxes';
 @import 'code';
+@import 'colors';
+@import 'footer';
 @import 'nav';
+@import 'table';
 @import 'sidebar-tree';
 @import 'sidebar-toc';
 @import 'breadcrumb';
@@ -41,57 +42,6 @@
 
 @if $td-enable-google-fonts {
   @import url($td-web-font-path);
-}
-
-.td-footer {
-  @extend .td-box--dark;
-
-  min-height: 150px;
-  padding-top: map-get($spacers, 5);
-
-  @include media-breakpoint-down(lg) {
-    min-height: 200px;
-  }
-
-  /* &__left { } */
-
-  &__center {
-    @extend .small;
-    text-align: center;
-  }
-
-  &__right {
-    text-align: right;
-  }
-
-  &__about {
-    font-size: initial;
-  }
-
-  &__links {
-    &-list {
-      @extend .list-inline;
-      margin-bottom: 0;
-    }
-
-    &-item {
-      @extend .list-inline-item;
-      @include font-size(map-get($font-sizes, 4));
-
-      a {
-        color: inherit !important;
-      }
-    }
-  }
-
-  &__authors,
-  &__all_rights_reserved {
-    padding-left: map-get($spacers, 1);
-  }
-
-  &__all_rights_reserved {
-    display: none;
-  }
 }
 
 // Adjust anchors vs the fixed menu.

--- a/docsy.dev/assets/scss/_navbar.scss
+++ b/docsy.dev/assets/scss/_navbar.scss
@@ -1,5 +1,5 @@
 .td-navbar {
-  // Illustrate translucent background for regular pages (without blocks/cover)
+  // Illustrates translucent background for regular pages (without blocks/cover)
   @include media-breakpoint-up(md) {
     --td-navbar-bg-color: rgba(var(--bs-body-bg-rgb), 0.85);
     --td-navbar-backdrop-filter: blur(8px);
@@ -19,14 +19,7 @@
     // Make search box border more visible
     --bs-border-color: #{$gray-500};
 
-    .nav-link {
-      @at-root .td-home & {
-        // On home page use more visible active color for all links
-        // --bs-nav-link-color: var(--bs-navbar-active-color) !important;
-      }
-    }
-
-    // Illustrate tinted transparent background color on desktop:
+    // Illustrates tinted transparent background color on desktop:
     @include media-breakpoint-up(md) {
       &.td-navbar-transparent {
         $rgba-primary: rgba($primary-darker, 0.65);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+73-g7cc86a3e",
+  "version": "0.14.0-dev+74-gca4a67eb",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Moved footer styles from main.scss to a new _footer.scss partial
- Added footer border and CSS var (1--td-footer-border-top`) to make it very easily configurable
- Relocated experimental navbar styles to extra/_navbar.scss and created extra/_index.scss for simplified styles imports
