### PR TITLE
Use blob URLs for page source links

### DIFF
--- a/layouts/_partials/page-meta-links.html
+++ b/layouts/_partials/page-meta-links.html
@@ -34,7 +34,7 @@
   {{ $gh_repo_path := printf "%s/%s/%s" $gh_branch $gh_subdir $path -}}
   {{ $gh_repo_path = replaceRE "//+" "/" $gh_repo_path -}}
 
-  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
+  {{ $viewURL := printf "%s/blob/%s" $gh_repo $gh_repo_path -}}
   {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
   {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
   {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}


### PR DESCRIPTION
## Summary\n- fix the generated `View page source` URL to use GitHub's file route\n- keep edit, new-page, and issue links unchanged\n\n## Testing\n- build the user guide locally with Hugo 0.157.0 and pinned module versions\n- verify rendered `.td-page-meta__view` links point to `https://github.com/google/docsy/blob/...`\n\nFixes #2403