### PR TITLE
Add a first-cut for `post_view_markdown` to all i18n files

### DIFF
--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -20,6 +20,7 @@ post_byline_by: الكاتب
 post_created: مُنْشِئة
 post_last_mod: آخر تَعدِيل
 post_edit_this: عدل هَذِه الصَّفْحة
+post_view_markdown: اعرض Markdown
 post_view_this: أَنظُر مَصدَر الصَّفْحة
 post_create_child_page: أُنْشِئ صَفحَة فَرعِية
 post_create_issue: أُنْشِئ مَسْأَلة حَوْل الوثائق

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -18,6 +18,7 @@ post_created: Създаден
 post_last_mod: Последна промяна
 post_edit_this: Промени тази страница
 post_create_child_page: Създай дъщерна страница
+post_view_markdown: Преглед на Markdown
 post_create_issue: Създаване на издаване на документ
 post_create_project_issue: Създаване на издаване на проект
 post_posts_in: Публикувано в

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -26,6 +26,7 @@ post_byline_by: দ্বারা
 post_created: তৈরি
 post_last_mod: সর্বশেষ পরিবর্তিত
 post_edit_this: এই পৃষ্ঠাটি সম্পাদনা করুন
+post_view_markdown: Markdown দেখুন
 post_view_this: পৃষ্ঠার উৎস দেখুন
 post_create_child_page: শাখা পৃষ্ঠা তৈরি করুন
 post_create_issue: ডকুমেন্টেশন ইস্যু তৈরি করুন

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -20,6 +20,7 @@ post_byline_by: Von
 post_created: Erstellt
 post_last_mod: Zuletzt geändert
 post_edit_this: Diese Seite bearbeiten
+post_view_markdown: Markdown anzeigen
 post_view_this: Quellcode dieser Seite ansehen
 post_create_child_page: Unterseite anlegen
 post_create_issue: Problem zu dieser Seite melden

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -26,6 +26,7 @@ post_byline_by: Por
 post_created: Creado
 post_last_mod: Última modificación
 post_edit_this: Editar esta página
+post_view_markdown: Ver Markdown
 post_view_this: Ver código de la página
 post_create_child_page: Crear página nueva
 post_create_issue: Notificar una incidencia con la documentanción

--- a/i18n/et.yaml
+++ b/i18n/et.yaml
@@ -19,6 +19,7 @@ post_byline_by: järgi
 post_created: Loodud
 post_last_mod: Viimati muudetud
 post_edit_this: Täienda lehte
+post_view_markdown: Vaata Markdowni
 post_create_child_page: Loo alamleht
 # perhaps there is a better translation for "issue"...
 post_create_issue: Tõstata dokumentatsiooni kohta ülesanne

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -18,6 +18,7 @@ post_created: ساخته شده
 post_last_mod: آخرین تغییرات
 post_edit_this: این صفحه را ویرایش کنید
 post_view_this: مشاهده منبع صفحه
+post_view_markdown: مشاهدهٔ Markdown
 post_create_child_page: ایجاد زیر صفحه در این صفحه
 post_create_issue: ساخت ایشو
 post_create_project_issue: ساخت ایشو برای پوسته

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -20,6 +20,7 @@ post_byline_by: Kirjoittanut
 post_created: Luonut
 post_last_mod: Viimeksi muokattu
 post_edit_this: Muokkaa sivua
+post_view_markdown: Näytä Markdown
 post_view_this: Katso lähdekoodi
 post_create_child_page: Luo alisivu
 post_create_issue: Luo dokumentaation vikailmoitus

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -24,6 +24,7 @@ post_byline_by: Par
 post_created: Créé
 post_last_mod: Dernière modification
 post_edit_this: Modifier cette page
+post_view_markdown: Voir le Markdown
 post_view_this: Afficher la source de la page
 post_create_child_page: Créer une page dans cette section
 post_create_issue: Signaler un problème dans la documentation

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -27,6 +27,7 @@ post_byline_by: על ידי
 post_created: נוצר
 post_last_mod: עדכון אחרון
 post_edit_this: עריכת העמוד
+post_view_markdown: הצג Markdown
 post_view_this: צפייה בקוד המקור של העמוד
 post_create_child_page: צור עמוד משנה
 post_create_issue: Create documentation issue

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -20,6 +20,7 @@ post_byline_by: द्वारा
 post_created: बनाया
 post_last_mod: अंतिम बार संशोधित
 post_edit_this: इस पृष्ठ को संपादित करें
