### PR TITLE
Trim spaces from titles and descriptions in `layouts/all.md`

### DIFF
--- a/layouts/all.md
+++ b/layouts/all.md
@@ -1,4 +1,4 @@
-# {{ .Title -}}
+# {{ .Title | strings.TrimSpace -}}
 
 {{ $needSeparator := false -}}
 
@@ -35,9 +35,9 @@
 Section pages:
 
 {{ range . -}}
-- [ {{- .Title -}} ]( {{- .RelPermalink -}} )
-  {{- with .Description -}}
-    : {{ strings.TrimSpace . -}}
+- [ {{- .Title | strings.TrimSpace -}} ]( {{- .RelPermalink -}} )
+  {{- with .Description | strings.TrimSpace -}}
+    : {{ . -}}
   {{ end }}
 {{ end -}}
 


### PR DESCRIPTION
- Contributes to #2596
- Ensures that titles and descriptions are trimmed of whitespace in `layouts/all.md`

**Preview**:

- Home: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/index.md)
- Docs home: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/docs/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/docs/index.md)
- Get started: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/docs/get-started/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/docs/get-started/index.md)
- Content: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/docs/content/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/docs/content/index.md)
- Blog index: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/blog/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/blog/index.md)
- Blog post: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/blog/2022/hello/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/blog/2022/hello/index.md)
- French home: [HTML](https://deploy-preview-2600--docsydocs.netlify.app/fr/) | [Markdown](https://deploy-preview-2600--docsydocs.netlify.app/fr/index.md)