### PR TITLE
Add name attribute to search input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ resources/
 # VS Code
 /.vscode/**
 !/.vscode/cspell.json
+/.cursor

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -63,7 +63,7 @@ params:
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
   version: 0.14.2-dev
-  versionWithBuildId: 0.14.2-dev+005-over-main-a6050113
+  versionWithBuildId: 0.14.2-dev+006-over-main-cc763a9b
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy
   github_subdir: docsy.dev

--- a/layouts/_partials/search-input.html
+++ b/layouts/_partials/search-input.html
@@ -1,3 +1,5 @@
+{{/* cSpell:ignore docsy docsearch absurlreplacer */ -}}
+
 {{ .Scratch.Set "docsy-search" 0 -}}
 
 {{ if .Site.Params.gcs_engine_id -}}
@@ -5,7 +7,10 @@
 
 <div class="td-search">
   <div class="td-search__icon"></div>
-  <input type="search" class="td-search__input form-control td-search-input" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off">
+  <input type="search" name="q" {{/**/ -}}
+    class="td-search__input form-control td-search-input" {{/**/ -}}
+    placeholder='{{ T "ui_search" }}' {{/**/ -}}
+    aria-label='{{ T "ui_search" }}' autocomplete="off">
 </div>
 
 {{- end -}}
@@ -36,9 +41,10 @@
   <div class="td-search__icon"></div>
   <input
     type="search"
+    name="q"
     class="td-search__input form-control"
-    placeholder="{{ T "ui_search" }}"
-    aria-label="{{ T "ui_search" }}"
+    placeholder='{{ T "ui_search" }}'
+    aria-label='{{ T "ui_search" }}'
     autocomplete="off"
     {{/*
       The data attribute name of the json file URL must end with `src` since

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.2-dev+005-over-main-a6050113",
+  "version": "0.14.2-dev+006-over-main-cc763a9b",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2545
- Adds a `name` attribute to the search input element

**Preview**:

- https://deploy-preview-2549--docsydocs.netlify.app/
- https://deploy-preview-2549--docsydocs.netlify.app/search/?q=search