### PR TITLE
chore(docs): reorg deployment section, normalize links

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -9,6 +9,7 @@
     "CNCF",
     "docset",
     "docsets",
+    "docsy",
     "Docsy",
     "errorf",
     "Gantt",

--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -7,6 +7,7 @@
 !/content/en/docs/best-practices/**/*.*
 !/content/en/docs/content/**/*.*
 !/content/en/docs/contributing.md
+!/content/en/docs/deployment/**/*.*
 !/content/en/docs/get-started/**/*.*
 !/content/en/docs/language.md
 !/content/en/examples/**/*.*

--- a/docsy.dev/content/en/blog/2023/0.7.x.md
+++ b/docsy.dev/content/en/blog/2023/0.7.x.md
@@ -7,7 +7,7 @@ author: >
   [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc))
 date: 2023-08-03
 aliases: [docsy-0.7]
-cSpell:ignore: opentelemetry namespacing docsy
+cSpell:ignore: opentelemetry namespacing
 ---
 
 Last June, Docsy celebrated a significant milestone with the release of version

--- a/docsy.dev/content/en/blog/2023/priorities-for-2024.md
+++ b/docsy.dev/content/en/blog/2023/priorities-for-2024.md
@@ -6,7 +6,7 @@ author: >
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 date: 2023-11-28
 # prettier-ignore
-cSpell:ignore: opentelemetry namespacing docsy customizability deprioritize
+cSpell:ignore: opentelemetry namespacing customizability deprioritize
 ---
 
 > **TL;DR** 1.4K projects use Docsy! The top user-project focused priorities for
@@ -78,7 +78,7 @@ and feature consolidation.
   https://www.cncf.io/blog/2023/01/19/fast-and-effective-tools-for-cncf-and-open-source-project-websites/
 [docsy-analytics]: https://github.com/google/docsy/network/dependents
 [ce]: https://github.com/kentcdodds/cross-env/issues/257
-[sc]: https://www.docsy.dev/blog/2022/hello/#introducing-the-psc
-[bs5-migration]: https://www.docsy.dev/blog/2023/bootstrap-5-migration/
+[sc]: ../2022/hello/#introducing-the-psc
+[bs5-migration]: bootstrap-5-migration/
 [share your thoughts]: https://github.com/google/docsy/discussions
 [quarterly milestones]: https://github.com/google/docsy/milestones

--- a/docsy.dev/content/en/blog/2024/year-in-review.md
+++ b/docsy.dev/content/en/blog/2024/year-in-review.md
@@ -31,13 +31,13 @@ lies ahead.
 We published three releases this year, each focusing on stability while
 introducing at least one major feature enhancement. Highlights include:
 
