### PR TITLE
chore: add mdl rule to enable no-docsy-dev-external-urls checking, fix link

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,8 @@
 # cSpell:ignore docsy github lookandfeel iconsimages
 
+customRules:
+  - ./scripts/_md-rules/link-rules.mjs
+
 globs:
   - '!docsy.dev/**'
   - '!layouts/**'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,3 +15,10 @@ no-inline-html: false
 no-trailing-punctuation: false
 no-trailing-spaces: {  br_spaces: 0, strict: true}
 # table-column-style: false
+
+# Link-validation rules (from scripts/_md-rules/link-rules.mjs)
+
+no-docsy-dev-external-urls:
+  pattern: 'https?://(?:www\.)?docsy\.dev/'
+  message: Use a site-relative path instead of the full docsy.dev URL.
+  replace: '/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- markdownlint-disable no-docsy-dev-external-urls -->
+
 The changelog is published online, see
 [Changelog](https://www.docsy.dev/project/about/changelog/) or the
 [page source](docsy.dev/content/en/project/about/changelog.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+<!-- markdownlint-disable no-docsy-dev-external-urls -->
+
 The contributing page is published online, see
 [Contributing](https://www.docsy.dev/docs/contributing/) or the
 [page source](docsy.dev/content/en/docs/contributing.md).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Docsy
 
+<!-- markdownlint-disable no-docsy-dev-external-urls -->
+
 Docsy is a [Hugo](https://gohugo.io) theme for technical documentation sets,
 providing simple navigation, site structure, and more.
 
@@ -106,9 +108,6 @@ This project is licensed under the Apache License 2.0, see
 [deploys]: https://app.netlify.com/sites/docsydocs/deploys
 [main-preview]: https://main--docsydocs.netlify.app/
 [netlify]: https://netlify.com
-
-<!-- FIXME: once 0.14.0 is released, update the link to the changelog page -->
-
 [official-support]:
   https://www.docsy.dev/project/about/changelog/#official-support
 [releases]: https://github.com/google/docsy/releases

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -7,7 +7,7 @@
 #   status: archived # Then fetch include
 
 version: &docsyVersion 0.14.4-dev
-tdBuildId: 020-over-main-4a09247b
+tdBuildId: 021-over-main-b219dab5
 versionLatest: &versionLatest v0.14.3
 version_menu: *docsyVersion
 version_menu_pagelinks: true

--- a/docsy.dev/content/en/docs/content/lookandfeel.md
+++ b/docsy.dev/content/en/docs/content/lookandfeel.md
@@ -617,7 +617,7 @@ translucent setting ensures that the hero image is maximally visible. Once the
 user has scrolled past the cover (hero image), the navbar reverts to its default
 (opaque) style.
 
-[About Docsy]: https://www.docsy.dev/about/
+[About Docsy]: /about/
 [blocks/cover]: /docs/content/shortcodes/#blocks-cover
 
 ### Customizing the navbar {#navbar-customization}

--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -8,8 +8,6 @@ cascade:
   type: docs
   params:
     hide_feedback: true
-params:
-  FAS: <i class="fa-solid fa-{1} text-{2}"></i>
 cSpell:ignore: docsydocs
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.4-dev+020-over-main-4a09247b",
+  "version": "0.14.4-dev+021-over-main-b219dab5",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -67,6 +67,7 @@
     "@cspell/dict-fr-fr": "^2.3.2",
     "cpy-cli": "^6.0.0",
     "markdownlint-cli2": "^0.20.0",
+    "markdownlint-rule-link-pattern": "github:chalin/markdownlint-rule-link-pattern#v0.2.0",
     "prettier": "^3.8.1"
   },
   "config": {

--- a/scripts/_md-rules/link-rules.mjs
+++ b/scripts/_md-rules/link-rules.mjs
@@ -1,0 +1,10 @@
+// @ts-check
+
+import { createLinkPatternRule } from 'markdownlint-rule-link-pattern';
+
+export default [
+  createLinkPatternRule(
+    'no-docsy-dev-external-urls',
+    'Use a local path instead of an external URL for site-local pages',
+  ),
+];


### PR DESCRIPTION
The added rule ensures that links to site-local pages are given as paths, not URLs.

### Why this matters?

Using a path for links to site-local pages allows the links to get properly processed in multilingual contexts, e.g., it can get fixed like this:

> <img width="899" height="246" alt="image" src="https://github.com/user-attachments/assets/a1b2cc5d-8e41-4c87-8843-74b387f43eb7" />

It also improves link checking.