### PR TITLE
Add td-navbar-links-all-active to list of experimental styles in 0.14.0 blog post

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -427,6 +427,7 @@ Docsy 0.14.0 includes the following style improvements and fixes:
 - Navbar link decoration for active and hover states
 - Nested-list margin fix for the last child
 - No-left-sidebar layout: use the `td-no-left-sidebar` class
+- Navbar helper class `td-navbar-links-all-active` for homepage
 
 For details, see [Extra styles][].
 

--- a/docsy.dev/content/en/tests/layouts/no-left-sidebar.md
+++ b/docsy.dev/content/en/tests/layouts/no-left-sidebar.md
@@ -5,36 +5,24 @@ params:
   body_class: td-no-left-sidebar
 ---
 
-This page uses the **no-left-sidebar** layout. The left (section) sidebar is hidden; only the right-hand table of contents is shown, and the main container is centered.
+This page uses the `docs` layout with the `td-no-left-sidebar` body class. The
+left (section) sidebar is hidden; only the right-hand table of contents is
+shown, and the main container is centered.
 
-To use this layout on any docs page, add to your front matter:
+## Section A
 
-```yaml
-body_class: td-no-left-sidebar
-```
+This is sample text for the first section. This is sample text for the first section. This is sample text for the first section. This is sample text for the first section.
 
-## Why use this layout?
+### Subsection
 
-A common use case is to allow top-level pages to use the `docs` layout but for which it doesn't make sense to have a left sidebar since it usually will show all pages of type `docs` in the site. This is usually not the desired page design.
+A short paragraph goes here.
 
-## Layout behavior
+### Another subsection
 
-- **Left sidebar**: Hidden.
-- **Main content**: Full width of the content area, centered on large screens.
-- **Right ToC**: Visible as usual on medium-and-up viewports.
+Another line of sample content.
 
-## Sample sections (for ToC)
+## Section B
 
-Here are some headings so the right-hand ToC is populated and you can see how the layout behaves with scroll.
-
-### Subsection one
-
-Some body text. The no-left-sidebar layout is defined in the theme's extra SCSS (`assets/scss/td/extra/_main-container.scss`).
-
-### Subsection two
-
-More sample content. Resize the window to see how the layout responds at different breakpoints.
-
-### Subsection three
-
-On small screens the ToC is hidden by default; on `md` and up it appears on the right with the content centered beside it.
+This is sample text for the second section. This is sample text for the second
+section. This is sample text for the second section. This is sample text for the
+second section.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+93-g555ca48f",
+  "version": "0.14.0-dev+94-g4fdc4844",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Adds `td-navbar-links-all-active` to list of experimental styles in 0.14.0 blog post
- Updates test page using `td-navbar-links-all-active`: uses bogus text (to avoid maintenance burden)