### PR TITLE
Centralize btn-lg helper to Hugo params, use anchors not buttons

### DIFF
--- a/docsy.dev/content/en/_index.md
+++ b/docsy.dev/content/en/_index.md
@@ -3,7 +3,6 @@ title: Docsy
 description: A Hugo theme for creating great technical documentation sites
 params:
   ui: { navbar_theme: dark }
-  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
 {{% blocks/cover
@@ -18,12 +17,12 @@ params:
 
 <!-- prettier-ignore -->
 <div class="td-cta-buttons my-5">
-  <button {{% _param btn-lg primary %}} href="about/">
+  <a {{% _param btn-lg primary %}} href="about/">
     Learn more
-  </button>
-  <button {{% _param btn-lg secondary %}} href="docs/get-started/">
+  </a>
+  <a {{% _param btn-lg secondary %}} href="docs/get-started/">
     Get started
-  </button>
+  </a>
 </div>
 
 {{% blocks/link-down color="info" %}}

--- a/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
@@ -4,8 +4,6 @@ linkTitle: Height auto
 type: home
 layout: home
 description: A Hugo theme for creating great technical documentation sites
-params:
-  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
 {{% blocks/cover
@@ -20,12 +18,8 @@ params:
 
 <!-- prettier-ignore -->
 <div class="td-cta-buttons my-5">
-  <button {{% _param btn-lg primary %}} href="/about/">
-    Learn more
-  </button>
-  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
-    Get started
-  </button>
+  <a {{% _param btn-lg primary %}} href="/about/">Learn more</a>
+  <a {{% _param btn-lg secondary %}} href="/docs/get-started/">Get started</a>
 </div>
 
 {{% blocks/link-down color="info" %}}

--- a/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
@@ -4,8 +4,6 @@ linkTitle: Height full
 type: home
 layout: home
 description: A Hugo theme for creating great technical documentation sites
-params:
-  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
 {{% blocks/cover
@@ -20,12 +18,8 @@ params:
 
 <!-- prettier-ignore -->
 <div class="td-cta-buttons my-5">
-  <button {{% _param btn-lg primary %}} href="/about/">
-    Learn more
-  </button>
-  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
-    Get started
-  </button>
+  <a {{% _param btn-lg primary %}} href="/about/">Learn more</a>
+  <a {{% _param btn-lg secondary %}} href="/docs/get-started/">Get started</a>
 </div>
 
 {{% blocks/link-down color="info" %}}

--- a/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
@@ -6,7 +6,6 @@ layout: home
 description: A Hugo theme for creating great technical documentation sites
 params:
   ui: { navbar_theme: dark }
-  btn-lg: class="btn btn-lg btn-{1}" type="button"
 ---
 
 {{% blocks/cover
@@ -21,12 +20,8 @@ params:
 
 <!-- prettier-ignore -->
 <div class="td-cta-buttons my-5">
-  <button {{% _param btn-lg primary %}} href="/about/">
-    Learn more
-  </button>
-  <button {{% _param btn-lg secondary %}} href="/docs/get-started/">
-    Get started
-  </button>
+  <a {{% _param btn-lg primary %}} href="/about/">Learn more</a>
+  <a {{% _param btn-lg secondary %}} href="/docs/get-started/">Get started</a>
 </div>
 
 {{% blocks/link-down color="info" %}}

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -142,6 +142,8 @@ params:
     enable: true
   drawio:
     enable: true
+  # UG helpers: use with _param
+  btn-lg: class="btn btn-lg btn-{1}" role="button"
 
 baseURL: *productionURL
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+89-g75e091ce",
+  "version": "0.14.0-dev+91-gba02f629",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Followup to #2514
- Keeps things DRY by moving `btn-lg` param into Hugo config
- Switch back to anchors instead of buttons (of course!)

**Preview**: https://deploy-preview-2517--docsydocs.netlify.app