### PR TITLE
Replace bogus placeholder locale by fr

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,6 +2,12 @@
 {
   "version": "0.2",
   "caseSensitive": true,
+  "import": [
+    "@cspell/dict-fr-fr/cspell-ext.json"
+  ],
+  "dictionaries": [
+    "fr-fr"
+  ],
   "words": [
     "anchorize",
     "baseof",

--- a/docsy.dev/.htmltest.yml
+++ b/docsy.dev/.htmltest.yml
@@ -7,12 +7,12 @@ IgnoreDirectoryMissingTrailingSlash: true # FIXME
 TestFilesConcurrently: true
 IgnoreDirs:
   - ^blog/(\d+/)?page/\d+
-  - ^xx # Placeholder language pages
+  - ^fr # French language pages
 IgnoreEmptyHref: true # FIXME
 IgnoreInternalEmptyHash: true # FIXME
 IgnoreInternalURLs: # list of paths
 IgnoreURLs: # list of regexs of paths or URLs to be ignored
-  - ^(https://www.docsy.dev/)?xx/ # Placeholder language pages
+  - ^(https://www.docsy.dev/)?fr/ # French language pages
   - \?no-link-check
   - index.xml$ # ignore <link rel=alternate ...>
   - ^https?://[^/]+/(categories|tags)/ # ignore Docsy-generated content

--- a/docsy.dev/.prettierignore
+++ b/docsy.dev/.prettierignore
@@ -12,5 +12,6 @@
 !/content/en/docs/language.md
 !/content/en/examples/**/*.*
 !/content/en/project/**/*.*
+!/content/fr/**/*.*
 
 /layouts

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -7,7 +7,7 @@
 #   status: archived # Then fetch include
 
 version: &docsyVersion 0.14.3-dev
-tdBuildId: 003-over-main-cf4f514b
+tdBuildId: 004-over-main-7a82d787
 versionLatest: &versionLatest v0.14.2
 version_menu: *docsyVersion
 version_menu_pagelinks: true

--- a/docsy.dev/content/en/_index.md
+++ b/docsy.dev/content/en/_index.md
@@ -17,11 +17,11 @@ params:
 
 <!-- prettier-ignore -->
 <div class="td-cta-buttons my-5">
-  <a {{% _param btn-lg primary %}} href="/docs/get-started/">
+  <a {{% _param btn-lg primary %}} href="docs/get-started/">
     Get started
   </a>
   <a {{% _param btn-lg secondary %}}
-    href="/examples/">
+    href="examples/">
     Explore examples
   </a>
 </div>

--- a/docsy.dev/content/fr/_index.md
+++ b/docsy.dev/content/fr/_index.md
@@ -1,0 +1,74 @@
+---
+title: Docsy
+description: >-
+  Un thème Hugo pour créer d'excellents sites de documentation technique
+params:
+  body_class: td-navbar-links-all-active
+  ui: { navbar_theme: dark }
+---
+
+{{% blocks/cover
+  title="Bienvenue sur Docsy !"
+  height="full td-below-navbar"
+%}}
+
+<!-- prettier-ignore -->
+{{% param description %}}
+{.display-6}
+
+<!-- prettier-ignore -->
+<div class="td-cta-buttons my-5">
+  <a {{% _param btn-lg primary %}} href="docs/get-started/">
+    Commencer
+  </a>
+  <a {{% _param btn-lg secondary %}}
+    href="examples/">
+    Voir les exemples
+  </a>
+</div>
+
+{{% blocks/link-down color="info" %}}
+
+{{% /blocks/cover %}}
+
+{{% blocks/lead color="white" %}}
+
+Docsy est un thème pour le générateur de sites statiques [Hugo][] conçu pour la
+documentation technique. Notre objectif est de vous aider à mettre en place un
+site de documentation le plus simplement possible, pour que vous puissiez vous
+concentrer sur la création de contenu pour vos utilisateurs.
+
+[![Déploiements par Netlify][netlify-badge]][netlify]
+
+[Hugo]: https://gohugo.io/
+[netlify]: https://www.netlify.com/
+[netlify-badge]:
+  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+
+{{% /blocks/lead %}}
+
+{{% blocks/section color="primary" type="row" %}}
+
+{{% blocks/feature icon="fa-lightbulb" title="Voir Docsy en action !" url="examples/" %}}
+
+En plus de notre site d'exemple, un nombre croissant de projets utilisent Docsy
+pour leurs sites de documentation.
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-brands fa-github" title="Les contributions sont bienvenues !" url="https://github.com/google/docsy" %}}
+
+Nous utilisons un workflow de
+[Pull Request](https://github.com/google/docsy/pulls) sur **GitHub**. Les
+nouveaux utilisateurs sont toujours les bienvenus !
+
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-brands fa-x-twitter" title="Suivez-nous sur Twitter !" url="https://twitter.com/docsydocs" %}}
+
+Découvrez les nouvelles fonctionnalités et comment nos utilisateurs utilisent
+Docsy.
+
+{{% /blocks/feature %}}
+
+{{% /blocks/section %}}

--- a/docsy.dev/hugo.yaml
+++ b/docsy.dev/hugo.yaml
@@ -26,11 +26,10 @@ languages:
     languageName: English
     params:
       description: Docsy does docs
-  # Placeholder language used to demo multilingual support
-  xx:
-    languageName: Placeholder
+  fr:
+    languageName: Français
     params:
-      description: Docsy does multilingual docs
+      description: Docsy, c’est la doc.
 
 markup:
   tableOfContents:
@@ -172,18 +171,20 @@ security:
 
 sites: &sites
   matrix:
-    languages: [en, xx]
+    languages: [en, fr]
 
 module:
   hugoVersion:
     extended: true
     min: *hugoMinVersion
   mounts:
-    # If our mock language (xx) had any content we'd configure this
-    # differently, but for now, this will do.
+    # French landing page overrides home for fr
+    - source: content/fr
+      target: content
+      sites: { matrix: { languages: [fr] } }
+    # English content for en and as fallback for fr (other pages)
     - source: content/en
       target: content
-      # English content for both en, and as fallback for xx sites
       sites: *sites
     # Mount the repo root *.md files for both languages
     - source: ../AGENTS.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.3-dev+003-over-main-cf4f514b",
+  "version": "0.14.3-dev+004-over-main-7a82d787",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -63,6 +63,7 @@
     "bootstrap": "5.3.8"
   },
   "devDependencies": {
+    "@cspell/dict-fr-fr": "^2.3.2",
     "cpy-cli": "^6.0.0",
     "markdownlint-cli2": "^0.20.0",
     "prettier": "^3.8.1"

--- a/scripts/git/check-version.sh
+++ b/scripts/git/check-version.sh
@@ -16,7 +16,7 @@ if [ -n "${SKIP_VERSION_CHECK:-}" ]; then
 fi
 
 new_version="$(scripts/get-build-id.sh)"
-output="$(npm run -s set:version -- --version "$new_version" --silent 2>&1)"
+output="$(npm run -s fix:version -- --silent 2>&1)"
 status=$?
 
 if [ $status -ne 0 ]; then

--- a/scripts/set-package-version/hugo-yaml.mjs
+++ b/scripts/set-package-version/hugo-yaml.mjs
@@ -43,9 +43,16 @@ export function readHugoYaml(filePath) {
   return parseParamsVersion(content);
 }
 
-export function writeHugoYaml(filePath, data) {
+/**
+ * Writes version and tdBuildId to YAML file.
+ *
+ * @param {{ version?: string, tdBuildId?: string }} data
+ * @param {string} filePath
+ */
+export function writeHugoYaml(versionInfo, filePath) {
+  console.log('writeHugoYaml', filePath, versionInfo);
   const content = fs.readFileSync(filePath, 'utf8');
-  const newContent = updateYamlWithVersions(content, data);
+  const newContent = updateYamlWithVersions(content, versionInfo);
   fs.writeFileSync(filePath, newContent);
 }
 


### PR DESCRIPTION
- Replace bogus `xx` placeholder locale by `fr`
- Adds a French homepage; all other content is `en` fallback
- **Preview**: https://deploy-preview-2558--docsydocs.netlify.app/fr/
- I'll eventually add a banner for the non-homepage pages so users know the content is known to not be translated yet (they're just fallback content).