### PR TITLE
Add RTL fixes for code blocks and foldable-nav icons

### DIFF
--- a/assets/scss/td/_nav.scss
+++ b/assets/scss/td/_nav.scss
@@ -267,25 +267,19 @@ nav.foldable-nav {
   }
 
   .ul-1 .with-child > label::before {
-    display: inline-block;
-    font-style: normal;
-    font-variant: normal;
-    text-rendering: auto;
-    -webkit-font-smoothing: antialiased;
-    font-family: $td-font-awesome-font-name;
-    font-weight: 900;
-    content: '\f0da';
+    font: var(--fa-font-solid);
+    line-height: 1.5;
+    content: fa-content($fa-var-caret-right);
+
+    @at-root [dir='rtl'] & {
+      content: fa-content($fa-var-caret-left);
+    }
+
     position: absolute;
     left: 0.1em;
     padding-left: 0.4em;
     padding-right: 0.4em;
-    font-size: 1em;
-    color: var(--bs-secondary-color);
     transition: all 0.5s;
-
-    &:hover {
-      transform: rotate(90deg);
-    }
   }
 
   .ul-1 .with-child > input:checked ~ label::before {

--- a/assets/scss/td/support/_rtl.scss
+++ b/assets/scss/td/support/_rtl.scss
@@ -1,0 +1,22 @@
+// Keep code blocks LTR, see: https://github.com/google/docsy/issues/2529
+
+/*rtl:ignore*/
+[dir='rtl'] {
+  .highlight,
+  pre,
+  pre code {
+    direction: ltr;
+    text-align: left;
+    unicode-bidi: plaintext;
+  }
+}
+
+/*rtl:ignore*/
+[dir='rtl'] {
+  .highlight pre button.td-click-to-copy {
+    left: auto;
+    right: 4px;
+  }
+}
+
+// For nav menu adjustments, see: _nav.scss.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.0-dev+103-g234f18dd-or-later-commit",
+  "version": "0.14.0-dev+104-g8bc5f537-or-later-commit",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2529
- Fixes #2532

### Screenshots (autotranslated back into English)

Before:

<img width="868" height="318" alt="image" src="https://github.com/user-attachments/assets/d40735e9-6c4e-4db1-97b5-e10d86a9f43a" />

After:

<img width="868" height="427" alt="image" src="https://github.com/user-attachments/assets/1348a0d0-ebdb-4ddf-9d71-162146cbbb67" />

/cc @ImanHz