+post_view_markdown: Markdown देखें
 post_view_this: पृष्ठ का स्त्रोत देखें
 post_create_child_page: चाइल्ड पृष्ठ बनाएं
 post_create_issue: समस्या की सुचना दें

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -18,6 +18,7 @@ post_created: Elkészítve
 post_last_mod: Utolsó módosítás
 post_edit_this: Oldal szerkesztése
 post_create_child_page: Create child page
+post_view_markdown: Markdown megtekintése
 post_create_issue: Dokumentáció issue létrehozása
 post_create_project_issue: Projekt issue létrehozása
 # so I left it as is

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -17,7 +17,7 @@ post_byline_by: Készítette
 post_created: Elkészítve
 post_last_mod: Utolsó módosítás
 post_edit_this: Oldal szerkesztése
-post_create_child_page: Create child page
+post_create_child_page: Aloldal létrehozása
 post_view_markdown: Markdown megtekintése
 post_create_issue: Dokumentáció issue létrehozása
 post_create_project_issue: Projekt issue létrehozása

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -18,6 +18,7 @@ post_created: Creato
 post_last_mod: Ultima modifica
 post_edit_this: Modifica
 post_create_child_page: Create child page
+post_view_markdown: Visualizza Markdown
 post_create_issue: Crea issue di documentazione
 post_create_project_issue: Crea issue di progetto
 post_posts_in: Post in

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -24,6 +24,7 @@ post_byline_by: By
 post_created: 作成
 post_last_mod: 最終更新
 post_edit_this: ページの編集
+post_view_markdown: Markdownを表示
 post_view_this: ページのソースコードを見る
 post_create_child_page: 子ページを作成
 post_create_issue: ドキュメントのissueを作成

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -18,6 +18,7 @@ post_created: 작성
 post_last_mod: 최종 수정
 post_edit_this: 페이지 편집
 post_create_child_page: 하부 페이지 생성
+post_view_markdown: Markdown 보기
 post_create_issue: 문서에 이슈 생성
 post_create_project_issue: 프로젝트에 이슈 생성
 post_posts_in: Posts in

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -19,6 +19,7 @@ post_byline_by: Door
 post_created: Aangemaakt
 post_last_mod: Laatst gewijzigd
 post_edit_this: Bewerk deze pagina
+post_view_markdown: Bekijk Markdown
 post_view_this: Bekijk paginabron
 post_create_child_page: Maak sub pagina
 post_create_issue: Maak documentatie issue

--- a/i18n/no.yaml
+++ b/i18n/no.yaml
@@ -27,6 +27,7 @@ post_byline_by: Av
 post_created: Opprettet
 post_last_mod: Sist endret
 post_edit_this: Endre denne siden
+post_view_markdown: Vis Markdown
 post_create_child_page: Lag underside
 post_create_issue: Opprett dokumentasjon sak
 post_create_project_issue: Opprett prosjekt sak

--- a/i18n/oc.yaml
+++ b/i18n/oc.yaml
@@ -20,6 +20,7 @@ post_byline_by: Per
 post_created: Creacion
 post_last_mod: Darrièra modificacion
 post_edit_this: Modificar aquesta pagina
+post_view_markdown: Veire Markdown
 post_view_this: Veire la pagina font
 post_create_child_page: Crear una pagina enfant
 post_create_issue: Crear una anomalia de documentacion

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -18,6 +18,7 @@ post_created: Utworzono
 post_last_mod: Ostatnia modyfikacja
 post_edit_this: Edytuj tę stronę
 post_create_child_page: Utwórz podstronę
+post_view_markdown: Zobacz Markdown
 post_create_issue: Zgłoś błąd w dokumencie
 post_create_project_issue: Zgłoś błąd na stronie
 post_posts_in: Posty

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -18,7 +18,7 @@ post_created: Utworzono
 post_last_mod: Ostatnia modyfikacja
 post_edit_this: Edytuj tę stronę
 post_create_child_page: Utwórz podstronę
-post_view_markdown: Zobacz Markdown
+post_view_markdown: Wyświetl Markdown
 post_create_issue: Zgłoś błąd w dokumencie
 post_create_project_issue: Zgłoś błąd na stronie
 post_posts_in: Posty

--- a/i18n/pt-br.yaml
+++ b/i18n/pt-br.yaml
@@ -26,6 +26,7 @@ post_byline_by: Por
 post_created: Criado
 post_last_mod: Última modificação
 post_edit_this: Editar essa página
