### PR TITLE
Add extra styles for cover CTA/layouts and update 0.14.0 blog post

### DIFF
--- a/assets/scss/td/extra/_buttons.scss
+++ b/assets/scss/td/extra/_buttons.scss
@@ -1,0 +1,15 @@
+$td-cta-buttons-row-breakpoint: sm !default;
+
+.td-cta-buttons {
+  --td-cta-buttons-gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--td-cta-buttons-gap);
+
+  @if $td-cta-buttons-row-breakpoint {
+    @include media-breakpoint-up($td-cta-buttons-row-breakpoint) {
+      flex-direction: row;
+    }
+  }
+}

--- a/assets/scss/td/extra/_index.scss
+++ b/assets/scss/td/extra/_index.scss
@@ -1,8 +1,11 @@
 // Experimental extra styles that projects can test run. These styles might
 // eventually be merged into the core Docsy theme.
 
+@import 'buttons';
+@import 'main-container';
 @import 'navbar';
 
+// -----------------------------------------------------------------------------
 // Margin fix for nested lists [EXPERIMENTAL]
 
 body {

--- a/assets/scss/td/extra/_main-container.scss
+++ b/assets/scss/td/extra/_main-container.scss
@@ -1,0 +1,44 @@
+// Styles for docs-like pages without left sidebar
+
+.td-no-left-sidebar .td-main {
+  // Hide left sidebar
+  .td-sidebar {
+    display: none !important;
+  }
+
+  // Adjust right/ToC sidebar, when visible (i.e., at md and up).
+  .td-sidebar-toc {
+    @include media-breakpoint-up(md) {
+      @extend .col-md-2;
+      display: block !important;
+    }
+  }
+
+  // The <main> element sibling of the ToC sidebar
+  > div > main {
+    // Always 10 col wide (unless the ToC sidebar is hidden)
+    @extend .col-md-10;
+    @extend .col-xl-10;
+
+    @include media-breakpoint-up(md) {
+      padding-right: 3rem;
+    }
+
+    @include media-breakpoint-up(lg) {
+      // Center content on larger screens
+
+      .td-content,
+      .td-breadcrumbs {
+        max-width: 80%;
+        margin-left: auto;
+        margin-right: auto;
+
+        // Cancel .td-max-width-on-larger-screens
+        // TODO: generalize this?
+        > * {
+          max-width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/docsy.dev/assets/scss/_styles_project.scss
+++ b/docsy.dev/assets/scss/_styles_project.scss
@@ -10,9 +10,10 @@
 @import 'blog';
 @import 'navbar';
 
-// To keep the `td/extra` color adjustments, while dropping the text-decoration,
-// use the following class (on your body element), or copy the class styles to
-// your project's style file. This class isn't used, it's just an example.
+// EXAMPLE: To keep the `td/extra` color adjustments, while dropping the
+// text-decoration, use the following class (on your body element), or copy the
+// class styles to your project's style file. This class isn't used, it's just
+// an example.
 ._td-navbar-no-decoration {
   .td-navbar {
     .nav-link {

--- a/docsy.dev/content/en/_index.md
+++ b/docsy.dev/content/en/_index.md
@@ -2,21 +2,36 @@
 title: Docsy
 description: A Hugo theme for creating great technical documentation sites
 params:
-  ui: { navbar_theme: dark}
+  ui: { navbar_theme: dark }
+  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
-{{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full" %}}
+{{% blocks/cover
+  title="Welcome to Docsy!"
+  image_anchor="top"
+  height="full td-below-navbar"
+%}}
+
+<!-- prettier-ignore -->
 {{% param description %}}
 {.display-6}
 
-<a class="btn btn-lg btn-primary me-3" href="about/">Learn More</a>
-<a class="btn btn-lg btn-secondary" href="docs/get-started/">Get started</a>
-{.p-initial .my-5}
+<!-- prettier-ignore -->
+<div class="td-cta-buttons my-5">
+  <button {{% _param btn-lg primary %}} href="about/">
+    Learn more
+  </button>
+  <button {{% _param btn-lg secondary %}} href="docs/get-started/">
+    Get started
+  </button>
+</div>
 
 {{% blocks/link-down color="info" %}}
+
 {{% /blocks/cover %}}
 
 {{% blocks/lead color="primary" %}}
+
 Docsy is a theme for the Hugo static site generator that's specifically designed
 for technical documentation sets. Our aim is to help you get a working
 documentation site up and running as easily as possible, so you can concentrate

--- a/docsy.dev/content/en/about/index.md
+++ b/docsy.dev/content/en/about/index.md
@@ -4,7 +4,7 @@ linkTitle: About
 menu: {main: {weight: 10}}
 ---
 
-{{% blocks/cover title="About Docsy" height="auto" %}}
+{{% blocks/cover title="About Docsy" height="auto td-below-navbar" %}}
 
 Docsy is a pre-configured Hugo theme that provides the core features and behaviors needed to create a technical documentation site. Use Docsy to set up your documentation website, including an optional Blog section, and then spend your time focusing on authoring technical content. Depending on how you choose to configure Docsy and whether you use a hosting service that supports continuous builds, you can even just add your Markdown or HTML content file into a folder on your source repository, and then sit back while it automatically gets added to your site - complete with updated menus.
 

--- a/docsy.dev/content/en/blog/2025/0.13.0.md
+++ b/docsy.dev/content/en/blog/2025/0.13.0.md
@@ -14,12 +14,12 @@ cSpell:ignore: docsy FOUC lookandfeel mhchem katex notoc lightdark
 
 {{% card header="Highlights" %}}
 
-- {{% _param FA_LG fire warning %}} <span>Docsy [0.13.0] includes the **_[most
+- {{% _param FAS_LG fire warning %}} <span>Docsy [0.13.0] includes the **_[most
   upvoted][]_ enhancement** [request of 2025][], and more.</span>
-- {{% _param FA_LG check success %}} <span>This release has new features and
+- {{% _param FAS_LG check success %}} <span>This release has new features and
   only
   [minor breaking changes](#breaking-changes).[^explain-report-format]</span>
-- {{% _param FA_LG robot info %}} <span>Read about
+- {{% _param FAS_LG robot info %}} <span>Read about
   [our experiences](#upgrading-and-ai) using AI to
   [upgrade Docsy projects](#upgrade).</span>
 
@@ -36,12 +36,12 @@ cSpell:ignore: docsy FOUC lookandfeel mhchem katex notoc lightdark
 
 Docsy [0.13.0] comes with the following notable features and fixes:
 
-- {{% _param FA compass "" %}} [Navigation and UX](#navigation-and-ux)
+- {{% _param FAS compass "" %}} [Navigation and UX](#navigation-and-ux)
   improvements including the **_most upvoted_ enhancement** [request of 2025][]:
   [Active TOC entry tracking](#active-toc-entry-tracking) ([#349], [#2289])
-- {{% _param FA code "" %}} [Alert shortcode](#alert-shortcode) rewrite for
+- {{% _param FAS code "" %}} [Alert shortcode](#alert-shortcode) rewrite for
   better Markdown support
-- {{% _param FA universal-access "" %}} [Accessibility](#accessibility)
+- {{% _param FAS universal-access "" %}} [Accessibility](#accessibility)
   enhancements for better color contrast and dark mode support
 
 ## Ready to upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
@@ -54,10 +54,10 @@ Docsy [0.13.0] comes with the following notable features and fixes:
 - Optionally skim:
   - {{% _param NEW %}} New features
   - [Other notable changes](#other-notable-changes)
-- {{% _param FA rocket primary %}} Jump to
+- {{% _param FAS rocket primary %}} Jump to
   [Upgrade to 0.13.0](#upgrading-and-ai) once you are ready.
 
-## {{% _param FA compass "" %}} Navigation and UX improvements {#navigation-and-ux}
+## {{% _param FAS compass "" %}} Navigation and UX improvements {#navigation-and-ux}
 
 ### {{% _param NEW %}} Active TOC entry tracking {#active-toc-entry-tracking}
 
@@ -149,7 +149,7 @@ additional navigation items ([#2406]).
 
 [#2406]: https://github.com/google/docsy/pull/2406
 
-## {{% _param FA code "" %}} Alert shortcode improvements {#alert-shortcode}
+## {{% _param FAS code "" %}} Alert shortcode improvements {#alert-shortcode}
 
 As of Docsy 0.13.0, `alert` shortcode content is processed differently when
 called as Markdown (`{{%/* alert */%}}`): the inner Markdown is now passed
@@ -167,14 +167,14 @@ This change means that your alerts can now:
 For details and examples, including important formatting requirements, see
 [alert]. For implementation details, see PR [#941].
 
-## {{% _param FA universal-access info %}} Accessibility improvements {#accessibility}
+## {{% _param FAS universal-access info %}} Accessibility improvements {#accessibility}
 
 - <i class="fa-solid fa-palette fa-lg text-info px-1"></i> **Color contrast**
   has been improved throughout the theme, and Docsy now falls back to Bootstrap
   defaults for typography and color. This ensures better accessibility
   compliance out of the box. For details, see [#2285] and [Site colors][].
 
-- {{% _param FA palette info %}} **Color contrast** improvements for dark mode:
+- {{% _param FAS palette info %}} **Color contrast** improvements for dark mode:
   - TOC entry color contrast has been fixed when user preferences differ from
     system settings ([#2379]).
 
@@ -183,10 +183,10 @@ For details and examples, including important formatting requirements, see
     to pick colors with good color-contrast][].
     {{% _param BADGE EXPERIMENTAL info %}}
 
-- {{% _param FA moon info %}} **[Dark mode][]**:
-  - {{% _param FA bolt warning %}} [Flash Of Unstyled Content][] (FOUC) has been
-    fixed ([#2332]).
-  - {{% _param FA search info %}} **Google search** results page now supports
+- {{% _param FAS moon info %}} **[Dark mode][]**:
+  - {{% _param FAS bolt warning %}} [Flash Of Unstyled Content][] (FOUC) has
+    been fixed ([#2332]).
+  - {{% _param FAS search info %}} **Google search** results page now supports
     dark-mode ([#2387]). {{%_param BADGE EXPERIMENTAL info %}}
 
   > [!SECONDARY] Dark mode quick reference
@@ -253,17 +253,17 @@ For details and examples, including important formatting requirements, see
 [diagrams-formulae]:
   /docs/content/diagrams-and-formulae/#latex-support-with-katex
 
-## {{% _param FA rocket primary %}} Upgrade to 0.13.0 {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to 0.13.0 {#upgrade}
 
 ### Prerequisites
 
-> {{% _param FA triangle-exclamation warning %}} **We recommend** that you
+> {{% _param FAS triangle-exclamation warning %}} **We recommend** that you
 > [Upgrade to Docsy 0.12.0][] first because it contains significant breaking
 > changes.
 
 ### Upgrade procedure and AI help {#upgrading-and-ai}
 
-> {{% _param FA robot info %}} Have you used AI to help you upgrade Docsy? It
+> {{% _param FAS robot info %}} Have you used AI to help you upgrade Docsy? It
 > can be a big help!
 
 The [0.12.0 upgrade guide][] was written with both human project maintainers and
@@ -319,10 +319,10 @@ currently _most upvoted_ enhancement requests include:
 <!-- prettier-ignore -->
 > [!INFO] Your opinion counts!
 >
-> - {{% _param FA thumbs-up success %}} If you'd like a feature or fix to be
+> - {{% _param FAS thumbs-up success %}} If you'd like a feature or fix to be
 >   considered for inclusion in an upcoming release, **upvote** (with a thumbs
 >   up) the associated issue or PR.
-> - {{% _param FA star warning %}} If you find Docsy useful, consider [starring
+> - {{% _param FAS star warning %}} If you find Docsy useful, consider [starring
 >   the repository][star-the-repo] to show your support.
 {._list-unstyled}
 

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -16,13 +16,13 @@ cSpell:ignore: docsy subrepo lightdark lookandfeel
 
 {{% card header="Highlights" %}}
 
-- {{% _param FA_LG palette success %}}
+- {{% _param FAS_LG palette success %}}
   <span>[**Styles and customization**](#styles-customization): navbar
   improvements, reorganized SCSS files</span>
-- {{% _param FA_LG book info %}} <span>**Content and localization**: new
+- {{% _param FAS_LG book info %}} <span>**Content and localization**: new
   Markdown [alert syntax](#alerts) and
   [internationalization](#other-notable-changes) improvements</span>
-- {{% _param FA_LG triangle-exclamation warning %}}
+- {{% _param FAS_LG triangle-exclamation warning %}}
   <span>**[Hugo 0.155.0 requirement](#hugo)**, and 0.153+ breaking and notable
   changes</span>
 
@@ -62,8 +62,10 @@ cSpell:ignore: docsy subrepo lightdark lookandfeel
     [Hugo 0.155.0 requirement and 0.153+ breaking changes](#hugo)
 - Optionally skim:
   - {{% _param NEW %}} New features (look for the green checkmark icon)
+  - {{% _param CLEANUP %}} Cleanup / improvement opportunities (look for this
+    icon)
   - [Other notable changes](#other-notable-changes)
-- {{% _param FA rocket primary %}} Jump to [Upgrade to 0.14.0](#upgrade) once
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.14.0](#upgrade) once
   you're ready
 
 ## {{% _param NEW %}} Markdown alert syntax {#alerts}
@@ -88,8 +90,9 @@ syntax for new content. For the new alert syntax and customization, see
 
 ### Actions (optional) {#alerts-actions}
 
-**Applies if** your project uses the `alert` shortcode. Consider migrating to
-Markdown alerts for consistency and better authoring/tooling support:
+{{% _param CLEANUP %}} **Applies if** your project uses the `alert` shortcode.
+Consider migrating to Markdown alerts for consistency and better
+authoring/tooling support:
 
 - Use Markdown alert syntax for new content.
 - Where the output is equivalent, replace existing `alert` shortcodes with the
@@ -149,9 +152,17 @@ Learn more about the default [Navbar] appearance and [Customizing the navbar][].
 
 You may need to update your project in the following areas:
 
-- {{% _param BREAKING %}} **Navbar light/dark color theme**: applies if you want
-  to restore the previous (always dark) behavior. Set `params.ui.navbar_theme`
-  to `dark` ([details][navbar-lightdark-theme]).
+- <!-- markdownlint-disable no-space-in-emphasis -->
+
+  {{% _param BREAKING %}} / {{% _param NEW %}} **Navbar light/dark color
+  theme**: the always-dark navbar was an early Docsy constraint and isn’t a fit
+  for all sites. You can now choose the theme that best matches your project’s
+  overall design.
+  - {{% _param CLEANUP %}} If your design does not require a dark navbar, you
+    may be able to drop any overrides you added just to force that theme.
+  - {{% _param BREAKING %}} If your design does require a dark navbar, set
+    `params.ui.navbar_theme` to `dark` to restore the previous behavior
+    ([details][navbar-lightdark-theme]).
 
 - {{% _param BREAKING %}} **Navbar over cover**: applies if your project targets
   navbar cover translucency classes.
@@ -159,9 +170,9 @@ You may need to update your project in the following areas:
   - Replace `.navbar-bg-on-scroll` and `.navbar-bg-onscroll--fade` with
     `.td-navbar-transparent` (used alongside `.td-navbar-cover`).
 
-- **Height and variables**: applies if you customize navbar height or styling.
-  Review and simplify your customizations using the new variables and styles —
-  see [Customizing the navbar][].
+- {{% _param CLEANUP %}} **Height and variables**: applies if you customize
+  navbar height or styling. Review and simplify your customizations using the
+  new variables and styles — see [Customizing the navbar][].
 
 - **Navbar partial overrides:** applies if your project overrides the navbar
   partial. Review [_nav.html][] for changes.
@@ -260,7 +271,11 @@ feel for your project, see [Project styles][] that covers:
 #### Actions: required and optional {#scss-actions}
 
 **Applies if** your project has any of the files in `assets/scss/` listed next,
-because you are overriding Docsy's internal SCSS files.
+because you are overriding Docsy's internal SCSS files.[^scss-action-note]
+
+[^scss-action-note]:
+    Except for [Swagger UI style customization](#swagger-scss), this is not a
+    breaking change since it only affects internal files.
 
 <details>
 <summary>
@@ -352,10 +367,15 @@ Two changes to [blocks/cover], the first of which is a breaking change:
   Use Hugo's shortcode [Markdown call syntax][]: `{{%/* */%}}`. Otherwise,
   Markdown content might not render correctly.
 
-- {{% _param NEW %}} **Applies if** you want to position your `blocks/cover`
-  below the navbar rather than behind it. Add the `td-below-navbar` helper class
-  to your `blocks/cover` call. For example: `height="auto td-below-navbar"`. See
-  [Below-navbar height adjustment][].
+- {{% _param NEW %}} **Recommended** for most projects.[^below-navbar-default]
+  If you want to position your `blocks/cover` below the navbar (instead of
+  behind it), add the `td-below-navbar` helper class to your `blocks/cover`
+  call. For example: `height="auto td-below-navbar"`. See [Below-navbar height
+  adjustment][].
+
+  [^below-navbar-default]:
+      We expect `td-below-navbar` to be the best design option for most
+      projects, and it may become the default in a future release.
 
 [below-navbar height adjustment]: /docs/content/shortcodes/#td-below-navbar
 [blocks/cover]: /docs/content/shortcodes/#blocks-cover
@@ -376,7 +396,7 @@ when moving to Hugo 0.153+, see [Hugo 0.153+ breaking changes & issues
 
 ## Other notable Docsy changes {#other-notable-changes}
 
-### {{% _param FA globe "" %}} Internationalization
+### {{% _param FAS globe "" %}} Internationalization
 
 Summary of changes:
 
@@ -385,8 +405,8 @@ Summary of changes:
 - New locale: Hebrew.
 - Alert type labels added to multiple locales ([#2390]).
 
-**Action** (optional): applies if your project has i18n files. You have an
-opportunity to clean up and reduce [technical debt][]:
+{{% _param CLEANUP %}} **Action** (optional): applies if your project has i18n
+files. You have an opportunity to clean up and reduce [technical debt][]:
 
 - Remove redundant entries from your files where Docsy's additions or updates
   already cover them.
@@ -401,10 +421,12 @@ Docsy 0.14.0 includes the following style improvements and fixes:
 - `<details>` margin fixes
 - TOC h1 entries made slightly bolder so they are more visually distinct
 
-Experimental extra styles:
+[Experimental][] extra styles:
 
+- CTA buttons group style: use the `td-cta-buttons` class
 - Navbar link decoration for active and hover states
 - Nested-list margin fix for the last child
+- No-left-sidebar layout: use the `td-no-left-sidebar` class
 
 For details, see [Extra styles][].
 
@@ -428,7 +450,7 @@ changes require action:
 - [Breaking change](/project/about/changelog/#breaking-change)
 - [Official support limits](/project/about/changelog/#official-support)
 
-## {{% _param FA rocket primary %}} Upgrade to 0.14.0 {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to 0.14.0 {#upgrade}
 
 > [!NB] First [upgrade to Docsy 0.13.0][] if you haven't already.
 
@@ -450,6 +472,9 @@ Docsy 0.12.0][]: follow them, using version **0.14.0** where the guide refers to
     supported.
 
 <section class="td-checkbox-list-wrapper">
+
+<details>
+<summary class="h4 text-primary"><span class="fa-regular fa-square-check"></span> Checks</summary>
 
 ### Sanity checks
 
@@ -479,14 +504,15 @@ your convenience, we link to required and optional actions for each section.
       [Swagger UI](#swagger-scss)
 - [ ] [Heading aliases and in-page targets required actions](#heading-aliases-actions)
 
-#### Cleanup and site improvements (optional) {#cleanup-opportunities}
+#### {{% _param CLEANUP %}} Cleanup and site improvements (optional) {#cleanup-opportunities}
 
 If your project overrides Docsy styles (navbar, blocks, TOC, and more), review
 those overrides against the changes in this release. This often lets you remove
 custom CSS/SCSS and reduce [technical debt][].
 
 - [ ] Switch to [Markdown alert syntax](#alerts-actions)
-- [ ] Adjust [navbar height and styling](#navbar-actions)
+- [ ] Review [navbar theme and styling](#navbar-actions), and drop any navbar
+      overrides you added only to force a dark theme
 - [ ] Adjust [`blocks/cover` position](#blocks-cover-actions) relative to the
       navbar
 - [ ] Remove redundant [i18n entries](#internationalization)
@@ -521,6 +547,7 @@ Review these updated files and port changes as needed:
 [community/list.html]:
   <{{% param github_repo %}}/blob/main/layouts/community/list.html?plain=1>
 
+</details>
 </section>
 
 ## What's next?
@@ -531,11 +558,11 @@ For general work items _tentatively_ planned for the next release, see [Release
 <!-- prettier-ignore -->
 > [!INFO]- Your opinion counts!
 >
-> - {{% _param FA thumbs-up success %}} If you'd like a feature or fix to be
+> - {{% _param FAS thumbs-up success %}} If you'd like a feature or fix to be
 >   considered for inclusion in an upcoming release, **upvote** (with a thumbs up)
 >   the associated issue or PR.
 >
-> - {{% _param FA star warning %}} If you find Docsy useful, consider [starring
+> - {{% _param FAS star warning %}} If you find Docsy useful, consider [starring
 >   the repository][star-the-repo] to show your support.
 {._list-unstyled}
 

--- a/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
@@ -32,7 +32,7 @@ you may need to take.
 - Optionally skim:
   - [Known issues and fixes](#known-issues)
   - [Notable changes](#notable-changes)
-- {{% _param FA rocket primary %}} Jump to [Upgrade to Hugo 0.155.x](#upgrade)
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.155.x](#upgrade)
   once you're ready
 
 ## {{% _param BREAKING %}} YAML yes/no tokens are strings (0.152.0) <a id="0.152.0"></a> {#yaml-yes-no-etc}
@@ -241,7 +241,7 @@ Notable changes that are non-breaking include:
 > - The [hugo-extended][] NPM package briefly required `sudo` in versions
 >   0.153.0–0.153.3.
 
-## {{% _param FA rocket primary %}} Upgrade to Hugo 0.155.x {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.155.x {#upgrade}
 
 After addressing all [breaking changes](#breaking-changes) and
 [deprecations](#deprecations), upgrade to the latest release of Hugo 0.155.x. If

--- a/docsy.dev/content/en/blog/_index.md
+++ b/docsy.dev/content/en/blog/_index.md
@@ -3,12 +3,15 @@ title: Blog
 menu: { main: { weight: 50 } }
 cascade:
   params:
-    # Icon usage: {{% _param FA iconName color %}}
+    # Icon usage: {{% _param FAS iconName color %}}
     BREAKING:
       <i class="fa-solid fa-triangle-exclamation fa-lg text-warning px-1"></i>
     NEW: <i class="fa-regular fa-square-check fa-lg text-success px-1"></i>
-    FA: <i class="fa-solid fa-{1} text-{2} px-1"></i>
-    FA_LG: <i class="fa-solid fa-{1} text-{2} fa-lg"></i>
+    CLEANUP:
+      <i class="fa-regular fa-wand-magic-sparkles fa-lg text-info px-1"></i>
+    FA: <i class="fa-{1} fa-{2} text-{3} px-1"></i>
+    FAS: <i class="fa-solid fa-{1} text-{2} px-1"></i>
+    FAS_LG: <i class="fa-solid fa-{1} text-{2} fa-lg"></i>
     # Badge usage: {{% _param BADGE text color %}}
     BADGE: <span class="badge text-bg-{2} rounded-pill text-small">{1}</span>
 ---

--- a/docsy.dev/content/en/docs/content/adding-content.md
+++ b/docsy.dev/content/en/docs/content/adding-content.md
@@ -438,15 +438,25 @@ resources together with the content.
 You can see examples of both approaches in this and our example site. For
 example, the source for this page is just a standalone file
 `/content/en/docs/content/adding-content.md`. However the source for
-[Docsy Shortcodes](/docs/content/shortcodes/) in this site lives in
+[Docsy Shortcodes](shortcodes/) in this site lives in
 `/content/en/docs/content/shortcodes/index.md`, with the image resource used by
-the page in the same `/shortcodes/` directory. In Hugo terminology, this is
+the page in the same `shortcodes/` directory. In Hugo terminology, this is
 called a _leaf bundle_ because it's a folder containing all the data for a
 single site page without any child pages (and uses `index.md` without an
 underscore).
 
 You can find out much more about managing resources with Hugo bundles in
-[Page Bundles](https://gohugo.io/content-management/page-bundles/).
+[Page bundles](https://gohugo.io/content-management/page-bundles/).
+
+> [!IMPORTANT]
+>
+> For multilingual single-host sites, Hugo does not duplicate shared page
+> resources (such as images) by default. You typically do not need to copy
+> shared resources into each locale's bundle. For details, see [Page resources
+> multilingual][pg-rsc-multilingual].
+
+[pg-rsc-multilingual]:
+  https://gohugo.io/content-management/page-resources/#multilingual
 
 ## Adding docs and blog posts
 

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -82,31 +82,48 @@ If you have special favicon requirements, you can create your own
 
 ### Landing pages
 
-Docsy's [`blocks/cover` shortcode](/docs/content/shortcodes/#blocks-cover) make
-it easy to add large cover images to your landing pages. The shortcode looks for
-an image with the word "background" in the name inside the landing page's
-[Page Bundle](https://gohugo.io/content-management/page-bundles/) - so, for
-example, if you've copied the example site, the landing page image in
-`content/en/_index.html` is `content/en/featured-background.jpg`.
+Docsy's [`blocks/cover` shortcode](/docs/content/shortcodes/#blocks-cover) makes
+it easy to add cover images (also known as hero images) to landing pages. The
+shortcode looks for an image with the word "background" in the name within the
+landing page's [page bundle](adding-content/#page-bundles).
 
-You specify the preferred display height of a cover block container (and hence
-its image) using the block's `height` parameter. For a full viewport height, use
-`full`:
+For example, the example site's landing page `content/en/_index.md` uses the
+image `content/en/featured-background.jpg`, which is in the same directory --
+see the [content/en][] folder on GitHub.
 
-```html
-{{</* blocks/cover title="Welcome to the Docsy Example Project!" image_anchor="top" height="full" */>}}
+[content/en]: https://github.com/google/docsy-example/tree/main/content/en
+
+Use the block's [`height` parameter][] to set the preferred display height of
+the cover container (and therefore its image). For a full viewport height, use
+`full`, along with the `td-below-navbar` helper class to position the cover
+below the navbar:
+
+[`height` parameter]: shortcodes/#blocks
+
+```go-html-template
+{{%/* blocks/cover
+  title="Welcome to Docsy!"
+  image_anchor="top"
+  height="full td-below-navbar"
+*/%}}
 ...
-{{</* /blocks/cover */>}}
+{{%/* /blocks/cover */%}}
 ```
 
-For a shorter image, as in the example site's About page, use one of `min`,
-`med`, `max` or `auto` (the actual height of the image):
+For a shorter image, as in the [example site's About][] page, use one of `min`,
+`med`, `max`, or `auto` (the image's natural height):
 
-```html
-{{</* blocks/cover title="About the Docsy Example" image_anchor="bottom" height="min" */>}}
+```go-html-template
+{{%/* blocks/cover
+  title="About the Docsy Example"
+  image_anchor="bottom"
+  height="min td-below-navbar"
+*/%}}
 ...
-{{</* /blocks/cover */>}}
+{{%/* /blocks/cover */%}}
 ```
+
+[example site's About]: <{{% param example_site_url %}}/about/>
 
 ### Other pages
 

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -9,13 +9,13 @@ cascade:
   params:
     hide_feedback: true
 params:
-  FA: <i class="fa-solid fa-{1} text-{2}"></i>
+  FAS: <i class="fa-solid fa-{1} text-{2}"></i>
 cSpell:ignore: docsydocs
 ---
 
 <span class="badge bg-warning text-bg-warning fs-6">
-{{% _param FA person-digging " pe-2" %}} Section under construction. {{%
-_param FA person-digging " ps-2" %}}
+{{% _param FAS person-digging " pe-2" %}} Section under construction. {{%
+_param FAS person-digging " ps-2" %}}
 </span>
 
 ## Content (planned) {#content}

--- a/docsy.dev/content/en/tests/_index.md
+++ b/docsy.dev/content/en/tests/_index.md
@@ -2,7 +2,8 @@
 title: Docsy tests
 linkTitle: Tests
 description: Tests of Docsy features
-params:
-  hide_feedback: true
-cascade: { type: docs }
+cascade:
+  params:
+    hide_feedback: true
+  type: docs
 ---

--- a/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
@@ -1,24 +1,39 @@
 ---
 title: Height auto with td-below-navbar
+linkTitle: Height auto
 type: home
 layout: home
 description: A Hugo theme for creating great technical documentation sites
 params:
-  ui: { navbar_theme: dark}
+  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
-{{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="auto td-below-navbar" %}}
+{{% blocks/cover
+  title="Welcome to Docsy!"
+  image_anchor="top"
+  height="auto td-below-navbar"
+%}}
+
+<!-- prettier-ignore -->
 {{% param description %}}
 {.display-6}
 
-<a class="btn btn-lg btn-primary me-3" href="/about/">Learn More</a>
-<a class="btn btn-lg btn-secondary" href="/docs/get-started/">Get started</a>
-{.p-initial .my-5}
+<!-- prettier-ignore -->
+<div class="td-cta-buttons my-5">
+  <button {{% _param btn-lg primary %}} href="/about/">
+    Learn more
+  </button>
+  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
+    Get started
+  </button>
+</div>
 
 {{% blocks/link-down color="info" %}}
+
 {{% /blocks/cover %}}
 
 {{% blocks/lead color="primary" %}}
+
 Docsy is a theme for the Hugo static site generator that's specifically designed
 for technical documentation sets. Our aim is to help you get a working
 documentation site up and running as easily as possible, so you can concentrate
@@ -28,3 +43,21 @@ on creating great content for your users.
   <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
 </a>
 {{% /blocks/lead %}}
+
+{{% blocks/section color="dark" type="row" %}}
+
+{{% blocks/feature icon="fa-lightbulb" title="See Docsy in action!" url="/docs/examples/" %}}
+As well as our example site, there's a growing number of projects using Docsy for their doc sites.
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-github" title="Contributions welcome!" url="https://github.com/google/docsy" %}}
+We do a [Pull Request](https://github.com/google/docsy/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-x-twitter" title="Follow us on Twitter!" url="https://twitter.com/docsydocs" %}}
+Find out about new features and how our users are using Docsy.
+{{% /blocks/feature %}}
+
+{{% /blocks/section %}}

--- a/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
@@ -1,24 +1,39 @@
 ---
 title: Height full with td-below-navbar
+linkTitle: Height full
 type: home
 layout: home
 description: A Hugo theme for creating great technical documentation sites
 params:
-  ui: { navbar_theme: dark}
+  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
-{{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="full td-below-navbar" %}}
+{{% blocks/cover
+  title="Welcome to Docsy!"
+  image_anchor="top"
+  height="full td-below-navbar"
+%}}
+
+<!-- prettier-ignore -->
 {{% param description %}}
 {.display-6}
 
-<a class="btn btn-lg btn-primary me-3" href="/about/">Learn More</a>
-<a class="btn btn-lg btn-secondary" href="/docs/get-started/">Get started</a>
-{.p-initial .my-5}
+<!-- prettier-ignore -->
+<div class="td-cta-buttons my-5">
+  <button {{% _param btn-lg primary %}} href="/about/">
+    Learn more
+  </button>
+  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
+    Get started
+  </button>
+</div>
 
 {{% blocks/link-down color="info" %}}
+
 {{% /blocks/cover %}}
 
 {{% blocks/lead color="primary" %}}
+
 Docsy is a theme for the Hugo static site generator that's specifically designed
 for technical documentation sets. Our aim is to help you get a working
 documentation site up and running as easily as possible, so you can concentrate
@@ -28,3 +43,21 @@ on creating great content for your users.
   <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
 </a>
 {{% /blocks/lead %}}
+
+{{% blocks/section color="dark" type="row" %}}
+
+{{% blocks/feature icon="fa-lightbulb" title="See Docsy in action!" url="/docs/examples/" %}}
+As well as our example site, there's a growing number of projects using Docsy for their doc sites.
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-github" title="Contributions welcome!" url="https://github.com/google/docsy" %}}
+We do a [Pull Request](https://github.com/google/docsy/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-x-twitter" title="Follow us on Twitter!" url="https://twitter.com/docsydocs" %}}
+Find out about new features and how our users are using Docsy.
+{{% /blocks/feature %}}
+
+{{% /blocks/section %}}

--- a/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
@@ -1,24 +1,40 @@
 ---
-title: Height min with td-below-navbar
+title: Height min with td-below-navbar and dark navbar
+linkTitle: Height min dark
 type: home
 layout: home
 description: A Hugo theme for creating great technical documentation sites
-# params: # test variant
-#   ui: { navbar_theme: dark}
+params:
+  ui: { navbar_theme: dark }
+  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
-{{% blocks/cover title="Welcome to Docsy!" image_anchor="top" height="min td-below-navbar" %}}
+{{% blocks/cover
+  title="Welcome to Docsy!"
+  image_anchor="top"
+  height="min td-below-navbar"
+%}}
+
+<!-- prettier-ignore -->
 {{% param description %}}
 {.display-6}
 
-<a class="btn btn-lg btn-primary me-3" href="/about/">Learn More</a>
-<a class="btn btn-lg btn-secondary" href="/docs/get-started/">Get started</a>
-{.p-initial .my-5}
+<!-- prettier-ignore -->
+<div class="td-cta-buttons my-5">
+  <button {{% _param btn-lg primary %}} href="/about/">
+    Learn more
+  </button>
+  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
+    Get started
+  </button>
+</div>
 
 {{% blocks/link-down color="info" %}}
+
 {{% /blocks/cover %}}
 
 {{% blocks/lead color="primary" %}}
+
 Docsy is a theme for the Hugo static site generator that's specifically designed
 for technical documentation sets. Our aim is to help you get a working
 documentation site up and running as easily as possible, so you can concentrate
@@ -28,3 +44,21 @@ on creating great content for your users.
   <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
 </a>
 {{% /blocks/lead %}}
+
+{{% blocks/section color="dark" type="row" %}}
+
+{{% blocks/feature icon="fa-lightbulb" title="See Docsy in action!" url="/docs/examples/" %}}
+As well as our example site, there's a growing number of projects using Docsy for their doc sites.
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-github" title="Contributions welcome!" url="https://github.com/google/docsy" %}}
+We do a [Pull Request](https://github.com/google/docsy/pulls) contributions workflow on **GitHub**. New users are always welcome!
+{{% /blocks/feature %}}
+
+
+{{% blocks/feature icon="fa-brands fa-x-twitter" title="Follow us on Twitter!" url="https://twitter.com/docsydocs" %}}
+Find out about new features and how our users are using Docsy.
+{{% /blocks/feature %}}
+
+{{% /blocks/section %}}

--- a/docsy.dev/content/en/tests/layouts/_index.md
+++ b/docsy.dev/content/en/tests/layouts/_index.md
@@ -1,0 +1,3 @@
+---
+title: Layouts
+---

--- a/docsy.dev/content/en/tests/layouts/no-left-sidebar.md
+++ b/docsy.dev/content/en/tests/layouts/no-left-sidebar.md
@@ -1,0 +1,40 @@
+---
+title: No left sidebar
+type: docs
+params:
+  body_class: td-no-left-sidebar
+---
+
+This page uses the **no-left-sidebar** layout. The left (section) sidebar is hidden; only the right-hand table of contents is shown, and the main container is centered.
+
+To use this layout on any docs page, add to your front matter:
+
+```yaml
+body_class: td-no-left-sidebar
+```
+
+## Why use this layout?
+
+A common use case is to allow top-level pages to use the `docs` layout but for which it doesn't make sense to have a left sidebar since it usually will show all pages of type `docs` in the site. This is usually not the desired page design.
+
+## Layout behavior
+
+- **Left sidebar**: Hidden.
+- **Main content**: Full width of the content area, centered on large screens.
+- **Right ToC**: Visible as usual on medium-and-up viewports.
+
+## Sample sections (for ToC)
+
+Here are some headings so the right-hand ToC is populated and you can see how the layout behaves with scroll.
+
+### Subsection one
+
+Some body text. The no-left-sidebar layout is defined in the theme's extra SCSS (`assets/scss/td/extra/_main-container.scss`).
+
+### Subsection two
+
+More sample content. Resize the window to see how the layout responds at different breakpoints.
+
+### Subsection three
+
+On small screens the ToC is hidden by default; on `md` and up it appears on the right with the content centered beside it.

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -122,6 +122,10 @@ params:
         url: /project/
         icon: fa fa-book
         desc: Site design documentation and resources
+      - name: Tests
+        url: /tests/
+        icon: fa-solid fa-flask
+        desc: Test and demo pages
       - name: GitHub
         url: https://github.com/google/docsy
         icon: fa-brands fa-github

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -2123,6 +2123,10 @@
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:37.217515-05:00"
   },
+  "https://gohugo.io/content-management/page-resources/#multilingual": {
+    "StatusCode": 200,
+    "LastSeen": "2026-02-05T07:39:17.203966-05:00"
+  },
   "https://gohugo.io/content-management/shortcodes/": {
     "StatusCode": 206,
     "LastSeen": "2025-11-16T18:27:35.287863-05:00"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+86-gd06e1406",
+  "version": "0.14.0-dev+87-gc725abe7",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
Introduce experimental extra SCSS and update example content to use new cover helpers and styles.

- Fix homepage styling by using Bootstrap-style buttons instead of anchors.
- Adds a test page with `td-no-left-sidebar`

Details:

- Add td/extra SCSS: _buttons.scss (td-cta-buttons) and _main-container.scss (td-no-left-sidebar) and import them in td/extra/_index.scss.
- Update docsy.dev styles and docs to use td-below-navbar helper and a btn-lg param for cover CTAs; replace inline anchor CTAs with td-cta-buttons markup in multiple example/test pages.
- Standardize icon parameter names (FA -> FAS / FAS_LG) and add CLEANUP param usage across blog and site pages.
- Add test pages and layout docs (tests/ and tests/layouts), update hugo.yaml menu to include Tests, and add a refcache entry for a Hugo docs URL.
- Misc: small content/link rewrites, formatting and explanatory text updates in docs and styles_project comment reflow.

These changes add customizable CTA grouping and a no-left-sidebar layout, update example pages to demonstrate new helpers, and tidy icon/param conventions.

**Preview**:

- https://deploy-preview-2514--docsydocs.netlify.app/blog/2026/0.14.0/
- https://deploy-preview-2514--docsydocs.netlify.app/docs/content/iconsimages/#landing-pages
- https://deploy-preview-2514--docsydocs.netlify.app/tests/layouts/no-left-sidebar/