### PR TITLE
Document heading aliases and in-page targets

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -10,6 +10,10 @@ tags: [release, upgrade]
 cSpell:ignore: docsy subrepo lightdark lookandfeel
 ---
 
+<style>
+  li > div.alert-nb { margin: 0.5rem 0 !important;}
+</style>
+
 {{% card header="Highlights" %}}
 
 - {{% _param FA_LG palette success %}}
@@ -27,13 +31,15 @@ cSpell:ignore: docsy subrepo lightdark lookandfeel
 ## Release summary
 
 - **[Styles and customization](#styles-customization)**:
-  - Navbar improvements, including configurable light/dark theme and adjustable
-    height
-  - Reorganized internal SCSS files
+  - [Navbar improvements](#navbar), including configurable light/dark theme and
+    adjustable height
+  - [Heading aliases and in-page targets](#heading-aliases)
+  - [Reorganized internal SCSS files](#improved-scss-soc)
     > [!NB] :warning: If you [customize **Swagger UI**][], this impacts you!
 - **Content and shortcodes**:
   - New Markdown [alert syntax](#alerts)
   - [`blocks/cover`](#blocks-cover) shortcode changes
+  - New [shortcode](#shortcodes) for Netlify build info
   - [Internationalization](#other-notable-changes) updates
 - **[Hugo 0.155.0 or later](#hugo)** required; discussion of breaking changes
   and new features such as [sites.matrix][]
@@ -110,13 +116,15 @@ feel.[^navbar-bg-color]
 
 Navbar **height and styling** are tunable via:
 
+<!-- prettier-ignore -->
 - `$td-navbar-min-height` SCSS variable
-- <details><summary>CSS variables (experimental)</summary>
+- <details><summary>CSS variables (EXPERIMENTAL)</summary>
+
   - `--td-navbar-bg-color`
   - `--td-navbar-backdrop-filter`
   - `--td-navbar-border-bottom`
-  - `--bs-bg-opacity` (used with `--td-navbar-bg-color` for background opacity)
-  - `--bs-link-underline-opacity` (nav link underline)
+  - `--bs-bg-opacity`, used with `--td-navbar-bg-color` for background opacity
+  - `--bs-link-underline-opacity`, nav link underline
 
   </details>
 
@@ -198,6 +206,16 @@ You may need to update your project in the following areas:
 [navbar-lightdark-theme]: /docs/content/lookandfeel/#navbar-lightdark-theme
 [navbar cover-image translucency]:
   /docs/content/lookandfeel/#customize-over-cover
+
+### Heading aliases and in-page targets {#heading-aliases}
+
+Heading aliases are a useful convention for keeping old [fragment] links
+working. In 0.14.0, scrolling behavior is fixed (purely in CSS using
+`scroll-padding-top`), so heading alias targets and in-page targets now scroll
+to the right place. See [Heading aliases and in-page targets][].
+
+[fragment]: https://gohugo.io/quick-reference/glossary/#fragment
+[Heading aliases and in-page targets]: /docs/content/navigation/#heading-aliases
 
 ### Improved separation of project and internal SCSS files {#improved-scss-soc}
 
@@ -353,10 +371,14 @@ Experimental extra styles:
 - Navbar link decoration for active and hover states
 - Nested-list margin fix for the last child
 
-For details, see [Experimental extra styles][].
+For details, see [Extra styles][].
 
-[Experimental extra styles]:
-  /docs/content/lookandfeel/#experimental-extra-styles
+[Extra styles]: /docs/content/lookandfeel/#extra-styles
+
+### Shortcodes
+
+- New [experimental] `td/site-build-info/netlify` shortcode for Netlify build
+  info. See an [example](/project/#site-build-information).
 
 ### Clarified public vs internal theme features
 
@@ -366,7 +388,7 @@ expectations are clear about what’s supported and what changes require action:
 
 - [Public customization surface](/project/about/changelog/#public)
 - [Private/internal features](/project/about/changelog/#private)
-- [Experimental features](/project/about/changelog/#experimental)
+- [Experimental features][experimental]
 - [Breaking change](/project/about/changelog/#breaking-change)
 - [Official support limits](/project/about/changelog/#official-support)
 
@@ -447,6 +469,7 @@ Other references:
 [Advanced style customization]:
   /docs/content/lookandfeel/#advanced-style-customization
 [CL@0.14.0]: /project/about/changelog/#v0.14.0
+[experimental]: /project/about/changelog/#experimental
 [hugo-0.152.0+]: /blog/2026/hugo-0.152.0+/
 [officially supports]: /project/about/changelog/#official-support
 [Project style files]: /docs/content/lookandfeel/#project-style-files

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -100,7 +100,7 @@ and filename as the Docsy file you want to reset.
 After resetting selected internal SCSS files, define your project’s actual
 styles in `_styles_project.scss`, as usual.
 
-#### Experimental extra styles {#experimental-extra-styles}
+#### Extra styles (EXPERIMENTAL) {#extra-styles}
 
 Docsy includes an optional [td/extra][] styles folder with [experimental] styles
 that projects can test. These styles may eventually be merged into the core
@@ -260,7 +260,12 @@ To [disable dark mode][] entirely:
   https://getbootstrap.com/docs/5.3/customize/color-modes/#building-with-sass
 [site configuration]: https://gohugo.io/configuration/introduction/
 
-### How to pick colors with good color-contrast (EXPERIMENTAL) {#pick-good-color-contrast}
+### How to pick colors with good color-contrast {#pick-good-color-contrast}
+
+> [!CAUTION]
+>
+> This feature is [experimental]. We invite projects to try it and share
+> feedback.
 
 Getting dark-mode theme colors to have proper contrast can be tricky. Docsy
 provides [_color-adjustments-dark.scss] as an example of theme color
@@ -294,14 +299,6 @@ dark mode theme customization file and import it in your project's
   https://github.com/google/docsy/blob/main/assets/scss/td/_color-adjustments-dark.scss
 [Chroma for code highlighting]: #code-highlighting-with-chroma
 [Light/dark code styles]: #lightdark-code-styles
-
-<!-- markdownlint-disable no-blanks-blockquote -->
-
-> [!CAUTION] EXPERIMENTAL
->
-> This feature is experimental. We're releasing this early to so that projects
-> can try out this approach and provide feedback on its usefulness and
-> convenience.
 
 > [!NOTE]
 >
@@ -902,6 +899,7 @@ highest-level page you want to modify.
 
 [bs-docs]: https://getbootstrap.com/docs/
 [color modes]: https://getbootstrap.com/docs/5.3/customize/color-modes/
+[experimental]: /project/about/changelog/#experimental
 [syntax highlighting]: https://gohugo.io/content-management/syntax-highlighting/
 [ug-project-styles]:
   https://github.com/google/docsy/blob/main/docsy.dev/assets/scss/_styles_project.scss

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -736,11 +736,55 @@ Your projects can also reuse (in your own custom heading render hook) or
 override the heading self-link partial `td/heading-self-link.html`, which is
 defined in [layouts/_partials/td/render-heading.html].
 
+## Heading aliases and in-page targets <a id="a-heading-aliases"></a> {#heading-aliases}
+
+By default, [heading IDs are auto-generated][] from heading text unless you set
+an explicit ID. If you change the text or explicit ID, the heading ID changes
+and existing [fragment] links to the heading will break. Treat a heading ID
+change like a page move: keep old fragments working with a heading ID alias.
+
+To create a heading ID alias:
+
+- Add an empty anchor element with the old ID to the heading.
+- Add the new heading ID using the `{#some-id}` [Markdown attributes] syntax.
+
+For example, if you rename "Getting Started" to "Quickstart":
+
+```html
+## Quickstart <a id="getting-started"></a> {#quickstart}
+```
+
+Now both `#getting-started` and `#quickstart` target the same heading and scroll
+to the right place.
+
+Give the heading alias for this section a try:
+[Heading aliases](#a-heading-aliases).[^might-not-scroll]
+
+> [!TIP] In-page targets <a id="in-page-targets-tip"></a>
+>
+> Anchor elements with IDs can be used to define in-page targets as well. For
+> example, you can link to this [in-page targets](#in-page-targets-tip)
+> tip.[^might-not-scroll]
+
+<!-- markdownlint-disable no-blanks-blockquote -->
+
+> [!IMPORTANT]
+>
+> Use an empty `<a id="..."></a>` for target IDs. Avoid `<span>` targets, as
+> they can be unreliable in some browsers.
+
+[^might-not-scroll]:
+    If the target is already visible, the page might not scroll.
+
 [configuration file]:
   https://gohugo.io/getting-started/configuration/#configuration-file
+[fragment]: https://gohugo.io/quick-reference/glossary/#fragment
+[heading IDs are auto-generated]:
+  https://gohugo.io/configuration/markup/#parserautoheadingid
+[hook]: https://gohugo.io/templates/render-hooks/
 [layouts/_partials/td/render-heading.html]:
   https://github.com/google/docsy/tree/main/layouts/_partials/td/render-heading.html
-[hook]: https://gohugo.io/templates/render-hooks/
+[Markdown attributes]: https://gohugo.io/content-management/markdown-attributes/
 [menu]: https://gohugo.io/content-management/menus/
 [menus]: https://gohugo.io/content-management/menus/
 [Multi-language support]: /docs/language/

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -66,6 +66,9 @@ Experimental features are not part of the
 [public customization surface](#public) and may change or be removed in future
 releases.
 
+We release experimental features so that projects can try them out and share
+feedback.
+
 ### Breaking change
 
 A **breaking change** is a backward-incompatible change to Docsy’s _public
@@ -129,6 +132,8 @@ For the full list of changes, see the [0.14.0] release page.
 **Other changes**:
 
 - Fixed [navbar color contrast (#2413)][#2413] via [#2477].
+- Fixed **fragment link scrolling** by using `scroll-padding-top`, see [Heading
+  aliases][0.14.0-blog-heading-aliases].
 - Internal **SCSS file reorganization**: moved internal SCSS files to
   `assets/scss/td/` ([#1654]) for [improved separation of project and internal
   SCSS files][0.14.0-blog-scss].
@@ -145,6 +150,7 @@ For the full list of changes, see the [0.14.0] release page.
 [0.14.0]: https://github.com/google/docsy/releases/v0.14.0
 [0.14.0-blog-alerts]: /blog/2026/0.14.0/#alerts
 [0.14.0-blog-cover]: /blog/2026/0.14.0/#blocks-cover
+[0.14.0-blog-heading-aliases]: /blog/2026/0.14.0/#heading-aliases
 [0.14.0-blog-hugo]: /blog/2026/0.14.0/#hugo
 [0.14.0-blog-internationalization]: /blog/2026/0.14.0/#internationalization
 [0.14.0-blog-navbar]: /blog/2026/0.14.0/#navbar

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -2007,6 +2007,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-01-15T20:07:12.494463-05:00"
   },
+  "https://gohugo.io/configuration/markup/#parserautoheadingid": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-02T12:12:36.230888-05:00"
+  },
   "https://gohugo.io/configuration/media-types/#create-a-media-type": {
     "StatusCode": 206,
     "LastSeen": "2025-06-06T15:13:21.028725+02:00"
@@ -2226,6 +2230,10 @@
   "https://gohugo.io/quick-reference/glossary/#content-type": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T19:33:33.89252-05:00"
+  },
+  "https://gohugo.io/quick-reference/glossary/#fragment": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-02T12:12:36.236086-05:00"
   },
   "https://gohugo.io/quick-reference/glossary/#partial-decorator": {
     "StatusCode": 206,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+80-g09b9a9f1",
+  "version": "0.14.0-dev+81-g3753ff78",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.14/commit-inventory.md
+++ b/tasks/0.14/commit-inventory.md
@@ -1,10 +1,10 @@
 ---
 title: 0.14 commit inventory
 date: 2026-01-16
-cSpell:ignore: docsy
+cSpell:ignore: docsy frontmatter subrepo
 ---
 
-> Report refreshed for commits through `5365d35` on `main`.
+> Report refreshed for commits through `3753ff78` on `main`.
 
 Chronological list of [commits since v0.13.0][], broadly grouped into a few
 categories. We'll do a more detailed analysis and groupings when we create the
@@ -13,98 +13,112 @@ client projects.
 
 ## Features & fixes
 
-- `69d4d6c` (`#2415`) Update changelog anchors, release process docs, and vers
-  to 0.13.1-dev
-- `5fd8175` (`#2427`) docsy.dev: set to_year to "present", and shortcode cleanup
-- `b7f7335` (`#2428`) Update all packages other than Hugo
-- `9334955` (`#2430`) Upgrade Hugo to 0.154.3
-- `b52c265` (`#2432`) Update Hugo to 0.154.5
-- `53d4393` (`#2434`) Update alias format in get started page so it works as a
+- `69d4d6c` (#2415) Update changelog anchors, release process docs, and vers to
+  0.13.1-dev
+- `5fd8175` (#2427) docsy.dev: set to_year to "present", and shortcode cleanup
+- `b7f7335` (#2428) Update all packages other than Hugo
+- `9334955` (#2430) Upgrade Hugo to 0.154.3
+- `b52c265` (#2432) Update Hugo to 0.154.5
+- `53d4393` (#2434) Update alias format in get started page so it works as a
   fallback too
-- `bf9f559` (`#2435`) chore: complete German localization
-- `8607ceb` i18n: zh_cn and zh_tw
-- `48f9c75` Update Serbian (Cyrillic & Latin)
-- `13ba7b2` Add author for Serbian translations
-- `02479b2` Add feedback section and table of contents to Bengali localization
-- `9cca91a` Update feedback section translations in Bengali localization
-- `1465641` Fix newline issue in Bengali localization for table of contents
-- `73a7b3f` Add Hugo Markdown-style alert support and docs
-- `68cb0e7` Add docs version as a badge
-- `884d714` Add version to docs landing page, bump version to 0.14.0-dev
-- `62d4aac` Add site build info and build documentation
-- `4a11ed0` Add AGENTS.md
-- `e1bb622` chore: Rename 'site' docs section to 'project' and update links
-- `113cc39` Move pages to About section
-- `8a2528f` Update links
-- `a1075cf` Migrate i18n files from TOML to YAML and add conversion scripts
-- `a989a32` Fix left sidebar height
-- `29bc71f` Add support for custom attributes in blockquote alerts
-- `c9f4299` Add alert label translations to i18n files
-- `3396c03` Convert i18n/uk.toml to .yaml
-- `ec122d8` Delete i18n/uk.toml since we have a .yaml format now
-- `f81406a` Convert most shortcode alerts to markdown, and more
-- `a600e53` Convert Bengali translations from TOML to YAML
-- `95c6a2d` Add Bengali translations for alert labels
-- `d2a63db` Address Hugo deprecation msg related to mounts
-- `93fe8ba` Convert Chinese i18n files from TOML to YAML
-- `81613ae` Convert Japanese translations from TOML to YAML
-- `23fea73` Add alert labels and all-rights-reserved in Japanese
-- `1a25ddf` Update i18n/ja.yaml
-- `6cbe364` Add alert label translations for zh-cn and zh-tw
-- `9dab6fe` zh-cn, use `note: 说明`
-- `e79719f` Create he.toml
-- `731531a` Update i18n/he.toml
-- `f4526dc` Update i18n/he.toml
-- `0d7d78d` Convert Hebrew translation file to YAML
-- `ebc264e` Add alert and table of contents labels to Hebrew i18n
-- `791a707` Convert all remaining i18n files to YAML, add helper scripts
-- `1dfd1a0` Format
-- `08a9569` Upgrade Prettier
-- `83db5b9` Format
-- `08fe966` Add CI/CD info about Prettier and i18n directory
-- `ef0e8b8` Update compare-i18n-toml-yaml.pl
-- `93322ff` Fix comment across locales
-- `199468a` Create scss-namespace.plan.md
-- `1e093f3` Namespace SCSS files, and make adjustments
-- `1560cec` Update refresh-sass-variables.pl
-- `7bcae61` Don't format \_variables_forward.scss
-- `b3cb2a7` Update Swagger UI customization instructions
-- `6f8f85a` Add nested `sidebar_root_for` to docs
-- `11bc51a` bugfix: nested sidebar_root_for
-- `bf7c497f` Update 0.14.0 release notes and changelog details
-- `4f855a02` Refactor blocks/cover and pageinfo shortcodes
-- `61282a64` (`#2465`) KaTeX use: move media type declaration to theme's config
+- `bf9f559` (#2435) chore: complete German localization
+- `8607ceb` (#2419) i18n: zh_cn and zh_tw
+- `48f9c75` (#2425) Update Serbian (Cyrillic & Latin)
+- `13ba7b2` (#2425) Add author for Serbian translations
+- `02479b2` (#2416) Add feedback section and table of contents to Bengali
+  localization
+- `9cca91a` (#2416) Update feedback section translations in Bengali localization
+- `1465641` (#2416) Fix newline issue in Bengali localization for table of
+  contents
+- `73a7b3f` (#2443) Add Hugo Markdown-style alert support and docs
+- `68cb0e7` (#2442) Add docs version as a badge
+- `884d714` (#2441) Add version to docs landing page, bump version to 0.14.0-dev
+- `62d4aac` (#2444) Add site build info and build documentation
+- `4a11ed0` (#2446) Add AGENTS.md
+- `e1bb622` (#2445) chore: Rename 'site' docs section to 'project' and update
+  links
+- `113cc39` (#2446) Move pages to About section
+- `8a2528f` (#2446) Update links
+- `a1075cf` (#2447) Migrate i18n files from TOML to YAML and add conversion
+  scripts
+- `a989a32` (#2453) Fix left sidebar height
+- `29bc71f` (#2452) Add support for custom attributes in blockquote alerts
+- `c9f4299` (#2450) Add alert label translations to i18n files
+- `3396c03` (#2454) Convert i18n/uk.toml to .yaml
+- `ec122d8` (#2455) Delete i18n/uk.toml since we have a .yaml format now
+- `f81406a` (#2457) Convert most shortcode alerts to markdown, and more
+- `a600e53` (#2458) Convert Bengali translations from TOML to YAML
+- `95c6a2d` (#2459) Add Bengali translations for alert labels
+- `d2a63db` (#2460) Address Hugo deprecation msg related to mounts
+- `93fe8ba` (#2461) Convert Chinese i18n files from TOML to YAML
+- `81613ae` (#2463) Convert Japanese translations from TOML to YAML
+- `23fea73` (#2464) Add alert labels and all-rights-reserved in Japanese
+- `1a25ddf` (#2464) Update i18n/ja.yaml
+- `6cbe364` (#2462) Add alert label translations for zh-cn and zh-tw
+- `9dab6fe` (#2462) zh-cn, use `note: 说明`
+- `e79719f` (#2272) Create he.toml
+- `731531a` (#2272) Update i18n/he.toml
+- `f4526dc` (#2272) Update i18n/he.toml
+- `0d7d78d` (#2466) Convert Hebrew translation file to YAML
+- `ebc264e` (#2467) Add alert and table of contents labels to Hebrew i18n
+- `791a707` (#2468) Convert all remaining i18n files to YAML, add helper scripts
+- `1dfd1a0` (#2468) Format
+- `08a9569` (#2468) Upgrade Prettier
+- `83db5b9` (#2468) Format
+- `08fe966` (#2468) Add CI/CD info about Prettier and i18n directory
+- `ef0e8b8` (#2468) Update compare-i18n-toml-yaml.pl
+- `93322ff` (#2468) Fix comment across locales
+- `199468a` (#2469) Create scss-namespace.plan.md
+- `1e093f3` (#2469) Namespace SCSS files, and make adjustments
+- `1560cec` (#2469) Update refresh-sass-variables.pl
+- `7bcae61` (#2469) Don't format \_variables_forward.scss
+- `b3cb2a7` (#2473) Update Swagger UI customization instructions
+- `6f8f85a` (#2476) Add nested `sidebar_root_for` to docs
+- `11bc51a` (#2470) bugfix: nested sidebar_root_for
+- `bf7c497f` (#2478) Update 0.14.0 release notes and changelog details
+- `4f855a02` (#2480) Refactor blocks/cover and pageinfo shortcodes
+- `61282a64` (#2465) KaTeX use: move media type declaration to theme's config
   file
-- `e7b91366` (`#2481`) docsy.dev: minor reorg and refactor SCSS
-- `6399194a` (`#2486`) Update devDeps, incl. Hugo to 0.155.0
-- `b1b03b95` (`#2487`) docsy.dev config: switch to using sites.matrix
-- `c3035f02` (`#2488`) Reformat and clarify Docsy 'Get Started' pages
-- `7cc86a3e` (`#2489`) Refactor navbar and layout SCSS, update examples
-- `ca4a67eb` (`#2490`) Add new Norwegian translations for UI and alerts
-- `5ac2b165` (`#2491`) Refactor extra and footer SCSS, add footer border
-- `5365d35d` (`#2494`) chore(hugo.yaml): cleanup config and add some explanation
+- `e7b91366` (#2481) docsy.dev: minor reorg and refactor SCSS
+- `6399194a` (#2486) Update devDeps, incl. Hugo to 0.155.0
+- `b1b03b95` (#2487) docsy.dev config: switch to using sites.matrix
+- `c3035f02` (#2488) Reformat and clarify Docsy 'Get Started' pages
+- `7cc86a3e` (#2489) Refactor navbar and layout SCSS, update examples
+- `ca4a67eb` (#2490) Add new Norwegian translations for UI and alerts
+- `5ac2b165` (#2491) Refactor extra and footer SCSS, add footer border
+- `5365d35d` (#2494) chore(hugo.yaml): cleanup config and add some explanation
+- `34ab5de0` (#2498) Fix grammatical error in Norwegian translation
+- `061b3762` (#2483) Use "front matter" rather than "frontmatter"
+- `2aef9560` (#2502) Update 0.14 release notes, Hugo upgrade guide, style
+  adjustments, and more
+- `09b9a9f1` (#2495) Only set td-sidebar-root-up-icon for links that are the
+  tree root
+- `3753ff78` (#2505) Reorganize SCSS, fix scroll padding, normalize
+  blocks-shortcode heading IDs and keep old IDs as alias
 
 ## CI / tooling only
 
-- `66a0c7d` Update README, contrib docs for deployment and release process
-- `6c1e391` [CI] Drop temp site-copy code and more
-- `4137043` Temporary: copy public to root while build config is in transition
-- `cb75133` [CI] Move Netlify config to docsy.dev subrepo
-- `ba7d0ec` Tasks, plan, and draft blog post for 0.14.0
-- `08fe966` Add CI/CD info about Prettier and i18n directory
-- `08a9569` Upgrade Prettier
-- `1dfd1a0` Format
-- `83db5b9` Format
-- `ef0e8b8` Update compare-i18n-toml-yaml.pl
-- `1560cec` Update refresh-sass-variables.pl
-- `7bcae61` Don't format \_variables_forward.scss
-- `24c01d23` Add read-only contents permission to workflows
+- `66a0c7d` (#2440) Update README, contrib docs for deployment and release
+  process
+- `6c1e391` (#2439) [CI] Drop temp site-copy code and more
+- `4137043` (#2437) Temporary: copy public to root while build config is in
+  transition
+- `cb75133` (#2437) [CI] Move Netlify config to docsy.dev subrepo
+- `ba7d0ec` (#2456) Tasks, plan, and draft blog post for 0.14.0
+- `08fe966` (#2468) Add CI/CD info about Prettier and i18n directory
+- `08a9569` (#2468) Upgrade Prettier
+- `1dfd1a0` (#2468) Format
+- `83db5b9` (#2468) Format
+- `ef0e8b8` (#2468) Update compare-i18n-toml-yaml.pl
+- `1560cec` (#2469) Update refresh-sass-variables.pl
+- `7bcae61` (#2469) Don't format \_variables_forward.scss
+- `24c01d23` (#2479) Add read-only contents permission to workflows
 
 ## Dependency / package configuration updates
 
-- `b7f7335` (`#2428`) Update all packages other than Hugo
-- `9334955` (`#2430`) Upgrade Hugo to 0.154.3
-- `b52c265` (`#2432`) Update Hugo to 0.154.5
-- `6399194a` (`#2486`) Update devDeps, incl. Hugo to 0.155.0
+- `b7f7335` (#2428) Update all packages other than Hugo
+- `9334955` (#2430) Upgrade Hugo to 0.154.3
+- `b52c265` (#2432) Update Hugo to 0.154.5
+- `6399194a` (#2486) Update devDeps, incl. Hugo to 0.155.0
 
 [commits since v0.13.0]: https://github.com/google/docsy/compare/v0.13.0...main

--- a/tasks/0.14/issue-audit.md
+++ b/tasks/0.14/issue-audit.md
@@ -4,7 +4,7 @@ date: 2026-01-16
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `db32f5b` on `main`.
+> Report refreshed for commits through `3753ff78` on `main`.
 
 Assessment of issues addressed by [commits since
 v0.13.0][commits since v0.13.0].

--- a/tasks/0.14/issue-mapping.md
+++ b/tasks/0.14/issue-mapping.md
@@ -4,7 +4,7 @@ date: 2026-01-16
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `5365d35` on `main`.
+> Report refreshed for commits through `3753ff78` on `main`.
 
 Mapping [commits since v0.13.0][] to their originating issues (when known).
 
@@ -16,64 +16,69 @@ Mapping [commits since v0.13.0][] to their originating issues (when known).
 
 ## Feature & bug-fix commits
 
-| Commit     | PR      | Summary                                                                | Originating Issue(s) | Notes                                      |
-| ---------- | ------- | ---------------------------------------------------------------------- | -------------------- | ------------------------------------------ |
-| `69d4d6c`  | `#2415` | Update changelog anchors, release process docs, and vers to 0.13.1-dev | —                    | Release process documentation              |
-| `5fd8175`  | `#2427` | docsy.dev: set to_year to "present", and shortcode cleanup             | —                    | Documentation maintenance                  |
-| `53d4393`  | `#2434` | Update alias format in get started page so it works as a fallback too  | —                    | Documentation fix                          |
-| `bf9f559`  | `#2435` | chore: complete German localization                                    | —                    | Translation update                         |
-| `8607ceb`  | —       | i18n: zh_cn and zh_tw                                                  | —                    | Translation updates for Chinese locales    |
-| `48f9c75`  | —       | Update Serbian (cyrillic & latin)                                      | —                    | Translation updates                        |
-| `13ba7b2`  | —       | Add author for Serbian translations                                    | —                    | Translation metadata                       |
-| `02479b2`  | —       | Add feedback section and table of contents to Bengali localization     | —                    | Translation additions                      |
-| `9cca91a`  | —       | Update feedback section translations in Bengali localization           | —                    | Translation updates                        |
-| `1465641`  | —       | Fix newline issue in Bengali localization for table of contents        | —                    | Translation bug fix                        |
-| `73a7b3f`  | —       | Add Hugo Markdown-style alert support and docs                         | —                    | Documentation feature                      |
-| `68cb0e7`  | —       | Add docs version as a badge                                            | —                    | Documentation enhancement                  |
-| `884d714`  | —       | Add version to docs landing page, bump version to 0.14.0-dev           | —                    | Version tracking                           |
-| `62d4aac`  | —       | Add site build info and build documentation                            | —                    | Documentation addition                     |
-| `4a11ed0`  | —       | Add AGENTS.md                                                          | —                    | Documentation for AI agents                |
-| `e1bb622`  | —       | chore: Rename 'site' docs section to 'project' and update links        | —                    | Documentation reorganization               |
-| `113cc39`  | —       | Move pages to About section                                            | —                    | Documentation reorganization               |
-| `8a2528f`  | —       | Update links                                                           | —                    | Documentation maintenance                  |
-| `a1075cf`  | —       | Migrate i18n files from TOML to YAML and add conversion scripts        | —                    | i18n format migration                      |
-| `a989a32`  | —       | Fix left sidebar height                                                | —                    | UI fix                                     |
-| `29bc71f`  | —       | Add support for custom attributes in blockquote alerts                 | —                    | Alert feature enhancement                  |
-| `c9f4299`  | —       | Add alert label translations to i18n files                             | —                    | i18n translation additions                 |
-| `3396c03`  | —       | Convert i18n/uk.toml to .yaml                                          | —                    | i18n format migration                      |
-| `ec122d8`  | —       | Delete i18n/uk.toml since we have a .yaml format now                   | —                    | i18n format migration cleanup              |
-| `f81406a`  | —       | Convert most shortcode alerts to markdown, and more                    | —                    | Alert conversion to Markdown               |
-| `a600e53`  | —       | Convert Bengali translations from TOML to YAML                         | —                    | i18n format migration                      |
-| `95c6a2d`  | —       | Add Bengali translations for alert labels                              | —                    | i18n translation additions                 |
-| `d2a63db`  | —       | Address Hugo deprecation msg related to mounts                         | —                    | Hugo deprecation fix                       |
-| `93fe8ba`  | —       | Convert Chinese i18n files from TOML to YAML                           | —                    | i18n format migration                      |
-| `81613ae`  | —       | Convert Japanese translations from TOML to YAML                        | —                    | i18n format migration                      |
-| `23fea73`  | —       | Add alert labels and all-rights-reserved in Japanese                   | —                    | i18n translation additions                 |
-| `1a25ddf`  | —       | Update i18n/ja.yaml                                                    | —                    | i18n translation updates                   |
-| `6cbe364`  | —       | Add alert label translations for zh-cn and zh-tw                       | —                    | i18n translation additions                 |
-| `9dab6fe`  | —       | zh-cn, use `note: 说明`                                                | —                    | i18n translation updates                   |
-| `e79719f`  | —       | Create he.toml                                                         | —                    | New locale addition                        |
-| `731531a`  | —       | Update i18n/he.toml                                                    | —                    | i18n translation updates                   |
-| `f4526dc`  | —       | Update i18n/he.toml                                                    | —                    | i18n translation updates                   |
-| `0d7d78d`  | —       | Convert Hebrew translation file to YAML                                | —                    | i18n format migration                      |
-| `ebc264e`  | —       | Add alert and table of contents labels to Hebrew i18n                  | —                    | i18n translation additions                 |
-| `791a707`  | —       | Convert all remaining i18n files to YAML, add helper scripts           | —                    | i18n format migration                      |
-| `93322ff`  | —       | Fix comment across locales                                             | —                    | i18n translation fixes                     |
-| `1e093f3`  | —       | Namespace SCSS files, and make adjustments                             | —                    | SCSS refactoring                           |
-| `396ad66`  | —       | Fix broken link Bump versions of mentioned prerequisites               | —                    | Documentation fix                          |
-| `b3cb2a7`  | —       | Update Swagger UI customization instructions                           | —                    | Documentation fix                          |
-| `6f8f85a`  | —       | Add nested `sidebar_root_for` to docs                                  | —                    | Documentation addition                     |
-| `11bc51a`  | `#2470` | bugfix: nested sidebar_root_for                                        | —                    | Bug fix                                    |
-| `bf7c497f` | —       | Update 0.14.0 release notes and changelog details                      | —                    | Release documentation                      |
-| `4f855a02` | `#2480` | Refactor blocks/cover and pageinfo shortcodes                          | `#939`               | **Breaking**: shortcode content processing |
-| `61282a64` | `#2465` | KaTeX use: move media type declaration to theme's config file          | —                    | KaTeX configuration improvement            |
-| `e7b91366` | `#2481` | docsy.dev: minor reorg and refactor SCSS                               | —                    | SCSS refactoring (docsy.dev)               |
-| `b1b03b95` | `#2487` | docsy.dev config: switch to using sites.matrix                         | —                    | Configuration update                       |
-| `c3035f02` | `#2488` | Reformat and clarify Docsy 'Get Started' pages                         | —                    | Documentation clarification                |
-| `7cc86a3e` | `#2489` | Refactor navbar and layout SCSS, update examples                       | —                    | SCSS refactoring (navbar)                  |
-| `ca4a67eb` | `#2490` | Add new Norwegian translations for UI and alerts                       | —                    | Translation addition (Norwegian)           |
-| `5ac2b165` | `#2491` | Refactor extra and footer SCSS, add footer border                      | —                    | SCSS refactoring (footer)                  |
-| `5365d35d` | `#2494` | chore(hugo.yaml): cleanup config and add some explanation              | —                    | Configuration cleanup                      |
+| Commit     | PR      | Summary                                                                                               | Originating Issue(s) | Notes                                                |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------- |
+| `69d4d6c`  | `#2415` | Update changelog anchors, release process docs, and vers to 0.13.1-dev                                | —                    | Release process documentation                        |
+| `5fd8175`  | `#2427` | docsy.dev: set to_year to "present", and shortcode cleanup                                            | —                    | Documentation maintenance                            |
+| `53d4393`  | `#2434` | Update alias format in get started page so it works as a fallback too                                 | —                    | Documentation fix                                    |
+| `bf9f559`  | `#2435` | chore: complete German localization                                                                   | —                    | Translation update                                   |
+| `8607ceb`  | —       | i18n: zh_cn and zh_tw                                                                                 | —                    | Translation updates for Chinese locales              |
+| `48f9c75`  | —       | Update Serbian (cyrillic & latin)                                                                     | —                    | Translation updates                                  |
+| `13ba7b2`  | —       | Add author for Serbian translations                                                                   | —                    | Translation metadata                                 |
+| `02479b2`  | —       | Add feedback section and table of contents to Bengali localization                                    | —                    | Translation additions                                |
+| `9cca91a`  | —       | Update feedback section translations in Bengali localization                                          | —                    | Translation updates                                  |
+| `1465641`  | —       | Fix newline issue in Bengali localization for table of contents                                       | —                    | Translation bug fix                                  |
+| `73a7b3f`  | —       | Add Hugo Markdown-style alert support and docs                                                        | —                    | Documentation feature                                |
+| `68cb0e7`  | —       | Add docs version as a badge                                                                           | —                    | Documentation enhancement                            |
+| `884d714`  | —       | Add version to docs landing page, bump version to 0.14.0-dev                                          | —                    | Version tracking                                     |
+| `62d4aac`  | —       | Add site build info and build documentation                                                           | —                    | Documentation addition                               |
+| `4a11ed0`  | —       | Add AGENTS.md                                                                                         | —                    | Documentation for AI agents                          |
+| `e1bb622`  | —       | chore: Rename 'site' docs section to 'project' and update links                                       | —                    | Documentation reorganization                         |
+| `113cc39`  | —       | Move pages to About section                                                                           | —                    | Documentation reorganization                         |
+| `8a2528f`  | —       | Update links                                                                                          | —                    | Documentation maintenance                            |
+| `a1075cf`  | —       | Migrate i18n files from TOML to YAML and add conversion scripts                                       | —                    | i18n format migration                                |
+| `a989a32`  | —       | Fix left sidebar height                                                                               | —                    | UI fix                                               |
+| `29bc71f`  | —       | Add support for custom attributes in blockquote alerts                                                | —                    | Alert feature enhancement                            |
+| `c9f4299`  | —       | Add alert label translations to i18n files                                                            | —                    | i18n translation additions                           |
+| `3396c03`  | —       | Convert i18n/uk.toml to .yaml                                                                         | —                    | i18n format migration                                |
+| `ec122d8`  | —       | Delete i18n/uk.toml since we have a .yaml format now                                                  | —                    | i18n format migration cleanup                        |
+| `f81406a`  | —       | Convert most shortcode alerts to markdown, and more                                                   | —                    | Alert conversion to Markdown                         |
+| `a600e53`  | —       | Convert Bengali translations from TOML to YAML                                                        | —                    | i18n format migration                                |
+| `95c6a2d`  | —       | Add Bengali translations for alert labels                                                             | —                    | i18n translation additions                           |
+| `d2a63db`  | —       | Address Hugo deprecation msg related to mounts                                                        | —                    | Hugo deprecation fix                                 |
+| `93fe8ba`  | —       | Convert Chinese i18n files from TOML to YAML                                                          | —                    | i18n format migration                                |
+| `81613ae`  | —       | Convert Japanese translations from TOML to YAML                                                       | —                    | i18n format migration                                |
+| `23fea73`  | —       | Add alert labels and all-rights-reserved in Japanese                                                  | —                    | i18n translation additions                           |
+| `1a25ddf`  | —       | Update i18n/ja.yaml                                                                                   | —                    | i18n translation updates                             |
+| `6cbe364`  | —       | Add alert label translations for zh-cn and zh-tw                                                      | —                    | i18n translation additions                           |
+| `9dab6fe`  | —       | zh-cn, use `note: 说明`                                                                               | —                    | i18n translation updates                             |
+| `e79719f`  | —       | Create he.toml                                                                                        | —                    | New locale addition                                  |
+| `731531a`  | —       | Update i18n/he.toml                                                                                   | —                    | i18n translation updates                             |
+| `f4526dc`  | —       | Update i18n/he.toml                                                                                   | —                    | i18n translation updates                             |
+| `0d7d78d`  | —       | Convert Hebrew translation file to YAML                                                               | —                    | i18n format migration                                |
+| `ebc264e`  | —       | Add alert and table of contents labels to Hebrew i18n                                                 | —                    | i18n translation additions                           |
+| `791a707`  | —       | Convert all remaining i18n files to YAML, add helper scripts                                          | —                    | i18n format migration                                |
+| `93322ff`  | —       | Fix comment across locales                                                                            | —                    | i18n translation fixes                               |
+| `1e093f3`  | —       | Namespace SCSS files, and make adjustments                                                            | —                    | SCSS refactoring                                     |
+| `396ad66`  | —       | Fix broken link Bump versions of mentioned prerequisites                                              | —                    | Documentation fix                                    |
+| `b3cb2a7`  | —       | Update Swagger UI customization instructions                                                          | —                    | Documentation fix                                    |
+| `6f8f85a`  | —       | Add nested `sidebar_root_for` to docs                                                                 | —                    | Documentation addition                               |
+| `11bc51a`  | `#2470` | bugfix: nested sidebar_root_for                                                                       | —                    | Bug fix                                              |
+| `bf7c497f` | —       | Update 0.14.0 release notes and changelog details                                                     | —                    | Release documentation                                |
+| `4f855a02` | `#2480` | Refactor blocks/cover and pageinfo shortcodes                                                         | `#939`               | **Breaking**: shortcode content processing           |
+| `61282a64` | `#2465` | KaTeX use: move media type declaration to theme's config file                                         | —                    | KaTeX configuration improvement                      |
+| `e7b91366` | `#2481` | docsy.dev: minor reorg and refactor SCSS                                                              | —                    | SCSS refactoring (docsy.dev)                         |
+| `b1b03b95` | `#2487` | docsy.dev config: switch to using sites.matrix                                                        | —                    | Configuration update                                 |
+| `c3035f02` | `#2488` | Reformat and clarify Docsy 'Get Started' pages                                                        | —                    | Documentation clarification                          |
+| `7cc86a3e` | `#2489` | Refactor navbar and layout SCSS, update examples                                                      | —                    | SCSS refactoring (navbar)                            |
+| `ca4a67eb` | `#2490` | Add new Norwegian translations for UI and alerts                                                      | —                    | Translation addition (Norwegian)                     |
+| `5ac2b165` | `#2491` | Refactor extra and footer SCSS, add footer border                                                     | —                    | SCSS refactoring (footer)                            |
+| `5365d35d` | `#2494` | chore(hugo.yaml): cleanup config and add some explanation                                             | —                    | Configuration cleanup                                |
+| `34ab5de0` | `#2498` | Fix grammatical error in Norwegian translation                                                        | —                    | Translation fix                                      |
+| `061b3762` | `#2483` | Use "front matter" rather than "frontmatter"                                                          | —                    | Documentation wording                                |
+| `2aef9560` | `#2502` | Update 0.14 release notes, Hugo upgrade guide, style adjustments, and more                            | —                    | Release documentation                                |
+| `09b9a9f1` | `#2495` | Only set td-sidebar-root-up-icon for links that are the tree root                                     | —                    | Sidebar UX fix                                       |
+| `3753ff78` | `#2505` | Reorganize SCSS, fix scroll padding, normalize blocks-shortcode heading IDs and keep old IDs as alias | —                    | SCSS partial, fragment scroll, shortcode doc aliases |
 
 ## CI / tooling commits
 

--- a/tasks/0.14/release-wrapup.plan.md
+++ b/tasks/0.14/release-wrapup.plan.md
@@ -79,7 +79,7 @@ Repeat when new commits land on `main` do the following:
 - Take note of fixes and features that are not yet documented in the blog post
   or changelog.
 
-Report refreshed for commits through [5365d35].
+Report refreshed for commits through [3753ff78].
 
 ### 0.14.0 blog post
 

--- a/tasks/0.14/wrapup-report.md
+++ b/tasks/0.14/wrapup-report.md
@@ -4,7 +4,7 @@ date: 2026-01-16
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `5365d35` on `main`.
+> Report refreshed for commits through `3753ff78` on `main`.
 
 ## Highlights since v0.13.0
 
@@ -59,6 +59,15 @@ cSpell:ignore: docsy
 - **blocks/cover shortcode refactoring**: Removed pre-Hugo-0.54.x compatibility
   code (breaking change - content processing now relies on Hugo's native
   shortcode delimiter behavior) ([#939], [#2480]).
+- **Scroll and fragment navigation**: Scroll padding (CSS `scroll-padding-top`)
+  and anchor-alias class (scroll-margin-top fallback) for fragment navigation
+  below fixed navbar; scroll styling moved to `_scroll.scss` partial ([#2505]).
+- **Shortcode docs heading IDs**: Normalized blocks shortcode heading IDs and
+  kept legacy IDs as span aliases for backward-compatible deep links ([#2505]).
+- **Sidebar root icon**: Only set `td-sidebar-root-up-icon` for links that are
+  the tree root ([#2495]).
+- **Documentation and style**: Release notes and Hugo upgrade guide updates,
+  "front matter" wording, Norwegian translation fix ([#2483], [#2498], [#2502]).
 
 ## References
 
@@ -71,6 +80,11 @@ cSpell:ignore: docsy
   [../docsy.dev/content/en/blog/2025/0.13.0.md](../docsy.dev/content/en/blog/2025/0.13.0.md)
 
 [#2404]: https://github.com/google/docsy/issues/2404
+[#2483]: https://github.com/google/docsy/pull/2483
+[#2495]: https://github.com/google/docsy/pull/2495
+[#2498]: https://github.com/google/docsy/pull/2498
+[#2502]: https://github.com/google/docsy/pull/2502
+[#2505]: https://github.com/google/docsy/pull/2505
 [v0.13.0...main]: https://github.com/google/docsy/compare/v0.13.0...main
 
 ## Action items


### PR DESCRIPTION
- Followup to #2505
- Completes the fix to #744 by updating the UG
- Adds heading‑alias guidance and references; refreshs 0.14.0 blog and changelog notes; clarifis experimental labeling in look‑and‑feel docs

**Preview**:

- https://deploy-preview-2506--docsydocs.netlify.app/blog/2026/0.14.0/
- https://deploy-preview-2506--docsydocs.netlify.app/docs/content/navigation/#in-page-targets-tip