+post_view_markdown: Ver Markdown
 post_view_this: Ver origem da página
 post_create_child_page: Criar uma subpágina
 post_create_issue: Relatar um problema de documentação

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -20,6 +20,7 @@ post_byline_by: Автор
 post_created: Создано
 post_last_mod: Изменено
 post_edit_this: Отредактировать страницу
+post_view_markdown: Посмотреть Markdown
 post_view_this: Увидеть источник страницы
 post_create_child_page: Создать дополнительную страницу
 post_create_issue: Предложить изменения документации

--- a/i18n/sr-cyrl.yaml
+++ b/i18n/sr-cyrl.yaml
@@ -26,6 +26,7 @@ post_byline_by: Аутор
 post_created: Креирано
 post_last_mod: Последњи пут измењено
 post_edit_this: Уредите ову страницу
+post_view_markdown: Погледајте Markdown
 post_view_this: Погледајте извор странице
 post_create_child_page: Креирајте подстраницу
 post_create_issue: Креирајте issue за документацију

--- a/i18n/sr-latn.yaml
+++ b/i18n/sr-latn.yaml
@@ -26,6 +26,7 @@ post_byline_by: Autor
 post_created: Kreirano
 post_last_mod: Poslednji put izmenjeno
 post_edit_this: Uredite ovu stranicu
+post_view_markdown: Pogledajte Markdown
 post_view_this: Pogledajte izvor stranice
 post_create_child_page: Kreirajte podstranicu
 post_create_issue: Kreirajte issue za dokumentaciju

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -20,6 +20,7 @@ post_byline_by: Av
 post_created: Skapat
 post_last_mod: Senast ändrad
 post_edit_this: Redigera sida
+post_view_markdown: Visa Markdown
 post_view_this: Visa sidans källa
 post_create_child_page: Skapa barnsida
 post_create_issue: Skapa dokumentationsfråga

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -20,6 +20,7 @@ post_byline_by: by
 post_created: Oluşturuldu
 post_last_mod: Son düzenleme
 post_edit_this: Bu sayfayı düzenle
+post_view_markdown: Markdown görüntüle
 post_view_this: Sayfa kaynağını görüntüle
 post_create_child_page: Çocuk sayfası oluştur
 post_create_issue: Belge konusu oluştur

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -20,7 +20,7 @@ post_byline_by: by
 post_created: Oluşturuldu
 post_last_mod: Son düzenleme
 post_edit_this: Bu sayfayı düzenle
-post_view_markdown: Markdown görüntüle
+post_view_markdown: Markdown'ı Görüntüle
 post_view_this: Sayfa kaynağını görüntüle
 post_create_child_page: Çocuk sayfası oluştur
 post_create_issue: Belge konusu oluştur

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -20,6 +20,7 @@ post_byline_by: Автор
 post_created: Створено
 post_last_mod: Востаннє змінено
 post_edit_this: Редагувати цю сторінку
+post_view_markdown: Переглянути Markdown
 post_view_this: Переглянути джерело сторінки
 post_create_child_page: Створити дочірню сторінку
 post_create_issue: Створити запит щодо документації

--- a/i18n/zh-cn.yaml
+++ b/i18n/zh-cn.yaml
@@ -27,6 +27,7 @@ post_byline_by: 撰文：
 post_created: 创建
 post_last_mod: 最后修改
 post_edit_this: 编辑此页
+post_view_markdown: 查看 Markdown
 post_view_this: 查看页面源码
 post_create_child_page: 添加子页面
 post_create_issue: 提交文档问题

--- a/i18n/zh-tw.yaml
+++ b/i18n/zh-tw.yaml
@@ -27,6 +27,7 @@ post_byline_by: 作者：
 post_created: 建立
 post_last_mod: 最後更新於
 post_edit_this: 編輯此頁
+post_view_markdown: 檢視 Markdown
 post_view_this: 檢視頁面原始碼
 post_create_child_page: 建立子頁面
 post_create_issue: 建立文件議題


### PR DESCRIPTION
- Contributes to #2596
- Translations codeveloped with GPT-5.4, reviewed by Gemini.
- Adds a value for `post_view_markdown` to all i18n files
- Feedback is most welcome from native speakers for all locales, before or after this gets merged
- **Preview**: https://deploy-preview-2602--docsydocs.netlify.app/fr/docs/