### PR TITLE
Fix toc position on desktop, and left sidenav + main layout on tablet

### DIFF
--- a/assets/scss/td/_main-container.scss
+++ b/assets/scss/td/_main-container.scss
@@ -24,6 +24,14 @@
 
 .td-main {
   flex-grow: 1;
+  @at-root .td-section &,
+    .td-page & {
+    // Use flex so descendant elements (like <main>) can grow to fill the
+    // available vertical (viewport) space, but only for docs layouts (it breaks
+    // td-home, which needs column-based layout). We select docs layouts via
+    // .td-section and .td-page above.
+    display: flex;
+  }
 }
 
 .td-404 main,

--- a/assets/scss/td/_sidebar-toc.scss
+++ b/assets/scss/td/_sidebar-toc.scss
@@ -8,7 +8,7 @@
 
   @supports (position: sticky) {
     position: sticky;
-    top: $td-navbar-min-height;
+    margin-top: $td-navbar-min-height;
     height: calc(100vh - #{$td-navbar-min-height});
     overflow-y: auto;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+96-gec568185",
+  "version": "0.14.0-dev+97-g6230b09e",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2523
- Fixes #1573, hopefully for real this time 😄 
- This implements the (re)design decision mentioned in https://github.com/google/docsy/issues/2523#issuecomment-3864503851

**Preview**: https://deploy-preview-2525--docsydocs.netlify.app/docs/best-practices/

## Screenshots

Page-meta / sidenav-toc position fix:

| Before | After |
|--------|--------|
| <img width="1220" height="894" alt="image" src="https://github.com/user-attachments/assets/7808c7ed-49ed-4bc2-9a7d-0e0bf9e8ac09" /> | <img width="1225" height="896" alt="image" src="https://github.com/user-attachments/assets/f679a5bd-db8c-4228-9f02-218db5657c38" /> | 

Notice how the footer peeks up in the before image. That's because the ToC sidenav isn't correctly positioned. The fix is to use margin-top not top.

---

Left sidenav (tree/section) fix:

| Before | After |
|--------|--------|
| <img width="1175" height="1125" alt="image" src="https://github.com/user-attachments/assets/4d5d624f-ce3d-47e9-a7fb-95a748f07639" /> | <img width="1175" height="1124" alt="image" src="https://github.com/user-attachments/assets/b2fe468b-b9ec-4d8e-a077-9258bca018d2" /> | 

When the sidenav entries are all open, both before and after have the same look (as expected):

| Before | After |
|--------|--------|
| <img width="1158" height="1123" alt="image" src="https://github.com/user-attachments/assets/3d84750b-5165-4710-931f-6be6637d5337" /> | <img width="1160" height="1124" alt="image" src="https://github.com/user-attachments/assets/4ea7f885-50db-411a-9fc7-00e463cbd131" /> | 