### PR TITLE
Project docs: allow default outputs, including md

### DIFF
--- a/docsy.dev/content/en/project/_index.md
+++ b/docsy.dev/content/en/project/_index.md
@@ -4,7 +4,6 @@ linkTitle: Project docs
 description: How Docsy theme and website are built, maintained, and deployed.
 aliases: [site]
 cascade:
-  outputs: [HTML]
   type: docs
   params:
     hide_feedback: true


### PR DESCRIPTION
- Contributes to #2596 
- Removes output format override for the `/project` section so that md files can be generated
- This allows afdocs to reach a score of 100% for the metrics we're measuring (vs 98% before)