### PR TITLE
fix(layout): ensure `.td-main > .row` grows vertically

### DIFF
--- a/assets/scss/td/_main-container.scss
+++ b/assets/scss/td/_main-container.scss
@@ -43,6 +43,10 @@
     // either, the TOC sidebar is there and makes .td-main fill the page.
     &:has(> .row .td-sidebar-nav) {
       display: flex;
+      flex-direction: column;
+      > .row {
+        flex-grow: 1;
+      }
     }
   }
 }

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -7,7 +7,7 @@
 #   status: archived # Then fetch include
 
 version: &docsyVersion 0.14.3-dev
-tdBuildId: 005-over-main-a285c134
+tdBuildId: 006-over-main-d125b877
 versionLatest: &versionLatest v0.14.2
 version_menu: *docsyVersion
 version_menu_pagelinks: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.3-dev+005-over-main-a285c134",
+  "version": "0.14.3-dev+006-over-main-d125b877",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2561
- **Preview**:  https://deploy-preview-2562--docsydocs.netlify.app/docs/content/adding-content/

### Screenshots

| When | Screenshot |
|--------|--------|
| Before |  <img width="1050" height="605" alt="Image" src="https://github.com/user-attachments/assets/e1f24da4-21db-43a2-8423-d2178a8bc33c" /> |
| After | <img width="1035" height="656" alt="image" src="https://github.com/user-attachments/assets/9b40cdcc-7189-47c7-9daa-e86d4e467d8f" /> | 

