### PR TITLE
chore(hugo.yaml): cleanup config and add some explanation

### DIFF
--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -1,3 +1,5 @@
+# cSpell:ignore docsy github goldmark markmap plantuml readingtime
+#
 # baseURL moved to be after params
 title: Docsy
 theme: [docsy]
@@ -166,6 +168,8 @@ module:
     extended: true
     min: *hugoMinVersion
   mounts:
+    # If our mock language (xx) had any content we'd configure this
+    # differently, but for now, this will do.
     - source: content/en
       target: content
       # English content for both en, and as fallback for xx sites
@@ -184,10 +188,3 @@ module:
       sites: *sites
     - source: ../CONTRIBUTING.md
       target: content/project/repo/CONTRIBUTING.md
-    # Placeholder language used to demo multilingual support
-    - source: content/en
-      target: content
-      sites:
-        matrix:
-          languages: ['xx']
-# cSpell:ignore docsy github goldmark markmap plantuml readingtime

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+74-gca4a67eb",
+  "version": "0.14.0-dev+75-g5ac2b165",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Adds explanatory comments and removed the placeholder language mount for the mock 'xx' language in the Hugo config
- Followup to #2487