### PR TITLE
Adjust ToC and main layout breakpoints under td-no-left-sidebar

### DIFF
--- a/assets/scss/td/extra/_main-container.scss
+++ b/assets/scss/td/extra/_main-container.scss
@@ -6,27 +6,29 @@
     display: none !important;
   }
 
-  // Adjust right/ToC sidebar, when visible (i.e., at md and up).
   .td-sidebar-toc {
-    @include media-breakpoint-up(md) {
-      @extend .col-md-2;
+    // Hidden on narrow viewports below xl
+
+    @include media-breakpoint-up(xl) {
+      @extend .col-xl-2;
       display: block !important;
+      // Ensure ToC top aligns with the navbar bottom
+      margin-top: $td-navbar-min-height;
     }
   }
 
   // The <main> element sibling of the ToC sidebar
   > div > main {
-    // Always 10 col wide (unless the ToC sidebar is hidden)
-    @extend .col-md-10;
+    @extend .col-md-12;
     @extend .col-xl-10;
 
-    @include media-breakpoint-up(md) {
+    // Only add padding when the ToC is visible
+    @include media-breakpoint-up(xl) {
       padding-right: 3rem;
     }
 
     @include media-breakpoint-up(lg) {
       // Center content on larger screens
-
       .td-content,
       .td-breadcrumbs {
         max-width: 80%;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+87-gc725abe7",
+  "version": "0.14.0-dev+89-g75e091ce",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Followup to #2514
- Adjusts ToC and main container widths based on more appropriate breakpoints

**Preview**: https://deploy-preview-2515--docsydocs.netlify.app/tests/layouts/no-left-sidebar/

### Screenshots

<img width="1032" height="753" alt="image" src="https://github.com/user-attachments/assets/5c3b4617-5480-4d78-9d98-8a40b83963de" />

---

<img width="1380" height="770" alt="image" src="https://github.com/user-attachments/assets/c25afb90-a612-40f2-bf89-27a8ed58ee5b" />
