### PR TITLE
layouts: use 'note' role instead of 'alert'

### DIFF
--- a/layouts/_markup/render-blockquote-alert.html
+++ b/layouts/_markup/render-blockquote-alert.html
@@ -19,7 +19,7 @@
   {{ $classes = printf "%s %s" $classes . -}}
 {{ end -}}
 
-<div class="{{ $classes }}" role="alert"
+<div class="{{ $classes }}" role="note"
   {{- range $key, $value := .Attributes -}}
     {{ if eq $key "class" }}{{ continue -}}{{ end -}}
     {{ printf " %s=%q" $key (string $value) | safeHTMLAttr -}}

--- a/layouts/_shortcodes/alert.html
+++ b/layouts/_shortcodes/alert.html
@@ -10,7 +10,7 @@ For details, see https://www.docsy.dev/docs/content/shortcodes/#alert.
 
 {{ $color := .Get "color" | default "primary" -}}
 
-<div class="alert alert-{{ $color }}" role="alert">
+<div class="alert alert-{{ $color }}" role="note">
 {{- with .Get "title" -}}
   <div class="h4 alert-heading" role="heading">
     {{- . | safeHTML -}}


### PR DESCRIPTION
The 'alert' role is meant for feedback deserving immediate attention, such as an incoming message.
The 'note' role, on the other hand, is meant for content that has no suitable semantic element otherwise and is supposed to hint the user on ancillary information.

See:
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/alert_role
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role

same as https://github.com/kubernetes/website/pull/54363