### PR TITLE
Resolve community and footer links paths under any permalinks scheme

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -7,7 +7,7 @@
 #   status: archived # Then fetch include
 
 version: &docsyVersion 0.14.4-dev
-tdBuildId: 019-over-main-c03fc161
+tdBuildId: 020-over-main-4a09247b
 versionLatest: &versionLatest v0.14.3
 version_menu: *docsyVersion
 version_menu_pagelinks: true

--- a/layouts/_partials/community_links.html
+++ b/layouts/_partials/community_links.html
@@ -17,7 +17,12 @@
     {{ end }}
     <p>
       {{ T "community_how_to" . }}
-      <a href="{{ $contribUrl | relURL }}">{{ T "community_guideline" }}</a>.
+      {{ $url := $contribUrl -}}
+      {{ $isExternal := (urls.Parse $url).IsAbs -}}
+      {{ if not $isExternal -}}
+        {{ with site.GetPage $url }}{{ $url = .RelPermalink }}{{ end -}}
+      {{ end -}}
+      <a href="{{ $url | relURL }}">{{ T "community_guideline" }}</a>.
     </p>
   </div>
 </section>
@@ -26,8 +31,12 @@
 <ul>
 {{ range . -}}
   <li title="{{ .name }}">
-    {{ $isExternal := hasPrefix .url "http" -}}
-    <a href="{{ .url }}"
+    {{ $url := .url -}}
+    {{ $isExternal := (urls.Parse $url).IsAbs -}}
+    {{ if not $isExternal -}}
+      {{ with site.GetPage .url }}{{ $url = .RelPermalink }}{{ end -}}
+    {{ end -}}
+    <a href="{{ $url | relURL }}"
       {{- if $isExternal }} target="_blank" rel="noopener" {{- end -}}
     > {{/**/ -}}
       <i class="{{ .icon }}"></i> {{ .name -}}

--- a/layouts/_partials/footer/links.html
+++ b/layouts/_partials/footer/links.html
@@ -1,12 +1,15 @@
 <ul class="td-footer__links-list">
   {{ range . }}
   {{ $rel := .rel | string -}}
-  {{ $isExternal := hasPrefix .url "http" -}}
+  {{ $url := .url -}}
+  {{ $isExternal := (urls.Parse $url).IsAbs -}}
   {{ if $isExternal -}}
     {{ $rel = cond $rel (add $rel " noopener") "noopener" -}}
+  {{ else -}}
+    {{ with site.GetPage $url }}{{ $url = .RelPermalink }}{{ end -}}
   {{ end -}}
   <li class="td-footer__links-item" data-bs-toggle="tooltip" title="{{ .name }}" aria-label="{{ .name }}">
-    <a href="{{ .url }}" aria-label="{{ .name }}"
+    <a href="{{ $url }}" aria-label="{{ .name }}"
       {{- if $isExternal }} target="_blank" {{- end -}}
       {{ with $rel }} rel="{{ . }}" {{- end -}}
     >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.4-dev+019-over-main-c03fc161",
+  "version": "0.14.4-dev+020-over-main-4a09247b",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Contributes to #2504
- For community links and footer links: switches to using `site.GetPage` to resolve to the targeted canonical page and the `.RelPermalink` returns the correct path under any [permalinks][] scheme.
- Potentially **BREAKING**: in multilingual sites, paths are (now correctly) interpreted as site relative. (To force a link to the default language, use the default language code as path prefix).

[permalinks]: https://gohugo.io/configuration/permalinks/