### PR TITLE
Apply .td-main flex only when sidebar exists

### DIFF
--- a/assets/scss/td/_main-container.scss
+++ b/assets/scss/td/_main-container.scss
@@ -32,7 +32,7 @@
 .td-main {
   flex-grow: 1;
   @include media-breakpoint-between(md, xl) {
-    // Between md and xl, a docs page has a left (section) sidebar but no right
+    // Between md and xl, a docs/blog page has a left (section) sidebar but no right
     // (TOC) sidebar. Since it's the TOC sidebar that makes the .td-main
     // vertically fill the .td-main container, we need another way to have
     // td-main be full height when it's not there.
@@ -41,7 +41,9 @@
     // it to be between md and xl only: below md .td-main doesn't need to fill
     // the page, we're in flow mode for mobile; above xl we don't need it
     // either, the TOC sidebar is there and makes .td-main fill the page.
-    display: flex;
+    &:has(> .row .td-sidebar-nav) {
+      display: flex;
+    }
   }
 }
 

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -62,7 +62,7 @@ params:
     to_year: present
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
-  version: 0.14.2-dev-002-over-main-6f8afa37
+  version: 0.14.2-dev-003-over-main-1f21d33c
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy
   github_subdir: docsy.dev

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.2-dev-002-over-main-6f8afa37",
+  "version": "0.14.2-dev-003-over-main-1f21d33c",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2544
- Ensures that the .td-main flex hack is applied only to docs and blog pages
- My last SCSS rework was a little to aggressive in the cleanup. I needed to keep the `:has(...)` guard. This adds it back.


**Preview**:

- https://deploy-preview-2546--docsydocs.netlify.app/
- https://deploy-preview-2546--docsydocs.netlify.app/docs/best-practices/

### Screenshot

<img width="1046" height="677" alt="image" src="https://github.com/user-attachments/assets/62d47d44-6c24-4ef8-98e5-3424f70c1ece" />
