### PR TITLE
Update blog and CL for 0.14.2, refactor contrib pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
 The contributing page is published online, see
-[Contributing](https://www.docsy.dev/project/about/contributing/) or the
-[page source](docsy.dev/content/en/project/about/contributing.md).
+[Contributing](https://www.docsy.dev/docs/contributing/) or the
+[page source](docsy.dev/content/en/docs/contributing.md).

--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -2,10 +2,11 @@
 
 /content/**/*.*
 !/content/en/blog/**/*.*
+!/content/en/community/**/*.*
 !/content/en/docs/_index.md
 !/content/en/docs/best-practices/**/*.*
 !/content/en/docs/content/**/*.*
-!/content/en/docs/contribution-guidelines/**/*.*
+!/content/en/docs/contributing.md
 !/content/en/docs/get-started/**/*.*
 !/content/en/docs/language.md
 !/content/en/examples/**/*.*

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -2,19 +2,21 @@
 title: Release 0.14.0 report and upgrade guide
 linkTitle: Release 0.14.0
 date: 2026-02-10
+lastmod: 2026-02-12
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 body_class: release-highlights
 tags: [release, upgrade]
-cSpell:ignore: docsy subrepo lightdark lookandfeel
+cSpell:ignore: docsy subrepo lightdark lookandfeel onedark
 ---
 
-> [!INFO] Patch update: 0.14.1 <a id="patch-update-0-14-1"></a>
+> [!INFO] Patch updates 0.14.2 and 0.14.1
 >
-> Docsy 0.14.1 is a patch release with one fix: Fixed ToC sidebar width in xl
-> viewports ([#2538]). If you are upgrading now, follow this guide and use
-> 0.14.1 where it references 0.14.0.
+> For the key fixes of these patch updates, see [0.14.2][CL@0.14.2] and
+> [0.14.1][CL@0.14.1]. For other changes to 0.14.2, see
+> [Patch update 0.14.2](#0.14.2). If you are upgrading now, follow this guide
+> and use 0.14.2 where it references 0.14.0.
 
 <style>
   li > div.alert-nb { margin: 0.5rem 0 !important;}
@@ -66,6 +68,8 @@ cSpell:ignore: docsy subrepo lightdark lookandfeel
     processing
   - {{% _param BREAKING %}}
     [Hugo 0.155.0 requirement and 0.153+ breaking changes](#hugo)
+  - {{% _param BREAKING %}} [Docsy 0.14.2 code-style update](#0.14.2) for
+    light/dark mode
 - Optionally skim:
   - {{% _param NEW %}} New features (look for the green checkmark icon)
   - {{% _param CLEANUP %}} Cleanup / improvement opportunities (look for this
@@ -410,6 +414,32 @@ guide][hugo-0.152.0+]. For a comprehensive list of issues and considerations
 when moving to Hugo 0.153+, see [Hugo 0.153+ breaking changes & issues
 (#2431)][#2431].
 
+## {{% _param BREAKING %}} / {{% _param NEW %}} Patch update 0.14.2 {#0.14.2}
+
+Docsy 0.14.2 adds the following changes:
+
+- For sites using `td/code-dark`, default code styles changed from
+  `tango`/`onedark` to `friendly`/`native` ([#2548]).
+- {{% _param NEW %}} Console block selection and copy-code now include commands
+  only, not output ([#2548]). For details, see [Selecting console block
+  content][].
+- Search form now includes a `name` attribute for better semantics and autofill
+  behavior ([#2549]).
+
+### Actions: required and optional {#0.14.2-actions}
+
+- {{% _param BREAKING %}} **Applies if** you use `td/code-dark` and you want to
+  revert to the `tango`/`onedark` styles. Follow the steps in [Light/dark code
+  styles and more][].
+- Verify that copy-code behavior in console examples (commands only) matches
+  your expectations. To use the old behavior, see [Selecting console block
+  content][].
+
+[Light/dark code styles and more]:
+  /docs/content/lookandfeel/#lightdark-code-styles
+[Selecting console block content]:
+  /docs/content/lookandfeel/#selecting-console-block-content
+
 ## Other notable Docsy changes {#other-notable-changes}
 
 ### {{% _param FAS globe "" %}} Internationalization
@@ -477,10 +507,10 @@ changes require action:
 
 Some upgrade steps are the same for each Docsy release (for example, updating
 your Docsy NPM package or Hugo module). Those steps are described in [Upgrade to
-Docsy 0.12.0][]: follow them, using version **0.14.1** where the guide refers to
+Docsy 0.12.0][]: follow them, using version **0.14.2** where the guide refers to
 0.12.0. For this release, use:[^vers-note]
 
-- **Docsy**: [0.13.0] → [0.14.1]
+- **Docsy**: [0.13.0] → [0.14.2]
 - **Hugo**: 0.152.2 → 0.155.0 or later, see [Hugo 0.152.0-0.155.x upgrade
   guide][hugo-0.152.0+]
 - **Node**: LTS 24 (unchanged)
@@ -545,6 +575,9 @@ These quick checks relate to the style and behavior changes in 0.14.0.
       [Heading aliases and in-page targets](#heading-aliases)).
 - [ ] `<details>` spacing in content pages.
 - [ ] TOC h1 weight/contrast in the right sidebar.
+- [ ] If you use `td/code-dark`, code block styles in light and dark mode match
+      your expectations.
+- [ ] Console copy-code behavior copies commands (not output) where intended.
 - [ ] If you enable experimental extra styles, check nav link decoration and
       nested list spacing.
 
@@ -634,8 +667,8 @@ an [issue] or starting a [discussion].
 
 About this release:
 
-- [0.14.0][CL@0.14.0] and [0.14.1][CL@0.14.1] changelog entries
-- [0.14.0][0.14.0] and [0.14.1][0.14.1] release pages
+- [0.14.0][CL@0.14.0] and [0.14.2][CL@0.14.2] changelog entries
+- [0.14.0][0.14.0] and [0.14.2][0.14.2] release pages
 - [Release 0.14.0 preparation **issue** (#2404)][#2404]
 
 Other references:
@@ -653,15 +686,17 @@ Other references:
 [#2501]: https://github.com/google/docsy/issues/2501
 [#2524]: https://github.com/google/docsy/pull/2524
 [#2533]: https://github.com/google/docsy/pull/2533
-[#2538]: https://github.com/google/docsy/pull/2538
+[#2548]: https://github.com/google/docsy/pull/2548
+[#2549]: https://github.com/google/docsy/pull/2549
 [#939]: https://github.com/google/docsy/issues/939
 [0.13.0]: /project/about/changelog/#v0.13.0
 [0.14.0]: https://github.com/google/docsy/releases/v0.14.0?no-link-check=1
-[0.14.1]: https://github.com/google/docsy/releases/v0.14.1?no-link-check=1
+[0.14.2]: https://github.com/google/docsy/releases/v0.14.2?no-link-check=1
 [Advanced style customization]:
   /docs/content/lookandfeel/#advanced-style-customization
 [CL@0.14.0]: /project/about/changelog/#v0.14.0
 [CL@0.14.1]: /project/about/changelog/#v0.14.1
+[CL@0.14.2]: /project/about/changelog/#v0.14.2
 [experimental]: /project/about/changelog/#experimental
 [hugo-0.152.0+]: /blog/2026/hugo-0.152.0+/
 [officially supports]: /project/about/changelog/#official-support

--- a/docsy.dev/content/en/community/_index.md
+++ b/docsy.dev/content/en/community/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Community
-menu: {main: {weight: 40}}
+menu: { main: { weight: 40 } }
 # Content below, if any, will be added to the community page.
 ---

--- a/docsy.dev/content/en/docs/contributing.md
+++ b/docsy.dev/content/en/docs/contributing.md
@@ -1,6 +1,7 @@
 ---
 title: Contribution guidelines
 description: How to contribute to Docsy
+aliases: [contribution-guidelines]
 weight: 9
 cSpell:ignore: docsy
 ---

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -10,10 +10,8 @@ We only document **breaking changes** and release **highlights** in this page.
 For the full list of changes of any particular release, see the [release
 notes][releases].
 
-Useful links:
-
-- [Releases] & [tags]. Jump to the [latest] release.
-- [Milestones]
+Useful links: [Releases] & [tags], jump to the [latest] release, and view the
+[milestones].
 
 [latest]: https://github.com/google/docsy/releases/latest
 [milestones]: https://github.com/google/docsy/milestones
@@ -35,6 +33,9 @@ Useful links:
     needed.
 
 ## Definitions
+
+<details>
+<summary>Definitions...</summary>
 
 ### Public customization surface {#public}
 
@@ -110,21 +111,24 @@ Any other compatibility (including Windows support) is on a best effort basis.
 
 <!-- TODO: look into https://www.conventionalcommits.org/en/v1.0.0/#summary -->
 
+</details>
+
 ## Next release
 
-> **UNRELEASED**: v0.14.2 or v0.15.0 - still under development
+> **UNRELEASED**: v0.14.3 or v0.15.0 - still under development
+
+<details>
+<summary>To be completed</summary>
 
 For the full list of changes, see the [0.15.0][] release page.
 
 [**Breaking changes**](#breaking-change):
 
-- **Default code styles** changed from `tango`/`onedark` to `friendly`/`native`
-  for sites using `td/code-dark`.
+- ...
 
 **New**:
 
-- **Console block content selection**: selection and copy-code now only includes
-  commands, not output.
+- ...
 
 **Other changes**:
 
@@ -134,19 +138,53 @@ For the full list of changes, see the [0.15.0][] release page.
 
 - ...
 
+</details>
+
 [0.15.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.15.0
+
+## v0.14.2 {#v0.14.2}
+
+**Key fix** for this patch: Apply `.td-main` flex only when sidebar exists
+([#2546]).
+
+For the full list of changes, see the [release report][0.14.2-blog] and
+[0.14.2][] release page.
+
+[**Breaking changes**](#breaking-change):
+
+- **[Default code styles][0.14.2-blog]** changed from `tango`/`onedark` to
+  `friendly`/`native` for sites using `td/code-dark` ([#2548]).
+
+**New**:
+
+- **[Console block content selection][0.14.2-blog]**: selection and copy-code
+  now only includes commands, not output ([#2548]).
+
+**Other changes**:
+
+- Added `name` attribute to search form field for better semantics and autofill
+  ([#2549]).
+- Package version build metadata and footer icon tweaks ([#2547]).
+
+[#2546]: https://github.com/google/docsy/pull/2546
+[#2547]: https://github.com/google/docsy/pull/2547
+[#2548]: https://github.com/google/docsy/pull/2548
+[#2549]: https://github.com/google/docsy/pull/2549
+[0.14.2]: https://github.com/google/docsy/releases/v0.14.2
+[0.14.2-blog]: /blog/2026/0.14.0/#0.14.2
 
 ## v0.14.1 {#v0.14.1}
 
-Patch release [0.14.1][]:
-
-- Fixed **ToC** sidebar width in xl viewports ([#2538]).
+Patch release [0.14.1][]: fixed **ToC** sidebar width in xl viewports ([#2538]).
 
 [0.14.1]: https://github.com/google/docsy/releases/v0.14.1
 
 ## v0.14.0 {#v0.14.0}
 
-For the full list of changes, see the [0.14.0][] release page.
+**Resources**:
+
+- [Release 0.14.0 report and upgrade guide][0.14.0-blog]
+- [0.14.0][] release page for the full list of changes
 
 [**Breaking changes**](#breaking-change):
 
@@ -165,9 +203,11 @@ For the full list of changes, see the [0.14.0][] release page.
 **New**:
 
 - **[Markdown alert syntax][0.14.0-blog-alerts]**: added support for Hugo's
-  Markdown alert syntax.
+  Markdown alert syntax ([#2443]).
 - **`td/site-build-info/netlify` shortcode** (experimental), see
-  [Shortcodes][0.14.0-blog-shortcodes].
+  [Shortcodes][0.14.0-blog-shortcodes] ([#2444]).
+- **`td-below-navbar` helper class** for [`blocks/cover`][0.14.0-blog-cover]
+  positioning ([#2480]).
 
 **Other changes**:
 
@@ -188,13 +228,14 @@ For the full list of changes, see the [0.14.0][] release page.
 [#1654]: https://github.com/google/docsy/issues/1654
 [#2413]: https://github.com/google/docsy/issues/2413
 [#2431]: https://github.com/google/docsy/issues/2431
+[#2443]: https://github.com/google/docsy/pull/2443
+[#2444]: https://github.com/google/docsy/pull/2444
 [#2470]: https://github.com/google/docsy/pull/2470
 [#2477]: https://github.com/google/docsy/pull/2477
 [#2480]: https://github.com/google/docsy/pull/2480
 [#2524]: https://github.com/google/docsy/pull/2524
 [#2533]: https://github.com/google/docsy/pull/2533
 [#2538]: https://github.com/google/docsy/pull/2538
-[0.14.0]: https://github.com/google/docsy/releases/v0.14.0
 [0.14.0-blog-alerts]: /blog/2026/0.14.0/#alerts
 [0.14.0-blog-cover]: /blog/2026/0.14.0/#blocks-cover
 [0.14.0-blog-heading-aliases]: /blog/2026/0.14.0/#heading-aliases
@@ -205,6 +246,8 @@ For the full list of changes, see the [0.14.0][] release page.
 [0.14.0-blog-shortcodes]: /blog/2026/0.14.0/#shortcodes
 [0.14.0-blog-style-fixes]: /blog/2026/0.14.0/#style-improvements-and-fixes
 [0.14.0-blog-swagger]: /blog/2026/0.14.0/#swagger-scss
+[0.14.0-blog]: /blog/2026/0.14.0/
+[0.14.0]: https://github.com/google/docsy/releases/v0.14.0
 
 ## v0.13.0 {#v0.13.0}
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -1,12 +1,12 @@
 ---
 title: Maintainer notes
 description: Notes for Docsy maintainers
-aliases: [../contributing]
+aliases: [contributing, ../contributing]
 cSpell:ignore: docsy hugo creatordate
 ---
 
 For our main contributing page covering license agreements, code of conduct and
-more, see [Contribution guidelines][]. This page is for **maintainers only**.
+more, see [Contributing][]. This page is for **maintainers only**.
 
 ## Publishing a release
 
@@ -16,7 +16,7 @@ accordingly.
 
 1.  **Change directory** to your local Docsy repo.
 
-2.  **Create or update a [CHANGELOG] entry** for {{% param version %}}.
+2.  **Create or update a [changelog][] entry** for {{% param version %}}.
     - The section should provide a brief summary of breaking changes using the
       section template at the end of the file.
     - Ensure to remove the UNRELEASED note.
@@ -307,12 +307,12 @@ before any further changes are merged into the `main` branch:
   script help for usage.
 
 [changelog]: /project/about/changelog/
-[contribution guidelines]: /docs/contribution-guidelines/
+[contributing]: /docs/contributing/
 [docsy-example]: https://github.com/google/docsy-example
 [docsy.dev]: https://www.docsy.dev/
+[docsy.dev/hugo.yaml]:
+  https://github.com/google/docsy/blob/main/docsy.dev/hugo.yaml
 [Draft a new release]: https://github.com/google/docsy/releases/new
 [go.mod]: https://github.com/google/docsy/blob/main/go.mod
 [package.json]: https://github.com/google/docsy/blob/main/package.json
-[docsy.dev/hugo.yaml]:
-  https://github.com/google/docsy/blob/main/docsy.dev/hugo.yaml
 [release-branch]: https://github.com/google/docsy/tree/release

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -63,7 +63,7 @@ params:
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
   version: 0.14.2-dev
-  versionWithBuildId: 0.14.2-dev+006-over-main-cc763a9b
+  versionWithBuildId: 0.14.2-dev+007-over-main-a1ddcab5
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy
   github_subdir: docsy.dev

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1379,6 +1379,14 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:19:01.139074-05:00"
   },
+  "https://github.com/google/docsy/pull/2443": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:10.432616-05:00"
+  },
+  "https://github.com/google/docsy/pull/2444": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:11.057764-05:00"
+  },
   "https://github.com/google/docsy/pull/2447": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:58.630851-05:00"
@@ -1410,6 +1418,22 @@
   "https://github.com/google/docsy/pull/2538": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:05.405992-05:00"
+  },
+  "https://github.com/google/docsy/pull/2546": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:08.217224-05:00"
+  },
+  "https://github.com/google/docsy/pull/2547": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:09.481344-05:00"
+  },
+  "https://github.com/google/docsy/pull/2548": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:08.334995-05:00"
+  },
+  "https://github.com/google/docsy/pull/2549": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T09:54:08.892388-05:00"
   },
   "https://github.com/google/docsy/pull/941": {
     "StatusCode": 206,
@@ -1470,6 +1494,10 @@
   "https://github.com/google/docsy/releases/v0.14.1": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:05.299942-05:00"
+  },
+  "https://github.com/google/docsy/releases/v0.14.2": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T07:50:49.680299-05:00"
   },
   "https://github.com/google/docsy/releases/v0.2.0": {
     "StatusCode": 206,
@@ -2191,6 +2219,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:06.451949-05:00"
   },
+  "https://main--docsydocs.netlify.app/docs/contributing/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T11:15:10.534035-05:00"
+  },
   "https://markmap.js.org/": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:57.576568-05:00"
@@ -2470,6 +2502,10 @@
   "https://www.docsy.dev/blog/2024/0.9.0/": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:50.227542-05:00"
+  },
+  "https://www.docsy.dev/docs/contributing/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-02-12T10:30:32.988537-05:00"
   },
   "https://www.docsy.dev/docs/get-started/": {
     "StatusCode": 206,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.2-dev+006-over-main-cc763a9b",
+  "version": "0.14.2-dev+007-over-main-a1ddcab5",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.14/commit-inventory.md
+++ b/tasks/0.14/commit-inventory.md
@@ -1,10 +1,10 @@
 ---
 title: 0.14 commit inventory
 date: 2026-01-16
-cSpell:ignore: docsy frontmatter subrepo
+cSpell:ignore: docsy frontmatter subrepo refache sidenav cyrillic latin
 ---
 
-> Report refreshed for commits through `37be7dc7` on `main`.
+> Report refreshed for commits through `a1ddcab5` on `main`.
 
 Chronological list of [commits since v0.13.0][], broadly grouped into a few
 categories. We'll do a more detailed analysis and groupings when we create the
@@ -96,7 +96,20 @@ client projects.
 - `3753ff78` (#2505) Reorganize SCSS, fix scroll padding, normalize
   blocks-shortcode heading IDs and keep old IDs as alias
 
-### Since last refresh (3753ff78..37be7dc7)
+### Since last refresh (37be7dc7..a1ddcab5)
+
+- `20ff86e7` (#2540) Release 0.14.1 preparation
+- `6f8afa37` (#2542) Set version to 0.14.2-dev-001-over-main-20ff86e7, and more
+- `1f21d33c` (#2543) Update supported Docsy vers for main examples, and other
+  misc changes
+- `55a3fb27` (#2546) Apply .td-main flex only when sidebar exists
+- `a6050113` (#2547) Adjust pkg version logic splitting out build metadata, and
+  tweak footer icons
+- `cc763a9b` (#2548) Console code blocks: output is no longer selectable; and
+  code style changes
+- `a1ddcab5` (#2549) Add name attribute to search input
+
+### Previous refresh (3753ff78..37be7dc7)
 
 - `4dc710b4` (#2506) Document heading aliases and in-page targets
 - `0ddab73a` (#2508) Improve 0.14.0 upgrade action-step guidance

--- a/tasks/0.14/release-wrapup.plan.md
+++ b/tasks/0.14/release-wrapup.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.14 Release wrapup plan
 date: 2026-01-16
-last-main-commit: 37be7dc7
+last-main-commit: a1ddcab5
 cSpell:ignore: docsy
 ---
 
@@ -79,7 +79,7 @@ Repeat when new commits land on `main` do the following:
 - Take note of fixes and features that are not yet documented in the blog post
   or changelog.
 
-Report refreshed for commits through [37be7dc7].
+Report refreshed for commits through [a1ddcab5].
 
 ### 0.14.0 blog post
 

--- a/tasks/0.14/wrapup-report.md
+++ b/tasks/0.14/wrapup-report.md
@@ -4,7 +4,7 @@ date: 2026-01-16
 cSpell:ignore: docsy
 ---
 
-> Report refreshed for commits through `37be7dc7` on `main`.
+> Report refreshed for commits through `a1ddcab5` on `main`.
 
 ## Highlights since v0.13.0
 
@@ -146,6 +146,19 @@ Verification, testing, and QA:
 - Structured as a release report focusing on new features and improvements, with
   a brief upgrade section that references the 0.13.0 upgrade guide for command
   examples.
+
+## Refresh note (a1ddcab5)
+
+- Plan and reports updated for commits through `a1ddcab5`. New commits in
+  [commit-inventory.md](commit-inventory.md) under "Since last refresh
+  (37be7dc7..a1ddcab5)": #2540 Release 0.14.1 preparation; #2542 version bump;
+  #2543 examples and misc; #2546 Apply .td-main flex only when sidebar exists
+  (0.14.2); #2547 pkg version build metadata and footer icons; #2548 Console
+  code blocks output not selectable, code style changes (friendly/native); #2549
+  Add name attribute to search input.
+- Changelog: 0.14.2 and "Next release" already cover #2546, console/code styles.
+  Added search input name (#2549) and version/footer (#2547) to Next release.
+- Blog: corrected [#2546] link (was pointing to #2538).
 
 ## Refresh note (37be7dc7)
 


### PR DESCRIPTION
**Preview**:

- https://deploy-preview-2550--docsydocs.netlify.app/blog/2026/0.14.0/
- https://deploy-preview-2550--docsydocs.netlify.app/docs/contributing/
- https://deploy-preview-2550--docsydocs.netlify.app/project/about/maintainer-notes/