### PR TITLE
Fix deprecation warning when running with latest hugo version 0.156.0

### DIFF
--- a/layouts/_partials/navbar-lang-selector.html
+++ b/layouts/_partials/navbar-lang-selector.html
@@ -14,22 +14,24 @@
   {{ end -}}
 
   <ul class="dropdown-menu">
-    {{ range $.Site.Languages -}}
-      {{ $translatedPages := where $allPages "Language.Lang" .Lang -}}
-      {{ $translated := "" -}}
-      {{ if gt (len $translatedPages) 0 -}}
-        {{ $translated = index $translatedPages 0 -}}
-      {{- end -}}
-      {{ $isActive := eq $.Site.Language.Lang .Lang -}}
-      <li>
-        {{- if $isActive -}}
-          <span class="dropdown-item active">{{ .LanguageName }}</span>
-        {{- else if $translated -}}
-          <a class="dropdown-item" href="{{ $translated.RelPermalink }}">{{ .LanguageName }}</a>
-        {{- else -}}
-          <span class="dropdown-item disabled">{{ .LanguageName }}</span>
+    {{ with .Rotate "language" }}
+      {{ range . -}}
+        {{ $translatedPages := where $allPages "Language.Lang" .Lang -}}
+        {{ $translated := "" -}}
+        {{ if gt (len $translatedPages) 0 -}}
+          {{ $translated = index $translatedPages 0 -}}
         {{- end -}}
-      </li>
+        {{ $isActive := eq $.Site.Language.Lang .Lang -}}
+        <li>
+          {{- if $isActive -}}
+            <span class="dropdown-item active">{{ .Site.Language.LanguageName }}</span>
+          {{- else if $translated -}}
+            <a class="dropdown-item" href="{{ $translated.RelPermalink }}">{{ .Site.Language.LanguageName }}</a>
+          {{- else -}}
+            <span class="dropdown-item disabled">{{ .Site.Language.LanguageName }}</span>
+          {{- end -}}
+        </li>
+        {{ end -}}
       {{ end -}}
     </ul>
 </div>


### PR DESCRIPTION
When running `dosy.dev` site with latest released hugo version 0.156.0, a deprecation warning is printed out:
```
INFO  deprecated: .Site.Languages was deprecated in Hugo v0.156.0
and will be removed in a future release.
See https://discourse.gohugo.io/t/56732.
```

This PR fixes this issue.