### PR TITLE
Factor sidebar-toc styles, and 0.13.0 + 0.14.0 blog post improvements

### DIFF
--- a/assets/scss/td/_sidebar-toc.scss
+++ b/assets/scss/td/_sidebar-toc.scss
@@ -3,6 +3,10 @@
 //
 .td-sidebar-toc {
   @include link-decoration;
+  display: none;
+  @extend .d-print-none;
+  @extend .d-xl-block;
+  @extend .col-xl-2;
 
   border-left: 1px solid var(--bs-border-color);
 

--- a/docsy.dev/content/en/blog/2025/0.13.0.md
+++ b/docsy.dev/content/en/blog/2025/0.13.0.md
@@ -2,7 +2,7 @@
 title: Release 0.13.0 report and upgrade guide
 linkTitle: Release 0.13.0
 date: 2025-11-24
-lastmod: 2026-02-02
+lastmod: 2026-02-07
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -141,7 +141,7 @@ For implementation details, see [#2035], [#2001], and PR [#2303].
 [lang-menu]: /docs/content/navigation/#language-menu
 [#2303]: https://github.com/google/docsy/pull/2303
 
-### Mobile navbar scroll indicators
+### {{% _param NEW %}} Mobile navbar scroll indicators {#mobile-navbar-scroll-indicators}
 
 The navbar now shows left/right scroll indicators when the navigation menu
 overflows (mainly for narrow viewports), making it easier for users to discover
@@ -149,7 +149,7 @@ additional navigation items ([#2406]).
 
 [#2406]: https://github.com/google/docsy/pull/2406
 
-## {{% _param FAS code "" %}} Alert shortcode improvements {#alert-shortcode}
+## {{% _param BREAKING %}} Alert shortcode improvements {#alert-shortcode}
 
 As of Docsy 0.13.0, `alert` shortcode content is processed differently when
 called as Markdown (`{{%/* alert */%}}`): the inner Markdown is now passed
@@ -166,6 +166,19 @@ This change means that your alerts can now:
 
 For details and examples, including important formatting requirements, see
 [alert]. For implementation details, see PR [#941].
+
+**Action required**: Applies if you use the `alert` in `.html` content files
+with Markdown in the body.
+
+Use Hugo's shortcode [Markdown call syntax][]: `{{%/* */%}}`. Otherwise,
+Markdown content might not render correctly.
+
+**Sanity check**: sample the rendering of pages that contain `alert` shortcodes,
+whether in Markdown or HTML content files. Ensure that the alert renders as
+expected.
+
+[Markdown call syntax]:
+  https://gohugo.io/content-management/shortcodes/#notation
 
 ## {{% _param FAS universal-access info %}} Accessibility improvements {#accessibility}
 

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -1,7 +1,7 @@
 ---
 title: Release 0.14.0 report and upgrade guide
 linkTitle: Release 0.14.0
-date: 2026-02-04
+date: 2026-02-07
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -18,7 +18,7 @@
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </aside>
-          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+          <aside class="td-sidebar-toc">
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -18,7 +18,7 @@
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </aside>
-          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+          <aside class="td-sidebar-toc">
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}

--- a/layouts/swagger/baseof.html
+++ b/layouts/swagger/baseof.html
@@ -20,7 +20,7 @@
           <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
             {{ partial "sidebar.html" . }}
           </aside>
-          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+          <aside class="td-sidebar-toc">
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+97-g6230b09e",
+  "version": "0.14.0-dev+98-gcc2d0569",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #783 for `.td-sidebar-toc`
- Makes a few 0.13.0 + 0.14.0 blog post improvements. Updates the publication date.

**Preview** (to double check that sidenav still displays correctly across viewport sizes):

- https://deploy-preview-2527--docsydocs.netlify.app/docs/
- https://deploy-preview-2527--docsydocs.netlify.app/blog/