-- **[0.9.0](https://www.docsy.dev/blog/2024/0.9.0/)** added _long-awaited_:
+- **[0.9.0](0.9.0/)** added _long-awaited_:
   - **CI testing** via GitHub Actions to ensure quality and reliability across
     Linux and Windows.
   - **Footer customization** &mdash; Docsy's [longest-standing issue (#2)][#2]!
     &mdash; as well as improved repository links, and enhanced accessibility and
     look-and-feel.
-- **[0.10.0](https://www.docsy.dev/blog/2024/0.10.0/):**
+- **[0.10.0](0.10.0/):**
   - Enabled [color themes and **dark mode**][dark mode] via Bootstrap 5.3
     upgrade, marking the completion of the [Bootstrap 5 migration] started
     in 2021. Also made adjustments to shortcodes and styles for dark-mode

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -6,7 +6,6 @@ lastmod: 2025-11-14
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
-cSpell:ignore: docsy
 tags: [upgrade]
 ---
 

--- a/docsy.dev/content/en/blog/2025/0.13.0.md
+++ b/docsy.dev/content/en/blog/2025/0.13.0.md
@@ -9,7 +9,7 @@ author: >-
 message: Hello, world!
 body_class: release-highlights
 tags: [release, upgrade]
-cSpell:ignore: docsy FOUC lookandfeel mhchem katex notoc lightdark
+cSpell:ignore: FOUC lookandfeel mhchem katex notoc lightdark
 ---
 
 {{% card header="Highlights" %}}

--- a/docsy.dev/content/en/blog/2026/0.14.0.md
+++ b/docsy.dev/content/en/blog/2026/0.14.0.md
@@ -8,7 +8,7 @@ author: >-
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 body_class: release-highlights
 tags: [release, upgrade]
-cSpell:ignore: docsy subrepo lightdark lookandfeel onedark
+cSpell:ignore: subrepo lightdark lookandfeel onedark
 ---
 
 > [!INFO] Patch updates 0.14.2 and 0.14.1

--- a/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
@@ -8,7 +8,7 @@ author: >-
 body_class: release-highlights
 tags: [hugo, upgrade]
 # prettier-ignore
-cSpell:ignore: docsy dartsass libsass IPTC multihost libwebp opentelemetry
+cSpell:ignore: dartsass libsass IPTC multihost libwebp opentelemetry
 ---
 
 This post summarizes the breaking and notable changes in Hugo 0.152.0 to

--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -2,7 +2,7 @@
 title: Diagrams and Formulae
 weight: 11
 description: Add generated diagrams and scientific formulae to your site.
-cSpell:ignore: docsy gatsby goldmark linenos markmap mhchem plantuml
+cSpell:ignore: gatsby goldmark linenos markmap mhchem plantuml
 ---
 
 Docsy has built-in support for a number of diagram creation and typesetting

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -9,7 +9,7 @@ params:
     light/dark mode menu <span class='badge text-bg-warning fs-6
     float-end'>EXPERIMENTAL</span>
 # prettier-ignore
-cSpell:ignore: anotherclass autoprefixing docsy lightdark monokai myclass onedark rgba wordmark FOUC
+cSpell:ignore: anotherclass autoprefixing lightdark monokai myclass onedark rgba wordmark FOUC
 ---
 
 By default, a site using Docsy has the theme's default fonts, colors, and

--- a/docsy.dev/content/en/docs/content/repository-links.md
+++ b/docsy.dev/content/en/docs/content/repository-links.md
@@ -3,7 +3,7 @@ title: Repository Links and other page information
 linkTitle: Repo links and page info
 description:
   Help your users interact with page source and view page-source information.
-cSpell:ignore: docsy lastmod
+cSpell:ignore: lastmod
 weight: 9
 ---
 

--- a/docsy.dev/content/en/docs/content/search.md
+++ b/docsy.dev/content/en/docs/content/search.md
@@ -69,7 +69,7 @@ params:
 By default Docsy uses a [Google Custom Search Engine][GCSE] (GCSE) to search
 your site. To enable this feature, you'll first need to make sure that you have
 built and deployed a
-[production version of your site](/docs/deployment#build-environments-and-indexing),
+[production version of your site](/docs/deployment/#build-environments-and-indexing),
 as otherwise your site won't be crawled and indexed.
 
 ### Setting up site search
@@ -288,11 +288,11 @@ results appear in a drop down when you use the search box.
 
 > [!TIP]
 >
-> If you're [testing this locally](/docs/deployment/#serving-your-site-locally)
-> using Hugo’s local server functionality, you need to build your
-> `offline-search-index.xxx.json` file first by running `hugo`. If you have the
-> Hugo server running while you build `offline-search-index.xxx.json`, you may
-> need to stop the server and restart it in order to see your search results.
+> If you're [testing this locally](/docs/deployment/local) using Hugo’s local
+> server functionality, you need to build your `offline-search-index.xxx.json`
+> file first by running `hugo`. If you have the Hugo server running while you
+> build `offline-search-index.xxx.json`, you may need to stop the server and
+> restart it in order to see your search results.
 
 ### Changing the summary length of the local search results
 

--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -11,7 +11,7 @@ resources:
 params:
   message: Hello, world!
 # prettier-ignore
-cSpell:ignore: cardpane docsy imgproc pageinfo petstore Bjørn Pedersen swaggerui grayscale Picea tryautoheight readfile domsignal buildcondition
+cSpell:ignore: cardpane imgproc pageinfo petstore Bjørn Pedersen swaggerui grayscale Picea tryautoheight readfile domsignal buildcondition
 ---
 
 {{< comment >}}

--- a/docsy.dev/content/en/docs/contributing.md
+++ b/docsy.dev/content/en/docs/contributing.md
@@ -3,7 +3,6 @@ title: Contribution guidelines
 description: How to contribute to Docsy
 aliases: [contribution-guidelines]
 weight: 9
-cSpell:ignore: docsy
 ---
 
 Docsy is an open source project and we love getting patches and contributions to

--- a/docsy.dev/content/en/docs/deployment/_index.md
+++ b/docsy.dev/content/en/docs/deployment/_index.md
@@ -1,291 +1,34 @@
 ---
-title: Previews and Deployment
+title: Deployment and previews
+linkTitle: Deployment
 weight: 7
 description: Deploying your Docsy site.
-cSpell:ignore: docsy peaceiris exampleid
 ---
 
-There are multiple possible options for deploying a Hugo site, including Netlify, Firebase Hosting, Bitbucket with Aerobatic, and more; you can read about them all in [Hosting and Deployment](https://gohugo.io/hosting-and-deployment/). Hugo also makes it easy to deploy your site locally for quick previews of your content.
-
-## Serving your site locally
-
-Depending on your deployment choice you may want to serve your site locally during development to preview content changes. To serve your site locally:
-
-1. Ensure you have an up to date local copy of your site files cloned from your repo.
-
-1. Ensure you have the tools described in [Prerequisites and installation](/docs/get-started/docsy-as-module/installation-prerequisites) installed on your local machine, including `postcss-cli` (you'll need it to generate the site resources the first time you run the server).
-1. Run the `hugo server` command in your site root. By default your site will be available at <http://localhost:1313>.
-
-Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site. If you have more than one local git branch, when you switch between git branches the local website reflects the files in the current branch.
+There are multiple possible options for deploying a Hugo site, including
+Netlify, Firebase Hosting, Bitbucket with Aerobatic, and more; you can read
+about them all in
+[Hosting and Deployment](https://gohugo.io/hosting-and-deployment/). Hugo also
+makes it easy to deploy your site locally for quick previews of your content.
 
 ## Build environments and indexing
 
-By default, Hugo sites built with `hugo` (rather than served locally with `hugo server`) have the Hugo build environment `production`. Deployed Docsy sites with `production` builds can be indexed by search engines, including [Google Custom Search Engines](/docs/content/search/#google-search). Production builds also have optimized JavaScript and CSS for live deployment (for example, minified JS rather than the more legible original source).
+By default, Hugo sites built with `hugo` (rather than served locally with
+`hugo server`) have the Hugo build environment `production`. Deployed Docsy
+sites with `production` builds can be indexed by search engines, including
+[Google Custom Search Engines](/docs/content/search/#google-search). Production
+builds also have optimized JavaScript and CSS for live deployment (for example,
+minified JS rather than the more legible original source).
 
-If you do not want your deployed site to be indexed by search engines (for example if you are still developing your live site), or if you want to build a development version of your site for offline analysis, you can set your Hugo build environment to something else such as `development` (the default for local deploys with `hugo server`), `test`, or another environment name of your choice.
+If you do not want your deployed site to be indexed by search engines (for
+example if you are still developing your live site), or if you want to build a
+development version of your site for offline analysis, you can set your Hugo
+build environment to something else such as `development` (the default for local
+deploys with `hugo server`), `test`, or another environment name of your choice.
 
-The simplest way to set this is by using the `-e` flag when specifying or running your `hugo` command, as in the following example:
+The simplest way to set this is by using the `-e` flag when specifying or
+running your `hugo` command, as in the following example:
 
 ```
 hugo -e development
 ```
-
-## Deployment with Netlify
-
-We recommend using [Netlify](https://www.netlify.com/) as a particularly simple way to serve your site from your Git provider (GitHub, GitLab, or BitBucket), with [continuous deployment](https://www.netlify.com/docs/continuous-deployment/), previews of the generated site when you or your users create pull requests against the doc repo, and more. Netlify is free to use for Open Source projects, with premium tiers if you require greater support.
-
-Before deploying with Netlify, make sure that you've pushed your site source to your chosen GitHub (or other provider) repo, following any setup instructions in [Using the theme](/docs/get-started/docsy-as-module).
-
-Then follow the instructions in [Host on Netlify](https://gohugo.io/hosting-and-deployment/hosting-on-netlify/) to set up a Netlify account (if you don't have one already) and authorize access to your GitHub or other Git provider account. Once you're logged in:
-
-1. Click **New site from Git**.
-1. Click your chosen Git provider, then choose your site repo from your list of repos.
-1. In the **Deploy settings** page:
-   1. Specify your **Build command**. The exact build command depends on how you have chosen to use Docsy:
-      * If you are using Docsy as a [Git submodule](/docs/get-started/other-options/#option-1-docsy-as-a-git-submodule), specify `cd themes/docsy && git submodule update -f --init && cd ../.. && hugo`. You need to specify this rather than just `hugo` so that Netlify can use the theme's submodules.
-      * If you are using Docsy as a [Hugo module](/docs/get-started/docsy-as-module/) or NPM package, you can just specify `hugo`.
-   3. Click **Show advanced**.
-   4. In the **Advanced build settings** section, click **New variable**.
-   5. Specify `NODE_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest LTS version](https://nodejs.org/en/download/) of Node.js.
-   6. In the **Advanced build settings** section, click **New variable**.
-   7. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://github.com/gohugoio/hugo/releases) of Hugo.
-   8. In the **Advanced build settings** section, click **New variable** again.
-   9. Specify `GO_VERSION` as the **Key** for the new variable, and set its **Value** to the [latest version](https://go.dev/dl/) of Go.
-
-   If you don't want your site to be indexed by search engines, you can add an environment flag to your build command to specify a non-`production` environment, as described in [Build environments and indexing](#build-environments-and-indexing).
-1. Click **Deploy site**.
-
-> [!NOTE]
->
-> Netlify uses your site repo's `package.json` file to install any JavaScript dependencies (like `postcss`) before building your site. If you haven't just copied our example site's version of this file, make sure that you've specified all our [prerequisites](/docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss).
->
-> For example, if you want to use a version of `postcss-cli` later than version 8.0.0, you need to ensure that your `package.json` also specifies `postcss` separately:
->
-> ```
->   "devDependencies": {
->     "autoprefixer": "^10.4.19",
->     "postcss-cli": "^11.0.0",
->     "postcss": "^8.4.38"
->   }
-> ```
-
-Alternatively, you can follow the same instructions but specify your **Deploy
-settings** in a [`netlify.toml` file][] in your repo rather than in the **Deploy
-settings** page. For an example, see the [netlify.toml][] for the Docsy website
-(though note that the build command here is a little unusual because the Docsy
-user guide is *inside* the theme repo).
-
-[`netlify.toml` file]: https://docs.netlify.com/configure-builds/file-based-configuration/
-[netlify.toml]: https://github.com/google/docsy/blob/main/docsy.dev/netlify.toml
-
-If you have an existing deployment you can view and update the relevant information by selecting the site from your list of sites in Netlify, then clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Focal 20.04** is selected in the **Build image selection** section - if you're creating a new deployment this is used by default. You need to use this image to run the extended version of Hugo.
-
-## Deployment on GitHub Pages
-
-If your repo is hosted on [GitHub](https://github.com), a simple option is to serve your site with [GitHub Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages). GitHub Pages lets you create project, user, and organization sites; for a project site, your site URL will be `http(s)://<username>.github.io/<repository_name>`, custom domains are also supported. GitHub Pages come with [continuous deployment](https://docs.github.com/en/actions/deployment/about-deployments/about-continuous-deployment) using GitHub actions, while the [marketplace for actions](https://github.com/marketplace?no-link-check&type=actions) has useful tools for spell and link checking, deploy previews, and more. Using your existing GitHub account, you can start by using the free plan for publicly available repositories, with premium tiers available for business use cases.
-
-The Docsy example site repo provides a [workflow file](https://github.com/google/docsy-example/blob/master/.github/workflows/deploy-github-pages.yml?no-link-check) that you can use when deploying to GitHub Pages. If you used the example site as template for your new site as described [here](https://www.docsy.dev/docs/get-started/docsy-as-module/example-site-as-template/), you may already have this file in your repo, if not the instructions below show you how to create your own workflow file.
-
-Before deploying on GitHub Pages, make sure that you've pushed your site source to your chosen GitHub repo, following any setup instructions in [Using the theme](/docs/get-started/docsy-as-module).
-
-> [!NOTE] Correct baseURL setting
->
-> Make sure to correctly set your site's `baseURL`, either via hugo's `--baseURL '…'` command line parameter or inside your `hugo.toml`/`hugo.yaml`/`hugo.json` configuration file. When deploying to GitHub pages your `baseURL` needs to be set to `https://<USERNAME>.github.io/<repository_name>`, otherwise your site layout will be broken.
-
-1. With GitHub Pages, a site is published to the branch `gh-pages` and served from there by default. You must create this branch first, either in the GitHub web interface or via command line (at the root of your local repo clone):
-
-    ```console
-    $ git checkout -b gh-pages
-    Switched to a new branch 'gh-pages'
-    ```
-
-1. Push this local branch to your repo:
-
-    ```console
-    $ git push --set-upstream origin gh-pages
-     details omitted …
-     * [new branch]      new -> new
-    branch 'gh-pages' set up to track 'origin/gh-pages'.
-    ```
-
-1. Switch back to the `main` (or `work`) branch of your repo:
-
-    ```console
-    $ git checkout main
-    Switched to branch 'main'
-
-    ```
-
-1. Check if you already have the workflow file `.github/workflows/deploy-github-pages.yml` in your repo. If this file doesn't exist, do the following:
-
-    1. Create a new empty workflow file from the root of your repo, as follows:
-
-       ```console
-       $ mkdir -p .github/workflows
-       $ touch .github/workflows/deploy-github-pages.yml
-       ```
-
-
-    1. Open the file in an editor of your choice, paste in the code below, and save the file:
-
-       ```yaml
-       name: Deployment to GitHub Pages
-
-       on:
-         workflow_dispatch:
-         push:
-           branches:
-             - main  # <-- specify the branch you want to deploy from
-         pull_request:
-
-       env:
-         REPO_NAME: ${{ github.event.repository.name }}
-         REPO_OWNER: ${{ github.repository_owner }}
-
-       jobs:
-         deploy:
-           runs-on: ubuntu-22.04
-           concurrency:
-             group: ${{ github.workflow }}-${{ github.ref }}
-           steps:
-             - uses: actions/checkout@v4
-               with:
-                 fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
-
-             - name: Setup Hugo
-               uses: peaceiris/actions-hugo@v3
-               with:
-                 hugo-version: {{% param "hugoMinVersion" %}}
-                 extended: true
-
-             - name: Setup Node
-               uses: actions/setup-node@v4
-               with:
-                 node-version: '20'
-                 cache: 'npm'
-                 cache-dependency-path: '**/package-lock.json'
-
-             - run: npm ci
-             - run: hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME} --minify
-
-             - name: Deploy
-               uses: peaceiris/actions-gh-pages@v4
-               if: ${{ github.ref == 'refs/heads/main' }} # <-- specify same branch as above here
-               with:
-                 github_token: ${{ secrets.GITHUB_TOKEN }}
-       ```
-
-   1. Add the file to the staging area, commit your change and push the change to your remote GitHub repo:
-
-       ```console
-       $ git add .github/workflows/deploy-github-pages.yml
-       $ git commit -m "Adding workflow file for site deployment"
-       $ git push origin
-       ```
-
-1. In your browser, make sure you are logged into your GitHub account. In your repo  **Settings**, select **Pages**.
-
-    1. Under **Build and deployment**, select **Deploy from a branch** in the **source** dropdown.
-
-    2. From the **branch** dropdown, select **gh-pages** as branch where the site is built from.
-
-    3. From the **folder** dropdown, select **/(root)** as root directory.
-
-That's it! Your deployment workflow for your site is configured.
-
-Any future push to the branch specified in your workflow file will now trigger the action workflow defined in the workflow file. Additionally, you can trigger the deployment manually by using GitHub web UI.
-
-Once you push to your repo, you can see the progress of the triggered workflow in the **Actions** tab of the GitHub web UI:
-
-```
-URL 'Repo actions': https://github.com/<username>/<repository_name>/actions
-```
-
-After the first successful deployment, a new environment `github-pages` is added to your repo. This is shown at the right of your repo main view (below **Releases** and **Packages**). When you click on this environment, a list of deployments is displayed:
-
-```
-URL 'Repo deployments': https://github.com/<username>/<repository_name>/deployments/
-```
-
-You can find out more in [Hosting on GitHub]( https://gohugo.io/hosting-and-deployment/hosting-on-github/) in the Hugo documentation.
-
-For advanced use cases, the [`hugo-action`](https://github.com/peaceiris/actions-hugo) used inside the workflow file has more configuration options, which are well [documented](https://github.com/marketplace/actions/hugo-setup).
-
-
-## Deployment with Amazon S3 + Amazon CloudFront
-
-There are several options for publishing your web site using [Amazon Web Services](https://aws.amazon.com). This section describes the most basic option, deploying your site using an S3 bucket and activating the CloudFront CDN (content delivery network) to speed up the delivery of your deployed contents.
-
-1. After your [registration](https://portal.aws.amazon.com/billing/signup#/start) at AWS, create your S3 bucket, connect it with your domain, and add it to the CloudFront CDN. This [blog post](https://www.noorix.com.au/blog/how-to/hosting-static-website-with-aws-s3-cloudfront/) has all the details and provides easy to follow step-by-step instructions for the whole procedure.
-1. Download and install the latest version 2 of the AWS [Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/get-started-install.html) (CLI). Then configure your CLI instance by issuing the command `aws configure` (make sure you have your AWS Access Key ID and your AWS Secret Access Key at hand):
-
-   ```
-   $ aws configure
-   AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
-   AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-   Default region name [None]: eu-central-1
-   Default output format [None]:
-   ```
-
-1. Check the proper configuration of your AWS CLI by issuing the command `aws s3 ls`, this should output a list of your S3 bucket(s).
-
-1. Inside your `hugo.toml`/`hugo.yaml`/`hugo.json`, add a `[deployment]` section like this one:
-
-    {{< tabpane >}}
-{{< tab header="Configuration file:" disabled=true />}}
-{{< tab header="hugo.toml" lang="toml" >}}
-[deployment]
-[[deployment.targets]]
-name = "aws"
-URL = "s3://www.your-domain.tld"
-cloudFrontDistributionID = "E9RZ8T1EXAMPLEID"
-{{< /tab >}}
-{{< tab header="hugo.yaml" lang="yaml" >}}
-deployment:
-  targets:
-    - name: aws
-      URL: 's3://www.your-domain.tld'
-      cloudFrontDistributionID: E9RZ8T1EXAMPLEID
-{{< /tab >}}
-{{< tab header="hugo.json" lang="json" >}}
-{
-  "deployment": {
-    "targets": [
-      {
-        "name": "aws",
-        "URL": "s3://www.your-domain.tld",
-        "cloudFrontDistributionID": "E9RZ8T1EXAMPLEID"
-      }
-    ]
-  }
-}
-{{< /tab >}}
-    {{< /tabpane >}}
-
-1. Run the command `hugo --gc --minify` to render the site's assets into the `public/` directory of your Hugo build environment.
-1. Use Hugo's built-in `deploy` command to deploy the site to S3:
-
-   ```
-   hugo deploy
-   Deploying to target "aws" (www.your-domain.tld)
-   Identified 77 file(s) to upload, totaling 5.3 MB, and 0 file(s) to delete.
-   Success!
-   Invalidating CloudFront CDN...
-   Success!
-   ```
-
-   As you can see, issuing the `hugo deploy` command automatically [invalidates](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html) your CloudFront CDN cache.
-
-1. That's all you need to do! From now on, you can easily deploy to your S3 bucket using Hugo's built-in `deploy` command!
-
-For more information about the Hugo `deploy` command, including command line options, see this [synopsis](https://gohugo.io/commands/hugo_deploy). In particular, you may find the `--maxDeletes int` option or the `--force` option (which forces upload of all files) useful.
-
-> [!NOTE] Automated deployment with GitHub actions
->
-> If the source of your site lives in a GitHub repository, you can use [GitHub Actions](https://docs.github.com/en/actions) to deploy the site to your S3 bucket as soon as you commit changes to your GitHub repo. Setup of this workflow is described in this [blog post](https://capgemini.github.io/development/Using-GitHub-Actions-and-Hugo-Deploy-to-Deploy-to-AWS/).
-
-> [!NOTE] Handling aliases
->
-> If you are using [aliases](https://gohugo.io/content-management/urls/#aliases) for URL management, you should have a look at this [blog post](https://blog.cavelab.dev/2021/10/hugo-aliases-to-s3-redirects/). It explains how to turn aliases into proper `301` redirects when using Amazon S3.
-
-If S3 does not meet your needs, consider AWS [Amplify Console](https://aws.amazon.com/amplify/console/). This is a more advanced continuous deployment (CD) platform with built-in support for the Hugo static site generator. A [starter](https://gohugo.io/hosting-and-deployment/hosting-on-aws-amplify/) can be found in Hugo's official docs.

--- a/docsy.dev/content/en/docs/deployment/amazon.md
+++ b/docsy.dev/content/en/docs/deployment/amazon.md
@@ -1,0 +1,122 @@
+---
+title: Deployment with Amazon S3 and CloudFront
+linkTitle: Amazon S3
+description: Deploying your Docsy site with Amazon S3 and Amazon CloudFront.
+cSpell:ignore: exampleid
+---
+
+There are several options for publishing your web site using
+[Amazon Web Services](https://aws.amazon.com). This section describes the most
+basic option, deploying your site using an S3 bucket and activating the
+CloudFront CDN (content delivery network) to speed up the delivery of your
+deployed contents.
+
+1. After your
+   [registration](https://portal.aws.amazon.com/billing/signup#/start) at AWS,
+   create your S3 bucket, connect it with your domain, and add it to the
+   CloudFront CDN. This
+   [blog post](https://www.noorix.com.au/blog/how-to/hosting-static-website-with-aws-s3-cloudfront/)
+   has all the details and provides easy to follow step-by-step instructions for
+   the whole procedure.
+1. Download and install the latest version 2 of the AWS
+   [Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/get-started-install.html)
+   (CLI). Then configure your CLI instance by issuing the command
+   `aws configure` (make sure you have your AWS Access Key ID and your AWS
+   Secret Access Key at hand):
+
+   ```console
+   $ aws configure
+   AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+   AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+   Default region name [None]: eu-central-1
+   Default output format [None]:
+   ```
+
+1. Check the proper configuration of your AWS CLI by issuing the command
+   `aws s3 ls`, this should output a list of your S3 bucket(s).
+
+<!-- prettier-ignore-start -->
+
+1. Inside your `hugo.toml`/`hugo.yaml`/`hugo.json`, add a `[deployment]` section
+   like this one:
+
+    {{< tabpane >}}
+{{< tab header="Configuration file:" disabled=true />}}
+{{< tab header="hugo.toml" lang="toml" >}}
+[deployment]
+[[deployment.targets]]
+name = "aws"
+URL = "s3://www.your-domain.tld"
+cloudFrontDistributionID = "E9RZ8T1EXAMPLEID"
+{{< /tab >}}
+{{< tab header="hugo.yaml" lang="yaml" >}}
+deployment:
+  targets:
+    - name: aws
+      URL: 's3://www.your-domain.tld'
+      cloudFrontDistributionID: E9RZ8T1EXAMPLEID
+{{< /tab >}}
+{{< tab header="hugo.json" lang="json" >}}
+{
+  "deployment": {
+    "targets": [
+      {
+        "name": "aws",
+        "URL": "s3://www.your-domain.tld",
+        "cloudFrontDistributionID": "E9RZ8T1EXAMPLEID"
+      }
+    ]
+  }
+}
+{{< /tab >}}
+    {{< /tabpane >}}
+
+<!-- prettier-ignore-end -->
+
+1. Run the command `hugo --gc --minify` to render the site's assets into the
+   `public/` directory of your Hugo build environment.
+1. Use Hugo's built-in `deploy` command to deploy the site to S3:
+
+   ```console
+   hugo deploy
+   Deploying to target "aws" (www.your-domain.tld)
+   Identified 77 file(s) to upload, totaling 5.3 MB, and 0 file(s) to delete.
+   Success!
+   Invalidating CloudFront CDN...
+   Success!
+   ```
+
+   As you can see, issuing the `hugo deploy` command automatically
+   [invalidates](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html)
+   your CloudFront CDN cache.
+
+1. That's all you need to do! From now on, you can easily deploy to your S3
+   bucket using Hugo's built-in `deploy` command!
+
+For more information about the Hugo `deploy` command, including command line
+options, see this [synopsis](https://gohugo.io/commands/hugo_deploy). In
+particular, you may find the `--maxDeletes int` option or the `--force` option
+(which forces upload of all files) useful.
+
+> [!NOTE] Automated deployment with GitHub actions
+>
+> If the source of your site lives in a GitHub repository, you can use
+> [GitHub Actions](https://docs.github.com/en/actions) to deploy the site to
+> your S3 bucket as soon as you commit changes to your GitHub repo. Setup of
+> this workflow is described in this
+> [blog post](https://capgemini.github.io/development/Using-GitHub-Actions-and-Hugo-Deploy-to-Deploy-to-AWS/).
+
+> [!NOTE] Handling aliases
+>
+> If you are using [aliases](https://gohugo.io/content-management/urls/#aliases)
+> for URL management, you should have a look at this
+> [blog post](https://blog.cavelab.dev/2021/10/hugo-aliases-to-s3-redirects/).
+> It explains how to turn aliases into proper `301` redirects when using Amazon
+> S3.
+
+If S3 does not meet your needs, consider AWS
+[Amplify Console](https://aws.amazon.com/amplify/console/). This is a more
+advanced continuous deployment (CD) platform with built-in support for the Hugo
+static site generator. A
+[starter](https://gohugo.io/hosting-and-deployment/hosting-on-aws-amplify/) can
+be found in Hugo's official docs.

--- a/docsy.dev/content/en/docs/deployment/github-pages.md
+++ b/docsy.dev/content/en/docs/deployment/github-pages.md
@@ -1,0 +1,184 @@
+---
+title: Deployment on GitHub Pages
+linkTitle: GitHub Pages
+description: Deploying your Docsy site to GitHub Pages.
+cSpell:ignore: peaceiris
+---
+
+If your repo is hosted on [GitHub](https://github.com), a simple option is to
+serve your site with [GitHub Pages][]. GitHub Pages lets you create project,
+user, and organization sites; for a project site, your site URL will be
+`http(s)://<username>.github.io/<repository_name>`, custom domains are also
+supported. GitHub Pages come with [continuous deployment][cd] using GitHub
+actions, while the [marketplace for actions][] has useful tools for spell and
+link checking, deploy previews, and more. Using your existing GitHub account,
+you can start by using the free plan for publicly available repositories, with
+premium tiers available for business use cases.
+
+The Docsy example site repo provides a [workflow file][] that you can use when
+deploying to GitHub Pages. If you used the [example site as template][] for your
+new site you may already have this file in your repo, if not the instructions
+below show you how to create your own workflow file.
+
+Before deploying on GitHub Pages, make sure that you've pushed your site source
+to your chosen GitHub repo, following any setup instructions in
+[Using the theme](/docs/get-started/docsy-as-module).
+
+> [!NOTE] Correct baseURL setting
+>
+> Make sure to correctly set your site's `baseURL`, either via hugo's
+> `--baseURL '…'` command line parameter or inside your
+> `hugo.toml`/`hugo.yaml`/`hugo.json` configuration file. When deploying to
+> GitHub pages your `baseURL` needs to be set to
+> `https://<USERNAME>.github.io/<repository_name>`, otherwise your site layout
+> will be broken.
+
+1. With GitHub Pages, a site is published to the branch `gh-pages` and served
+   from there by default. You must create this branch first, either in the
+   GitHub web interface or via command line (at the root of your local repo
+   clone):
+
+   ```console
+   $ git checkout -b gh-pages
+   Switched to a new branch 'gh-pages'
+   ```
+
+1. Push this local branch to your repo:
+
+   ```console
+   $ git push --set-upstream origin gh-pages
+    details omitted …
+    * [new branch]      new -> new
+   branch 'gh-pages' set up to track 'origin/gh-pages'.
+   ```
+
+1. Switch back to the `main` (or `work`) branch of your repo:
+
+   ```console
+   $ git checkout main
+   Switched to branch 'main'
+
+   ```
+
+1. Check if you already have the workflow file
+   `.github/workflows/deploy-github-pages.yml` in your repo. If this file
+   doesn't exist, do the following:
+   1. Create a new empty workflow file from the root of your repo, as follows:
+
+      ```console
+      $ mkdir -p .github/workflows
+      $ touch .github/workflows/deploy-github-pages.yml
+      ```
+
+   1. Open the file in an editor of your choice, paste in the code below, and
+      save the file:
+
+      ```yaml
+      name: Deployment to GitHub Pages
+
+      on:
+        workflow_dispatch:
+        push:
+          branches:
+            - main # <-- specify the branch you want to deploy from
+        pull_request:
+
+      env:
+        REPO_NAME: ${{ github.event.repository.name }}
+        REPO_OWNER: ${{ github.repository_owner }}
+
+      jobs:
+        deploy:
+          runs-on: ubuntu-22.04
+          concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}
+          steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+
+            - name: Setup Hugo
+              uses: peaceiris/actions-hugo@v3
+              with:
+                hugo-version: '{{% param "hugoMinVersion" %}}'
+                extended: true
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                node-version: '20'
+                cache: 'npm'
+                cache-dependency-path: '**/package-lock.json'
+
+            - run: npm ci
+            - run: >-
+                hugo --baseURL https://${REPO_OWNER}.github.io/${REPO_NAME}
+                --minify
+
+            - name: Deploy
+              uses: peaceiris/actions-gh-pages@v4
+              if: ${{ github.ref == 'refs/heads/main' }} # <-- specify same branch as above here
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+      ```
+
+   1. Add the file to the staging area, commit your change and push the change
+      to your remote GitHub repo:
+
+      ```console
+      $ git add .github/workflows/deploy-github-pages.yml
+      $ git commit -m "Adding workflow file for site deployment"
+      $ git push origin
+      ```
+
+1. In your browser, make sure you are logged into your GitHub account. In your
+   repo **Settings**, select **Pages**.
+   1. Under **Build and deployment**, select **Deploy from a branch** in the
+      **source** dropdown.
+
+   2. From the **branch** dropdown, select **gh-pages** as branch where the site
+      is built from.
+
+   3. From the **folder** dropdown, select **/(root)** as root directory.
+
+That's it! Your deployment workflow for your site is configured.
+
+Any future push to the branch specified in your workflow file will now trigger
+the action workflow defined in the workflow file. Additionally, you can trigger
+the deployment manually by using GitHub web UI.
+
+Once you push to your repo, you can see the progress of the triggered workflow
+in the **Actions** tab of the GitHub web UI:
+
+```
+URL 'Repo actions': https://github.com/<username>/<repository_name>/actions
+```
+
+After the first successful deployment, a new environment `github-pages` is added
+to your repo. This is shown at the right of your repo main view (below
+**Releases** and **Packages**). When you click on this environment, a list of
+deployments is displayed:
+
+```
+URL 'Repo deployments': https://github.com/<username>/<repository_name>/deployments/
+```
+
+You can find out more in
+[Hosting on GitHub](https://gohugo.io/hosting-and-deployment/hosting-on-github/)
+in the Hugo documentation.
+
+For advanced use cases, the
+[`hugo-action`](https://github.com/peaceiris/actions-hugo) used inside the
+workflow file has more configuration options, which are well
+[documented](https://github.com/marketplace/actions/hugo-setup).
+
+[GitHub Pages]:
+  https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages
+[cd]:
+  https://docs.github.com/en/actions/deployment/about-deployments/about-continuous-deployment
+[marketplace for actions]:
+  https://github.com/marketplace?no-link-check&type=actions
+[workflow file]:
+  https://github.com/google/docsy-example/blob/master/.github/workflows/deploy-github-pages.yml?no-link-check
+[example site as template]:
+  /docs/get-started/docsy-as-module/example-site-as-template/

--- a/docsy.dev/content/en/docs/deployment/local.md
+++ b/docsy.dev/content/en/docs/deployment/local.md
@@ -1,0 +1,24 @@
+---
+title: Serving your site locally
+linkTitle: Local
+---
+
+Depending on your deployment choice you may want to serve your site locally
+during development to preview content changes. To serve your site locally:
+
+1. Ensure you have an up to date local copy of your site files cloned from your
+   repo.
+
+1. Ensure you have the tools described in [Prerequisites and
+   installation][prereq] installed on your local machine, including
+   `postcss-cli` (you'll need it to generate the site resources the first time
+   you run the server).
+1. Run the `hugo server` command in your site root. By default your site will be
+   available at <http://localhost:1313>.
+
+Now that you're serving your site locally, Hugo will watch for changes to the
+content and automatically refresh your site. If you have more than one local git
+branch, when you switch between git branches the local website reflects the
+files in the current branch.
+
+[prereq]: /docs/get-started/docsy-as-module/installation-prerequisites

--- a/docsy.dev/content/en/docs/deployment/netlify.md
+++ b/docsy.dev/content/en/docs/deployment/netlify.md
@@ -1,0 +1,95 @@
+---
+title: Deployment on Netlify
+linkTitle: Netlify
+description: Deploying your Docsy site on Netlify.
+---
+
+We recommend using [Netlify](https://www.netlify.com/) as a particularly simple
+way to serve your site from your Git provider (GitHub, GitLab, or BitBucket),
+with [continuous deployment][cd], previews of the generated site when you or
+your users create pull requests against the doc repo, and more. Netlify is free
+to use for Open Source projects, with premium tiers if you require greater
+support.
+
+Before deploying with Netlify, make sure that you've pushed your site source to
+your chosen GitHub (or other provider) repo, following any setup instructions in
+[Using the theme](/docs/get-started/docsy-as-module).
+
+Then follow the instructions in [Host on Netlify][] to set up a Netlify account
+(if you don't have one already) and authorize access to your GitHub or other Git
+provider account. Once you're logged in:
+
+1. Click **New site from Git**.
+1. Click your chosen Git provider, then choose your site repo from your list of
+   repos.
+1. In the **Deploy settings** page:
+   1. Specify your **Build command**. The exact build command depends on how you
+      have chosen to use Docsy:
+      - If you are using Docsy as a [Git submodule][], specify
+        `cd themes/docsy && git submodule update -f --init && cd ../.. && hugo`.
+        You need to specify this rather than just `hugo` so that Netlify can use
+        the theme's submodules.
+      - If you are using Docsy as a [Hugo module][] or NPM package, you can just
+        specify `hugo`.
+   2. Click **Show advanced**.
+   3. In the **Advanced build settings** section, click **New variable**.
+   4. Specify `NODE_VERSION` as the **Key** for the new variable, and set its
+      **Value** to the [latest LTS version](https://nodejs.org/en/download/) of
+      Node.js.
+   5. In the **Advanced build settings** section, click **New variable**.
+   6. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its
+      **Value** to the
+      [latest version](https://github.com/gohugoio/hugo/releases) of Hugo.
+   7. In the **Advanced build settings** section, click **New variable** again.
+   8. Specify `GO_VERSION` as the **Key** for the new variable, and set its
+      **Value** to the [latest version](https://go.dev/dl/) of Go.
+
+   If you don't want your site to be indexed by search engines, you can add an
+   environment flag to your build command to specify a non-`production`
+   environment, as described in
+   [Build environments and indexing](/docs/deployment/#build-environments-and-indexing).
+
+1. Click **Deploy site**.
+
+> [!NOTE]
+>
+> Netlify uses your site repo's `package.json` file to install any JavaScript
+> dependencies (like `postcss`) before building your site. If you haven't just
+> copied our example site's version of this file, make sure that you've
+> specified all our [prerequisites][].
+>
+> For example, if you want to use a version of `postcss-cli` later than version
+> 8.0.0, you need to ensure that your `package.json` also specifies `postcss`
+> separately:
+>
+> ```
+>   "devDependencies": {
+>     "autoprefixer": "^10.4.19",
+>     "postcss-cli": "^11.0.0",
+>     "postcss": "^8.4.38"
+>   }
+> ```
+
+Alternatively, you can follow the same instructions but specify your **Deploy
+settings** in a [`netlify.toml` file][] in your repo rather than in the **Deploy
+settings** page. For an example, see the [netlify.toml][] for the Docsy website
+(though note that the build command here is a little unusual because the Docsy
+user guide is _inside_ the theme repo).
+
+[`netlify.toml` file]:
+  https://docs.netlify.com/configure-builds/file-based-configuration/
+[netlify.toml]: <{{% param github_repo %}}/blob/main/docsy.dev/netlify.toml>
+
+If you have an existing deployment you can view and update the relevant
+information by selecting the site from your list of sites in Netlify, then
+clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Focal
+20.04** is selected in the **Build image selection** section - if you're
+creating a new deployment this is used by default. You need to use this image to
+run the extended version of Hugo.
+
+[cd]: https://www.netlify.com/docs/continuous-deployment/
+[Host on Netlify]: https://gohugo.io/hosting-and-deployment/hosting-on-netlify/
+[Git submodule]:
+  /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
+[Hugo module]: /docs/get-started/docsy-as-module/
+[prerequisites]: /docs/get-started/docsy-as-module/installation-prerequisites

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -4,7 +4,6 @@ date: 2021-12-08
 weight: 1
 description: >
   Prerequisites for building a site with Docsy as a Hugo Module.
-cSpell:ignore: docsy
 ---
 
 This page describes the prerequisites for building a site that uses Docsy as a

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -5,7 +5,7 @@ date: 2021-12-08T09:21:54+01:00
 weight: 3
 description: >
   Create a new Hugo site from scratch with Docsy as a Hugo Module
-cSpell:ignore: batchfile docsy
+cSpell:ignore: batchfile
 ---
 
 The simplest approach to creating a Docsy site is

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -2,7 +2,7 @@
 title: Other setup options
 description: Create a new Docsy site with Docsy using Git or NPM
 date: 2021-12-08
-cSpell:ignore: docsy hugo myproject pushd popd
+cSpell:ignore: hugo myproject pushd popd
 weight: 2
 ---
 

--- a/docsy.dev/content/en/docs/get-started/quickstart-docker.md
+++ b/docsy.dev/content/en/docs/get-started/quickstart-docker.md
@@ -4,7 +4,6 @@ weight: 3
 date: 2018-07-30
 description: >
   Instructions on how to set up and run a local Docsy site with Docker.
-cSpell:ignore: docsy
 ---
 
 We provide a Docker image that you can use to run and test your Docsy site

--- a/docsy.dev/content/en/docs/updating/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/updating/convert-site-to-module.md
@@ -2,7 +2,7 @@
 title: Migrate to Hugo Modules
 weight: 3
 description: Convert an existing site to use Docsy as a Hugo Module
-cSpell:ignore: docsy findstr batchfile twbs
+cSpell:ignore: findstr batchfile twbs
 ---
 
 ## TL;DR: Conversion for the impatient expert

--- a/docsy.dev/content/en/examples/index.md
+++ b/docsy.dev/content/en/examples/index.md
@@ -6,7 +6,7 @@ aliases: [/docs/examples]
 body_class: td-no-left-sidebar
 menu: { main: { weight: 30 } }
 # prettier-ignore
-cSpell:ignore: docsy Agones kubeflow Navidrome tekton fluxcd Graphviz Stroom protobuf Dapr
+cSpell:ignore: Agones kubeflow Navidrome tekton fluxcd Graphviz Stroom protobuf Dapr
 ---
 
 {{% blocks/cover

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -3,7 +3,7 @@ title: Changelog
 description: Docsy repository changelog
 aliases: [../changelog]
 # prettier-ignore
-cSpell:ignore: deining docsy FOUC gitmodules gtag katex lookandfeel mhchem navs notoc tabpane onedark
+cSpell:ignore: deining FOUC gitmodules gtag katex lookandfeel mhchem navs notoc tabpane onedark
 ---
 
 We only document **breaking changes** and release **highlights** in this page.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -2,7 +2,7 @@
 title: Maintainer notes
 description: Notes for Docsy maintainers
 aliases: [contributing, ../contributing]
-cSpell:ignore: docsy hugo creatordate
+cSpell:ignore: hugo creatordate
 ---
 
 For our main contributing page covering license agreements, code of conduct and
@@ -328,11 +328,10 @@ before any further changes are merged into the `main` branch:
 
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/
-[docsy-example]: https://github.com/google/docsy-example
-[docsy.dev]: https://www.docsy.dev/
-[docsy.dev/hugo.yaml]:
-  https://github.com/google/docsy/blob/main/docsy.dev/hugo.yaml
-[Draft a new release]: https://github.com/google/docsy/releases/new
-[go.mod]: https://github.com/google/docsy/blob/main/go.mod
-[package.json]: https://github.com/google/docsy/blob/main/package.json
-[release-branch]: https://github.com/google/docsy/tree/release
+[docsy-example]: <{{% param github_repo %}}-example>
+[docsy.dev]: <{{% _param baseURL %}}>
+[docsy.dev/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/hugo.yaml>
+[Draft a new release]: <{{% param github_repo %}}/releases/new>
+[go.mod]: <{{% param github_repo %}}/blob/main/go.mod>
+[package.json]: <{{% param github_repo %}}/blob/main/package.json>
+[release-branch]: <{{% param github_repo %}}/tree/release>

--- a/docsy.dev/content/en/project/about/readme.md
+++ b/docsy.dev/content/en/project/about/readme.md
@@ -3,7 +3,7 @@ title: ReadMe
 description: Docsy repository README
 aliases: [../readme]
 weight: -1
-cSpell:ignore: docsy readfile
+cSpell:ignore: readfile
 ---
 
 <style>

--- a/docsy.dev/content/en/project/build/git-repo.md
+++ b/docsy.dev/content/en/project/build/git-repo.md
@@ -1,7 +1,7 @@
 ---
 title: Git repository information
 linkTitle: Git repos
-cSpell:ignore: docsy hotfixes
+cSpell:ignore: hotfixes
 ---
 
 ## Monorepo

--- a/docsy.dev/content/en/project/style-guide.md
+++ b/docsy.dev/content/en/project/style-guide.md
@@ -32,8 +32,8 @@ and uses Prettier and Markdownlint to enforce basic formatting rules.
 [changelog]: /project/about/changelog/
 [cl-style-guide]: /project/about/changelog/#style-guide
 [present tense]: https://developers.google.com/style/tense
-[release]: <{{% param productionURL %}}/tags/release/>
-[upgrade]: <{{% param productionURL %}}/tags/upgrade/>
+[release]: <{{% _param baseURL %}}/tags/release/>
+[upgrade]: <{{% _param baseURL %}}/tags/upgrade/>
 
 ### Lists
 

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -63,7 +63,7 @@ params:
   privacy_policy: https://policies.google.com/privacy
   archived_version: false
   version: 0.14.3-dev
-  versionWithBuildId: 0.14.3-dev+001-over-main-24e96f1c
+  versionWithBuildId: 0.14.3-dev+002-over-main-4edd8f61
   github_repo: https://github.com/google/docsy
   github_project_repo: https://github.com/google/docsy
   github_subdir: docsy.dev

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -11,7 +11,7 @@
     "_hugo-dev": "npm run _hugo -- --logLevel info -e dev -DFE",
     "_hugo": "hugo --cleanDestinationDir --themesDir ../..",
     "_postbuild": "npm run _check:links--warn",
-    "_serve": "npm run _hugo-dev -- serve --minify --disableFastRender --renderToMemory",
+    "_serve": "npm run _hugo-dev -- serve --disableFastRender --renderToMemory",
     "build:preview": "cross-env npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "cross-env npm run _build -- --baseURL \"${BASE_URL:-http://localhost}\"",
@@ -28,7 +28,7 @@
     "precheck:links": "npm run build",
     "prepare-disabled": "cd .. && npm install",
     "prune:refcache": "node scripts/prune-refcache.mjs",
-    "serve": "npm run _serve",
+    "serve": "npm run _serve -- --minify",
     "test": "npm run check:format && npm run check:links",
     "update:hugo": "npm install --save-exact -D hugo-extended@latest",
     "update:packages": "npx npm-check-updates -u"

--- a/layouts/_shortcodes/_param.html
+++ b/layouts/_shortcodes/_param.html
@@ -19,6 +19,11 @@ NOTE: This is currently an Docsy-private shortcode.
 {{ $position := .Position -}}
 {{ $paramName := .Get 0 | default (.Get "name") -}}
 {{ $paramValue := $.Page.Param $paramName | string -}}
+{{ if not $paramValue -}}
+  {{ if eq $paramName "baseURL" -}}
+    {{ $paramValue = .Site.BaseURL -}}
+  {{ end -}}
+{{ end -}}
 {{ if not $paramName -}}
   {{ errorf "%s: shortcode '_param': parameter name is missing" $position -}}
 {{ else if not $paramValue -}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.3-dev+001-over-main-24e96f1c",
+  "version": "0.14.3-dev+002-over-main-4edd8f61",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -21,6 +21,7 @@
     "_prepare:scrollspy-patch": "npm run _cp:bs-scrollspy && bash scripts/scrollspy-patch/apply-patch.sh && perl scripts/scrollspy-patch/update-patch-js.pl",
     "_prepare": "npm run _cp:bs-rfs && npm run _prepare:scrollspy-patch && npm run _refresh-forward-sass-var && npm run _gen-chroma-styles && npm run get:hugo-modules",
     "_refresh-forward-sass-var": "bash -c scripts/refresh-sass-variables.pl",
+    "_serve": "npm run _cd:docsy.dev -- npm run _serve --",
     "build": "npm run _cd:docsy.dev -- npm run build --",
     "cd:docsy.dev": "echo 'Running in docsy.dev...'; npm run _cd:docsy.dev -- npm run",
     "check:format": "npm list prettier && npm run _check:format || (echo '[help] Run: npm run fix:format'; exit 1)",


### PR DESCRIPTION
- Splits deployment page into sections, one for each of Amazon, Netlify, etc
- Normalizes links: drops domain for site-local URLs: e.g. https://www.docsy.dev/blog/2023/bootstrap-5-migration/ to `bootstrap-5-migration/`
- Adds `docsy` to the dictionary. It occurs too often to continue to add it to page-local dicts. I'll trust that contributors will get the capitalization right when needed.

**Preview**: https://deploy-preview-2556--docsydocs.netlify.app/docs/deployment/