### PR TITLE
consider docs-only sites for sidebar root default

### DIFF
--- a/layouts/_partials/sidebar-tree.html
+++ b/layouts/_partials/sidebar-tree.html
@@ -46,15 +46,11 @@
       {{ partial "navbar-lang-selector.html" . }}
     </div>
     {{ end -}}
-    {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
-    {{ if $sidebarRoot -}}
-      {{ $navRoot = $sidebarRoot -}}
-    {{ end -}}
     {{ $ulNr := 0 -}}
     {{ $ulShow := .Site.Params.ui.ul_show | default 1 -}}
     {{ $sidebarMenuTruncate := .Site.Params.ui.sidebar_menu_truncate | default 100 -}}
     <ul class="td-sidebar-nav__section pe-md-3 ul-{{ $ulNr }}">
-      {{ template "section-tree-nav-section" (dict "page" . "section" $navRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
+      {{ template "section-tree-nav-section" (dict "page" . "section" $sidebarRoot "shouldDelayActive" $shouldDelayActive "sidebarMenuTruncate" $sidebarMenuTruncate "ulNr" $ulNr "ulShow" (add $ulShow 1)) }}
     </ul>
   </nav>
 </div>

--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -10,8 +10,8 @@
 {{ $cacheSidebar := ge (len .Site.Pages) $sidebarCacheLimit -}}
 
 {{/* Determine sidebar root and ID (if enabled) */ -}}
-{{ $sidebarRoot := .FirstSection -}}
 {{ $navRoot := cond (and (ne .Params.toc_root true) (eq .Site.Home.Type "docs")) .Site.Home .FirstSection -}}
+{{ $sidebarRoot := $navRoot -}}
 {{ if .Site.Params.ui.sidebar_root_enabled -}}
   {{ if and .IsSection (eq .Params.sidebar_root_for "self") -}}
     {{ $sidebarRoot = . -}}


### PR DESCRIPTION
This PR sets a better default value for sidebar root pages by considering docs-only sites as it has been done in earlier Docsy versions.

This fixes a bug that caused top-level section pages being always rooted in the sidebar for docs-only sites, even if `toc_root` and section-as-root as been disabled. (fixes #2492)