### PR TITLE
Prepare 0.15.0 release tooling, site metadata, and release-prep docs

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -8,8 +8,8 @@
 
 tdVersion:
   latest: &tdLatestVers v0.14.3
-  dev: &tdDevVers v0.14.4-dev
-  buildId: &tdBuildId 024-over-main-500ee239
+  dev: &tdDevVers v0.15.0-dev
+  buildId: &tdBuildId ''
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.14.3
   dev: &tdDevVers v0.15.0-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 040-over-main-7a0b370f
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.14.3
   dev: &tdDevVers v0.15.0-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 040-over-main-7a0b370f
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -2,8 +2,8 @@
 
 tdVersion:
   latest: &tdLatestVers v0.14.3
-  dev: &tdDevVers v0.14.4-dev
-  buildId: &tdBuildId 024-over-main-500ee239
+  dev: &tdDevVers v0.15.0-dev
+  buildId: &tdBuildId ''
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -2,8 +2,8 @@
 
 tdVersion:
   latest: &tdLatestVers v0.14.3
-  dev: &tdDevVers v0.14.4-dev
-  buildId: &tdBuildId 024-over-main-500ee239
+  dev: &tdDevVers v0.15.0-dev
+  buildId: &tdBuildId ''
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.14.3
   dev: &tdDevVers v0.15.0-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 040-over-main-7a0b370f
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -38,8 +38,6 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
 
 ## Ready to Upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
 
-Section status: revisited as of 2026-04-25
-
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}}
     [Community and footer links](#community-footer-links)

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -214,7 +214,7 @@ About this release:
 [0.14.3]: https://github.com/google/docsy/releases/v0.14.3
 [0.155.3]: https://github.com/gohugoio/hugo/releases/tag/v0.155.3
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
-[0.15.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.15.0
+[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [Adding a community page]: /docs/content/adding-content/#adding-a-community-page
 [CL@0.15.0]: /project/about/changelog/#v0.15.0
 [Doc-rooted example]: https://doc-rooted--docsydocs.netlify.app

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -147,8 +147,8 @@ patterns—for example logging requests to Markdown URLs or `llms.txt`, and
 collecting metrics on their use. For details, see
 [Agent-support checks](/project/build/ci-cd/#agent-support-checks).
 
-The `docsy.dev` project contains [AFDocs][] configuration and npm scripts
-so maintainers can score a deployed URL against checks that overlap with Docsy’s
+The `docsy.dev` project contains [AFDocs][] configuration and npm scripts so
+maintainers can score a deployed URL against checks that overlap with Docsy’s
 agent-support goals, including Markdown URLs, llms.txt, and related categories.
 
 ### Scorecard examples

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -147,7 +147,7 @@ patterns—for example logging requests to Markdown URLs or `llms.txt`, and
 collecting metrics on their use. For details, see
 [Agent-support checks](/project/build/ci-cd/#agent-support-checks).
 
-The `docsy.dev` subrepository contains [AFDocs][] configuration and npm scripts
+The `docsy.dev` project contains [AFDocs][] configuration and npm scripts
 so maintainers can score a deployed URL against checks that overlap with Docsy’s
 agent-support goals, including Markdown URLs, llms.txt, and related categories.
 

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -21,8 +21,8 @@ cSpell:ignore: llmstxt
 When your site opts in, these are the user-facing and machine-readable behaviors
 Docsy enables:
 
-- **[Markdown output format](#markdown-output)** support. Your
-  project's `outputs` configuration controls which page kinds publish Markdown.
+- **[Markdown output format](#markdown-output)** support. Your project's
+  `outputs` configuration controls which page kinds publish Markdown.
 - **Discovery**: page HTML headers include `rel="alternate"` links to the
   Markdown version of the page.
 - **View Markdown**: page meta area includes a **View Markdown** link to the

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -12,7 +12,7 @@ cSpell:ignore: llmstxt
 > Features described in this page are [experimental][], and are useful for early
 > adoption and evaluation. Output details and validation coverage may change in
 > future releases. To track the phased evolution of the agent-support feature,
-> see [Improve support for AI-agent doc consumption #2614][ #2614].
+> see [Improve support for AI-agent doc consumption #2614][#2614].
 
 [#2614]: https://github.com/google/docsy/issues/2614
 
@@ -21,7 +21,8 @@ cSpell:ignore: llmstxt
 When your site opts in, these are the user-facing and machine-readable behaviors
 Docsy enables:
 
-- **[Markdown output format](#markdown-output)** support for all site pages.
+- **[Markdown output format](#markdown-output)** support. Your
+  project's `outputs` configuration controls which page kinds publish Markdown.
 - **Discovery**: page HTML headers include `rel="alternate"` links to the
   Markdown version of the page.
 - **View Markdown**: page meta area includes a **View Markdown** link to the

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -167,7 +167,7 @@ full list of changes, see the [0.15.0][] release page.
 [0.15.0-blog-community-footer]: /blog/2026/0.15.0/#community-footer-links
 [0.15.0-blog-doc-rooted]: /blog/2026/0.15.0/#doc-rooted-sites
 [0.15.0-blog-internationalization]: /blog/2026/0.15.0/#internationalization
-[0.15.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.15.0
+[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 
 ## v0.14.3 {#v0.14.3}
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -113,9 +113,7 @@ Any other compatibility (including Windows support) is on a best effort basis.
 
 </details>
 
-## Next release {#v0.15.0}
-
-> **UNRELEASED**: v0.15.0 - still under development
+## v0.15.0 {#v0.15.0}
 
 For an introduction to this release, see the [0.15.0 release report][]. For the
 full list of changes, see the [0.15.0][] release page.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -347,8 +347,10 @@ before any further changes are merged into the `main` branch:
 
 - NPM scripts: `set:version` and `set:version:*`; **`set:hugo:version`** (see
   [Hugo version pins](#hugo-version-pins))
-- `scripts/get-build-id.sh`: Generates build ID from git describe (empty on
-  tags).
+- `scripts/get-build-id.sh`: Builds `X.Y.Z-dev+…-over-main-…` from the latest
+  semver tag on `main`, commit offset, and tip SHA; if **`package.json`**’s
+  X.Y.Z core is already **greater** than that git-derived core, keeps the higher
+  core (release prep ahead of tagging).
 - `scripts/set-package-version/index.mjs`: Low-level version manager. See script
   help for usage.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -8,6 +8,24 @@ cSpell:ignore: hugo creatordate
 For our main contributing page covering license agreements, code of conduct and
 more, see [Contributing][]. This page is for **maintainers only**.
 
+## Hugo version pins
+
+From the repo root:
+
+```sh
+npm run set:hugo:version -- X.Y.Z
+npm install  # optional, if hugo is already installed
+```
+
+This updates:
+
+- [docsy.dev/config/_default/hugo.yaml][]:
+  - `params.hugoMinVersion` / `&hugoMinVersion`
+  - Note: `module.hugoVersion.min` stays as `*hugoMinVersion`
+- [docsy.dev/package.json][]: `hugo-extended`
+- [package.json][]: `config.hugo_version`, used by [install-hugo.sh][], which
+  installs `hugo-extended` into `docsy.dev` if it is not already present.
+
 ## Publishing a release
 
 These notes are WIP for creating a **release** from a local copy of the repo.
@@ -327,11 +345,14 @@ before any further changes are merged into the `main` branch:
 
 ## Release helper scripts
 
-- NPM scripts: `set:version` and `set:version:*`
+- NPM scripts: `set:version` and `set:version:*`; **`set:hugo:version`** (see
+  [Hugo version pins](#hugo-version-pins))
 - `scripts/get-build-id.sh`: Generates build ID from git describe (empty on
   tags).
 - `scripts/set-package-version/index.mjs`: Low-level version manager. See script
   help for usage.
+
+<!-- prettier-ignore-start -->
 
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/
@@ -339,7 +360,12 @@ before any further changes are merged into the `main` branch:
 [docsy-example]: <{{% param github_repo %}}-example>
 [docsy.dev]: <{{% _param baseURL %}}>
 [docsy.dev/config]: <{{% param github_repo %}}/blob/main/docsy.dev/config/>
+[docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>
+[docsy.dev/package.json]: <{{% param github_repo %}}/blob/main/docsy.dev/package.json>
 [Draft a new release]: <{{% param github_repo %}}/releases/new>
 [go.mod]: <{{% param github_repo %}}/blob/main/go.mod>
+[install-hugo.sh]: <{{% param github_repo %}}/blob/main/docsy.dev/scripts/install-hugo.sh>
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
 [tags]: <{{% param github_repo %}}/tags>
+
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -19,12 +19,12 @@ npm install  # optional, if hugo is already installed
 
 This updates:
 
+- [package.json][]: `config.hugo_version`, used by [install-hugo.sh][], which
+  installs `hugo-extended` into `docsy.dev` if it is not already present.
 - [docsy.dev/config/_default/hugo.yaml][]:
   - `params.hugoMinVersion` / `&hugoMinVersion`
   - Note: `module.hugoVersion.min` stays as `*hugoMinVersion`
 - [docsy.dev/package.json][]: `hugo-extended`
-- [package.json][]: `config.hugo_version`, used by [install-hugo.sh][], which
-  installs `hugo-extended` into `docsy.dev` if it is not already present.
 
 ## Publishing a release
 

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1651,6 +1651,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-17T18:45:11.323854-05:00"
   },
+  "https://github.com/google/docsy/releases/v0.15.0": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T02:22:00.009495-04:00"
+  },
   "https://github.com/google/docsy/releases/v0.2.0": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:50.294445-05:00"

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -799,6 +799,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-18T03:26:03.119227-05:00"
   },
+  "https://github.com/google/docsy/blob/main/docsy.dev/config/_default/hugo.yaml": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T03:52:11.351682-04:00"
+  },
   "https://github.com/google/docsy/blob/main/docsy.dev/content/en/_index.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:49.8453-05:00"
@@ -818,6 +822,10 @@
   "https://github.com/google/docsy/blob/main/docsy.dev/package.json": {
     "StatusCode": 206,
     "LastSeen": "2026-04-26T12:08:49.818821-04:00"
+  },
+  "https://github.com/google/docsy/blob/main/docsy.dev/scripts/install-hugo.sh": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T03:52:10.528499-04:00"
   },
   "https://github.com/google/docsy/blob/main/go.mod": {
     "StatusCode": 206,

--- a/docsy.dev/tests/md-output/goldens/docs/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/index.md
@@ -6,10 +6,10 @@ LLMS index: [llms.txt](/llms.txt)
 
 <!-- markdownlint-disable-next-line no-space-in-links -->
 
-<span class="badge bg-primary text-bg-primary fs-6">v0.14.4-dev
+<span class="badge bg-primary text-bg-primary fs-6">v0.15.0-dev
 </span>
 
-Welcome to the Docsy theme user guide for version `v0.14.4-dev`. This
+Welcome to the Docsy theme user guide for version `v0.15.0-dev`. This
 guide shows you how to get started creating technical documentation sites using
 Docsy, including site customization and how to use Docsy's blocks and templates.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.0-dev",
+  "version": "0.15.0-dev+040-over-main-7a0b370f",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "hugo_version": "0.157.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "spelling": "cSpell:ignore afdocs docsy hugo fortawesome fontawesome onedark -"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.14.4-dev+024-over-main-500ee239",
+  "version": "0.15.0-dev",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prune:refcache": "npm run cd:docsy.dev -- prune:refcache --",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve": "npm run cd:docsy.dev -- serve --",
+    "set:hugo:version": "node scripts/set-hugo-version.mjs",
     "set:version:example:git-info": "echo FIXME - npm run set:version:example -- -c ../hugo.yaml --version \"$(scripts/get-build-id.sh)\"",
     "set:version:example": "echo FIXME - 'cd ../docsy-example && node ../docsy/scripts/set-package-version/index.mjs'",
     "set:version:git-info": "npm run -s _spv -- --version \"$(scripts/get-build-id.sh)\"",
@@ -75,7 +76,7 @@
     "prettier": "^3.8.1"
   },
   "config": {
-    "hugo_version": "0.151.0"
+    "hugo_version": "0.157.0"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/get-build-id.sh
+++ b/scripts/get-build-id.sh
@@ -10,6 +10,8 @@
 #     0.14.1-dev+001-over-main-617b5960
 #   - Same tag but package.json version 0.15.0-dev — core stays 0.15.0:
 #     0.15.0-dev+001-over-main-617b5960
+#
+# cSpell:ignore toplevel
 
 set -euo pipefail
 

--- a/scripts/get-build-id.sh
+++ b/scripts/get-build-id.sh
@@ -1,34 +1,83 @@
 #!/bin/bash
 #
-# Creates a build ID from `release` using the latest semver tag on `release` as a base,
-# and the parts returned by `git describe --tags` over the current branch.
+# Build ID for dev versions: next patch after latest semver tag on main, plus
+# commit offset and SHA. If package.json already declares a higher X.Y.Z core
+# (e.g. 0.15.0-dev during release prep), that core is kept so set:version:git-info
+# does not downgrade semver.
 #
-# Example, from:
-#   - release at v0.14.0 (617b5960)
-#   - `git describe --tags` v0.14.0-1-g8047f659
-#   We get: 0.14.1-dev+001-over-release-617b5960
+# Example:
+#   - Tag on main: v0.14.0 — git-derived core 0.14.1 — output like:
+#     0.14.1-dev+001-over-main-617b5960
+#   - Same tag but package.json version 0.15.0-dev — core stays 0.15.0:
+#     0.15.0-dev+001-over-main-617b5960
 
 set -euo pipefail
 
 base_branch="main"
 
-# Get the latest semver-like tag from release.
-if ! base_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' $base_branch 2>/dev/null); then
-  echo "Error: couldn't find a semver tag on $base_branch" >&2
+# Numeric max of two X.Y.Z cores (stdout). Empty second arg → first arg.
+semver_max_core() {
+  local a="$1" b="$2"
+  [[ -z "${b}" ]] && {
+    echo "${a}"
+    return
+  }
+  local a1 a2 a3 b1 b2 b3
+  IFS=. read -r a1 a2 a3 <<<"${a}"
+  IFS=. read -r b1 b2 b3 <<<"${b}"
+  ((b1 > a1)) && {
+    echo "${b}"
+    return
+  }
+  ((b1 < a1)) && {
+    echo "${a}"
+    return
+  }
+  ((b2 > a2)) && {
+    echo "${b}"
+    return
+  }
+  ((b2 < a2)) && {
+    echo "${a}"
+    return
+  }
+  ((b3 > a3)) && {
+    echo "${b}"
+    return
+  }
+  echo "${a}"
+}
+
+# Get the latest semver-like tag on main.
+if ! base_tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' "${base_branch}" 2>/dev/null); then
+  echo "Error: couldn't find a semver tag on ${base_branch}" >&2
   exit 1
 fi
 
-# Parse the version and compute next patch.
+# Parse tag and compute next patch (git-derived dev-line core).
 version="${base_tag#v}"
 IFS=. read -r major minor patch <<<"${version}"
 next_patch=$((patch + 1))
+git_core="${major}.${minor}.${next_patch}"
 
-# Count commits atop the base tag on release, then shift to 1-based and zero-pad.
-commit_count=$(git rev-list --count --first-parent "${base_tag}..$base_branch")
+repo_root="$(git rev-parse --show-toplevel)"
+pkg_json="${repo_root}/package.json"
+pkg_core=""
+if [[ -f "${pkg_json}" ]]; then
+  pkg_line="$(PACKAGE_JSON="${pkg_json}" node -e "console.log(require(process.env.PACKAGE_JSON).version)" 2>/dev/null || true)"
+  if [[ "${pkg_line}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    pkg_core="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+  fi
+fi
+
+core="$(semver_max_core "${git_core}" "${pkg_core}")"
+
+# Count commits atop the base tag on main, then shift to 1-based and zero-pad.
+commit_count=$(git rev-list --count --first-parent "${base_tag}..${base_branch}")
 build_num=$((commit_count + 1))
 build_num_padded=$(printf "%03d" "${build_num}")
 
-# Pin the base to the current release tip hash.
-release_sha=$(git rev-parse --short=8 $base_branch)
+# Pin the base to the current main tip hash.
+release_sha=$(git rev-parse --short=8 "${base_branch}")
 
-echo "${major}.${minor}.${next_patch}-dev+${build_num_padded}-over-$base_branch-${release_sha}"
+echo "${core}-dev+${build_num_padded}-over-${base_branch}-${release_sha}"

--- a/scripts/set-hugo-version.mjs
+++ b/scripts/set-hugo-version.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// @ts-check
+/** Bump Hugo Extended semver across docsy.dev pins (see maintainer notes). */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const paths = {
+  hugoYaml: path.join(ROOT, 'docsy.dev/config/_default/hugo.yaml'),
+  docsyDevPkg: path.join(ROOT, 'docsy.dev/package.json'),
+  rootPkg: path.join(ROOT, 'package.json'),
+};
+
+function usage(code = 0) {
+  const out = code ? console.error : console.log;
+  out(`Usage: npm run set:hugo:version -- X.Y.Z`);
+  process.exit(code);
+}
+
+function main() {
+  const v = process.argv[2];
+  if (!v || v === '-h' || v === '--help') usage(v ? 0 : 1);
+  if (!SEMVER.test(v)) {
+    console.error(`Expected X.Y.Z semver, got: ${v}`);
+    usage(1);
+  }
+
+  let yaml = fs.readFileSync(paths.hugoYaml, 'utf8');
+  const yamlLine =
+    /^(\s*hugoMinVersion:\s*&hugoMinVersion\s+)(\d+\.\d+\.\d+)(\s*)$/m;
+  const ym = yaml.match(yamlLine);
+  if (!ym) {
+    console.error(`Missing hugoMinVersion anchor line in ${paths.hugoYaml}`);
+    process.exit(1);
+  }
+  const prev = ym[2];
+  yaml = yaml.replace(yamlLine, `$1${v}$3`);
+  fs.writeFileSync(paths.hugoYaml, yaml, 'utf8');
+
+  function setQuotedField(filePath, field) {
+    let t = fs.readFileSync(filePath, 'utf8');
+    const re = new RegExp(`^(\\s*"${field}":\\s*")([^"]+)(")`, 'm');
+    if (!re.test(t)) {
+      console.error(`Missing "${field}" in ${path.relative(ROOT, filePath)}`);
+      process.exit(1);
+    }
+    fs.writeFileSync(filePath, t.replace(re, `$1${v}$3`), 'utf8');
+  }
+
+  setQuotedField(paths.rootPkg, 'hugo_version');
+  setQuotedField(paths.docsyDevPkg, 'hugo-extended');
+
+  console.log(`set:hugo:version ${prev} → ${v}`);
+  for (const p of Object.values(paths)) {
+    console.log(`  ${path.relative(ROOT, p)}`);
+  }
+  console.log('Next: npm install');
+}
+
+main();

--- a/tasks/0.15/release-prep/commit-inventory.md
+++ b/tasks/0.15/release-prep/commit-inventory.md
@@ -1,17 +1,17 @@
 ---
 title: 0.15 commit inventory
 date: 2026-04-25
-lastmod: 2026-04-26
+lastmod: 2026-04-30
 range: v0.14.3..main
-last-main-commit: 343d6154
+last-main-commit: 7a0b370f
 ---
 
 ## Scope
 
-Inventory covers commits in [v0.14.3...main][] through [343d6154][].
+Inventory covers commits in [v0.14.3...main][] through [7a0b370f][].
 
-- First-parent commits: 37
-- Raw commits in range: 46
+- First-parent commits: 39
+- Raw commits in range: 48
 - Baseline: latest official release tag, [v0.14.3][]
 
 The extra raw commits are implementation commits that are also represented by
@@ -77,6 +77,10 @@ uses first-parent commits as the release-audit spine.
 - `343d6154` [#2610][] 0.15 release-prep: release report blog draft, changelog
   “Next release”, refcache refresh, wide user-guide link sweep, and
   `tasks/0.15/release-prep` reports
+- `566be03e` [#2611][] Add Agent support user-guide page, AFDocs scorecard,
+  release-prep refresh, CI docs, and `readfile` shortcode cleanup
+- `7a0b370f` [#2616][] Update the 0.15 release blog, changelog, and user-guide
+  docs; finalize 0.15 upgrade guidance around Hugo 0.157.0 and Node LTS 24
 
 ## Internationalization
 
@@ -115,6 +119,11 @@ uses first-parent commits as the release-audit spine.
 - [#2610][] is a large release-prep omnibus (blog, changelog, refcache, link
   hygiene, and task reports). Prefer the feature PRs above for functional change
   notes.
+- [#2611][] completes the agent-support user-guide slice and refreshes release
+  prep after [#2610][]; treat it as documentation and validation for [#2596][]
+  rather than a separate user-facing feature.
+- [#2616][] finalizes the release blog, changelog, doc-rooted guidance, and
+  version-support wording. It closes stale WIP notes from earlier report passes.
 
 [#2082]: https://github.com/google/docsy/pull/2082
 [#2555]: https://github.com/google/docsy/pull/2555
@@ -144,6 +153,7 @@ uses first-parent commits as the release-audit spine.
 [#2586]: https://github.com/google/docsy/pull/2586
 [#2587]: https://github.com/google/docsy/pull/2587
 [#2591]: https://github.com/google/docsy/pull/2591
+[#2596]: https://github.com/google/docsy/issues/2596
 [#2597]: https://github.com/google/docsy/pull/2597
 [#2599]: https://github.com/google/docsy/pull/2599
 [#2600]: https://github.com/google/docsy/pull/2600
@@ -154,6 +164,8 @@ uses first-parent commits as the release-audit spine.
 [#2605]: https://github.com/google/docsy/pull/2605
 [#2606]: https://github.com/google/docsy/pull/2606
 [#2610]: https://github.com/google/docsy/pull/2610
-[343d6154]: https://github.com/google/docsy/commit/343d6154
+[#2611]: https://github.com/google/docsy/pull/2611
+[#2616]: https://github.com/google/docsy/pull/2616
+[7a0b370f]: https://github.com/google/docsy/commit/7a0b370f
 [v0.14.3...main]: https://github.com/google/docsy/compare/v0.14.3...main
 [v0.14.3]: https://github.com/google/docsy/releases/tag/v0.14.3

--- a/tasks/0.15/release-prep/index.plan.md
+++ b/tasks/0.15/release-prep/index.plan.md
@@ -1,8 +1,8 @@
 ---
 title: 0.15 Release wrapup plan
 date: 2026-04-25
-lastmod: 2026-04-26
-last-main-commit: 343d6154
+lastmod: 2026-04-30
+last-main-commit: 7a0b370f
 ---
 
 ## Agent guidance
@@ -134,7 +134,7 @@ When new commits land on `main`, repeat the following:
   or changelog.
 
 Refresh reports for commits in [v0.14.3...main][] through the commit named as
-`last-main-commit` in this file’s front matter (currently [343d6154][]).
+`last-main-commit` in this file’s front matter (currently [7a0b370f][]).
 
 ### 0.15.0 blog post
 
@@ -169,7 +169,7 @@ Refresh reports for commits in [v0.14.3...main][] through the commit named as
   ../../../docsy.dev/content/en/project/about/changelog/#v0.15.0
 [v0.14.3...main]: https://github.com/google/docsy/compare/v0.14.3...main
 [0.15.0 blog post]: ../../../docsy.dev/content/en/blog/2026/0.15.0.md
-[343d6154]: https://github.com/google/docsy/commit/343d6154
+[7a0b370f]: https://github.com/google/docsy/commit/7a0b370f
 [changelog style guide]:
   ../../../docsy.dev/content/en/project/about/changelog/#style-guide
 [Docsy style guide]: ../../../docsy.dev/content/en/project/style-guide/

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -1,15 +1,15 @@
 ---
 title: 0.15 issue audit
 date: 2026-04-25
-lastmod: 2026-04-26
+lastmod: 2026-04-30
 range: v0.14.3..main
-last-main-commit: 343d6154
+last-main-commit: 7a0b370f
 cSpell:ignore: afdocs overpromising
 ---
 
 ## Scope
 
-Draft audit covers material changes in [v0.14.3...main][] through [343d6154][].
+Draft audit covers material changes in [v0.14.3...main][] through [7a0b370f][].
 This is an evidence pass for review before writing the wrapup report, release
 blog post, or changelog updates.
 
@@ -28,14 +28,14 @@ blog post, or changelog updates.
   - [#2565][] changes `card` shortcode rendering from `markdownify` to
     `$.Page.RenderString`, which may affect some client overrides or shortcode
     content rendering.
-  - [#2585][] raises the repository-supported Hugo version to 0.157.0.
-- Changelog status: draft 0.15.0 entry exists and needs final review before
-  release.
-- Blog status: draft release report exists at
-  `docsy.dev/content/en/blog/2026/0.15.0.md` ([#2610][]).
-- Link check: the blog points to `/docs/content/agent-support/`; that user-guide
-  page is **not** on `main` at [343d6154][] (landed in follow-up branch work).
-  Resolve before publishing the post.
+  - [#2585][] raises the repository-supported Hugo version to 0.157.0 and keeps
+    release guidance on Node LTS 24.
+- Changelog status: refreshed 0.15.0 entry exists ([#2616][]); final release
+  pass still needs replacing prerelease/release-page placeholders when tagging.
+- Blog status: refreshed release report exists at
+  `docsy.dev/content/en/blog/2026/0.15.0.md` ([#2616][]).
+- Link check: the agent-support user-guide page is now on `main` via [#2611][];
+  the earlier blog-link blocker is resolved.
 
 ### Docs/blog/changelog status summary
 
@@ -51,57 +51,59 @@ each of these for Docs, Blog, and Changelog (CL). Table entry values include:
 
 | Item                                                       | Docs | Blog | CL   | Notes                                      |
 | ---------------------------------------------------------- | ---- | ---- | ---- | ------------------------------------------ |
-| [#2082][]: Add Azerbaijan language                         | rel  | WIP  | WIP  | Internationalization                       |
+| [#2082][]: Add Azerbaijan language                         | rel  | done | done | Internationalization                       |
 | [#2555][]: Set version to 0.14.3-dev                       | N/A  | N/A  | N/A  | Release-prep maintenance                   |
-| [#2556][]: Reorg deployment docs, normalize links          | done | WIP  | rel  | Documentation/process cleanup              |
+| [#2556][]: Reorg deployment docs, normalize links          | done | done | rel  | Documentation/process cleanup              |
 | [#2557][]: Add version menu to site                        | done | rel  | rel  | No client-facing release-note impact       |
-| [#2558][]: Replace placeholder locale by French            | rel  | WIP  | WIP  | Internationalization                       |
-| [#2559][]: Document `deploy/prod` branch                   | done | WIP  | rel  | Documentation/process cleanup              |
+| [#2558][]: Replace placeholder locale by French            | rel  | rel  | rel  | Site-only i18n setup                       |
+| [#2559][]: Document `deploy/prod` branch                   | done | done | rel  | Documentation/process cleanup              |
 | [#2560][]: Update bug report template                      | N/A  | N/A  | N/A  | Admin                                      |
 | [#2562][]: Ensure `.td-main > .row` grows vertically       | rel  | rel  | done | Already covered by v0.14.3                 |
-| [#2563][]: Add doc-rooted example version and guidance     | rel  | WIP  | WIP  | Doc-rooted sites                           |
-| [#2564][]: Use `TD_BUILD_CTX` for doc-rooted builds        | rel  | WIP  | WIP  | Doc-rooted sites                           |
-| [#2565][]: Update doc-rooted configs and `card` rendering  | rel  | WIP  | WIP  | Includes client-impacting `card` change    |
-| [#2567][]: Remove `sidebar_root_for` user-guide docs       | rel  | WIP  | WIP  | Doc-rooted cleanup                         |
-| [#2568][]: Dedup site homepages for doc-rooted sites       | rel  | WIP  | WIP  | Doc-rooted sites                           |
+| [#2563][]: Add doc-rooted example version and guidance     | done | done | done | Doc-rooted sites                           |
+| [#2564][]: Use `TD_BUILD_CTX` for doc-rooted builds        | rel  | done | done | Doc-rooted sites                           |
+| [#2565][]: Update doc-rooted configs and `card` rendering  | rel  | done | done | Includes client-impacting `card` change    |
+| [#2567][]: Remove `sidebar_root_for` user-guide docs       | rel  | done | done | Doc-rooted cleanup                         |
+| [#2568][]: Dedup site homepages for doc-rooted sites       | rel  | done | done | Doc-rooted sites                           |
 | [#2571][]: Update `deploy/prod` to 0.14.3                  | N/A  | N/A  | N/A  | Branch maintenance                         |
-| [#2572][]: Clarify release process and branch model        | done | WIP  | rel  | Documentation/process cleanup              |
+| [#2572][]: Clarify release process and branch model        | done | done | rel  | Documentation/process cleanup              |
 | [#2573][]: Sync `release` and `deploy/prod` branches       | N/A  | N/A  | N/A  | Branch maintenance                         |
 | [#2574][]: Link release branches back into main ancestry   | N/A  | N/A  | N/A  | Branch maintenance                         |
-| [#2575][]: Format project about docs and add project link  | done | WIP  | rel  | Documentation/process cleanup              |
-| [#2576][]: Fix footer/community link target and `rel`      | 0    | WIP  | WIP  | Community/footer links                     |
+| [#2575][]: Format project about docs and add project link  | done | done | rel  | Documentation/process cleanup              |
+| [#2576][]: Fix footer/community link target and `rel`      | rel  | done | done | Community/footer links                     |
 | [#2577][]: Record ancestry with release branches           | N/A  | N/A  | N/A  | Branch ancestry                            |
-| [#2579][]: Use canonical URL to contributing page          | done | WIP  | rel  | Documentation/process cleanup              |
-| [#2580][]: Resolve community/footer links under permalinks | 0    | WIP  | WIP  | Potentially breaking multilingual behavior |
-| [#2583][]: Add Romanian locale                             | rel  | WIP  | WIP  | Internationalization                       |
-| [#2584][]: Add site-local URL markdownlint rule            | done | WIP  | rel  | Documentation/process cleanup              |
-| [#2585][]: Update NPM packages and Hugo tooling            | WIP  | WIP  | WIP  | Confirm final supported versions           |
+| [#2579][]: Use canonical URL to contributing page          | done | done | rel  | Documentation/process cleanup              |
+| [#2580][]: Resolve community/footer links under permalinks | rel  | done | done | Potentially breaking multilingual behavior |
+| [#2583][]: Add Romanian locale                             | rel  | done | done | Internationalization                       |
+| [#2584][]: Add site-local URL markdownlint rule            | done | done | rel  | Documentation/process cleanup              |
+| [#2585][]: Update NPM packages and Hugo tooling            | done | done | done | Final versions reflected in blog           |
 | [#2586][]: Update version and variant menu                 | done | rel  | rel  | No client-facing release-note impact       |
-| [#2587][]: Finalize doc-rooted configuration explanation   | rel  | WIP  | WIP  | Doc-rooted sites                           |
-| [#2591][]: Add German alert-label translations             | rel  | WIP  | WIP  | Internationalization                       |
-| [#2597][]: Add Markdown output phase 1                     | WIP  | WIP  | WIP  | Experimental agent support                 |
-| [#2599][]: Drop Docsy-defined `Markdown` output format     | WIP  | WIP  | WIP  | Experimental agent support                 |
-| [#2600][]: Trim Markdown output titles and descriptions    | WIP  | WIP  | WIP  | Experimental agent support                 |
-| [#2601][]: Add View Markdown page-meta link                | WIP  | WIP  | WIP  | Experimental agent support                 |
-| [#2602][]: Add `post_view_markdown` to i18n files          | WIP  | WIP  | WIP  | Agent support and i18n                     |
-| [#2603][]: Add Romanian View Markdown translation          | rel  | WIP  | WIP  | Internationalization                       |
-| [#2604][]: Create `az.yaml` from TOML                      | rel  | WIP  | WIP  | Internationalization                       |
-| [#2605][]: Add LLMS output and `llms.txt`                  | WIP  | WIP  | WIP  | Experimental agent support                 |
-| [#2606][]: Allow Markdown output for project docs          | WIP  | WIP  | WIP  | Experimental agent support                 |
+| [#2587][]: Finalize doc-rooted configuration explanation   | done | done | done | Doc-rooted sites                           |
+| [#2591][]: Add German alert-label translations             | rel  | done | done | Internationalization                       |
+| [#2597][]: Add Markdown output phase 1                     | done | done | done | Experimental agent support                 |
+| [#2599][]: Drop Docsy-defined `Markdown` output format     | done | done | done | Experimental agent support                 |
+| [#2600][]: Trim Markdown output titles and descriptions    | done | done | done | Experimental agent support                 |
+| [#2601][]: Add View Markdown page-meta link                | done | done | done | Experimental agent support                 |
+| [#2602][]: Add `post_view_markdown` to i18n files          | done | done | done | Agent support and i18n                     |
+| [#2603][]: Add Romanian View Markdown translation          | rel  | done | done | Internationalization                       |
+| [#2604][]: Create `az.yaml` from TOML                      | rel  | done | done | Internationalization                       |
+| [#2605][]: Add LLMS output and `llms.txt`                  | done | done | done | Experimental agent support                 |
+| [#2606][]: Allow Markdown output for project docs          | done | done | done | Experimental agent support                 |
 | [#2610][]: 0.15 release-prep omnibus                       | done | rel  | rel  | Blog, changelog, refcache, reports, links  |
+| [#2611][]: Agent support UG and release-prep refresh       | done | rel  | rel  | Resolves agent-support blog-link blocker   |
+| [#2616][]: Update 0.15 release blog, CL, and docs          | done | done | done | Final release-content refresh              |
 
 Raw commits in scope without PR numbers in their commit subjects:
 
-| Item                                                 | Docs | Blog | CL  | Notes                         |
-| ---------------------------------------------------- | ---- | ---- | --- | ----------------------------- |
-| `40bef3c7`: Record ancestry with release             | N/A  | N/A  | N/A | Covered by branch maintenance |
-| `21a1ff37`: Record ancestry with deploy/prod         | N/A  | N/A  | N/A | Covered by branch maintenance |
-| `5f0b2c86`: Use canonical URL to contributing page   | done | WIP  | rel | Covered by [#2579][]          |
-| `df519b49`: Resolve community and footer links paths | 0    | WIP  | WIP | Covered by [#2580][]          |
-| `e91cf749`: Add markdownlint rule and fix link       | done | WIP  | rel | Covered by [#2584][]          |
-| `ca5deb63`: Update NPM packages and Hugo to 0.157.0  | WIP  | WIP  | WIP | Covered by [#2585][]          |
-| `2ad607a8`: Update package.json                      | WIP  | WIP  | WIP | Covered by [#2585][]          |
-| `28d44d1f`: Use bash `cp` instead of NPM `cpy-cli`   | WIP  | WIP  | WIP | Covered by [#2585][]          |
+| Item                                                 | Docs | Blog | CL   | Notes                         |
+| ---------------------------------------------------- | ---- | ---- | ---- | ----------------------------- |
+| `40bef3c7`: Record ancestry with release             | N/A  | N/A  | N/A  | Covered by branch maintenance |
+| `21a1ff37`: Record ancestry with deploy/prod         | N/A  | N/A  | N/A  | Covered by branch maintenance |
+| `5f0b2c86`: Use canonical URL to contributing page   | done | done | rel  | Covered by [#2579][]          |
+| `df519b49`: Resolve community and footer links paths | rel  | done | done | Covered by [#2580][]          |
+| `e91cf749`: Add markdownlint rule and fix link       | done | done | rel  | Covered by [#2584][]          |
+| `ca5deb63`: Update NPM packages and Hugo to 0.157.0  | done | done | done | Covered by [#2585][]          |
+| `2ad607a8`: Update package.json                      | done | done | done | Covered by [#2585][]          |
+| `28d44d1f`: Use bash `cp` instead of NPM `cpy-cli`   | done | done | done | Covered by [#2585][]          |
 
 ## Audit details
 
@@ -109,43 +111,38 @@ Raw commits in scope without PR numbers in their commit subjects:
 
 - Evidence: [#2597][], [#2599][], [#2600][], [#2601][], [#2602][], [#2605][],
   [#2606][]; tracker [#2596][]; golden-test tracker [#726][].
-- Status: partial. The basic Markdown output and `llms.txt` implementation is
-  merged, but tracker [#2596][] intentionally remains open while additional 0.15
-  follow-up work is still undecided.
+- Status: resolved for 0.15 phase 1. The basic Markdown output, `llms.txt`,
+  "View Markdown" link, user-guide page, and scorecard documentation are merged.
+  Phase-1 tracker [#2596][] is closed; future work moved to [#2614][].
 - Downstream/client impact:
   - Adds opt-in theme support through Hugo output formats and templates.
   - Adds a visible "View Markdown" page-meta link when Markdown alternate output
     exists.
   - Includes new i18n key `post_view_markdown`.
 - Docs impact:
-  - Status: rel. Feature planning in `tasks/0.15/agent-friendly-support.plan.md`
-    on `main` at [343d6154][] (branch renames it to `agent-support.plan.md`).
+  - Status: done. Feature planning is in `tasks/0.15/agent-support.plan.md`.
   - Golden-test planning exists in `tasks/0.15/md-output-golden-tests.plan.md`.
   - `docsy.dev` is configured to enable Markdown and LLMS outputs.
   - Dedicated user-guide page `docsy.dev/content/en/docs/content/agent-support/`
-    exists on the current branch; **merge before release** so the blog link is
-    not dead on `main`.
+    exists on `main` via [#2611][].
 - Changelog impact:
-  - Status: WIP.
-  - Draft 0.15 changelog entry includes this under Experimental.
+  - Status: done.
+  - The 0.15 changelog entry includes this under Experimental.
 - Blog inclusion:
-  - Status: WIP.
-  - Include as a major experimental feature. Explain what is available now, what
-    is opt-in, and what remains experimental.
+  - Status: done.
+  - Included as a major experimental feature, with a link to the user guide and
+    [#2614][] follow-up tracker.
 - Release-post treatment: experimental.
 - Follow-up needed:
-  - Add user-guide or release-blog guidance for enabling Markdown output and
-    `llms.txt`.
-  - Note any measured AFDocs caveats without overpromising support.
+  - Use [#2614][] for post-0.15 improvements.
 
 ### Doc-rooted site support
 
 - Evidence: [#2563][], [#2564][], [#2565][], [#2567][], [#2568][], [#2579][],
   [#2580][], [#2586][], [#2587][]; tracker [#2504][]; closed issues [#2492][]
   and [#2499][].
-- Status: partial. [#2492][] and [#2499][] are closed through [#2563][], but the
-  overall [#2504][] tracker remains open. Current expectation is that [#2504][]
-  will close for 0.15, but confirm before finalizing release content.
+- Status: resolved for 0.15. [#2492][] and [#2499][] are closed through
+  [#2563][], and the overall [#2504][] tracker is closed.
 - Downstream/client impact:
   - Adds a concrete configuration pattern for documentation-first sites.
   - May affect users with custom docs-only/doc-rooted configurations.
@@ -161,18 +158,17 @@ Raw commits in scope without PR numbers in their commit subjects:
   - `docsy.dev/content/en/project/build/git-repo.md` documents the `doc-rooted`
     branch.
 - Changelog impact:
-  - Status: WIP.
-  - Draft 0.15 changelog entry includes doc-rooted sites and `card` shortcode
+  - Status: done.
+  - The 0.15 changelog entry includes doc-rooted sites and `card` shortcode
     rendering.
 - Blog inclusion:
-  - Status: WIP.
-  - Include as a major feature or improvement, with migration notes for projects
-    that previously used docs-only patterns.
-  - Mention the `card` shortcode rendering change as an internal behavior change
-    that may affect some client projects.
+  - Status: done.
+  - Included as a major improvement, with migration notes for projects that
+    previously used docs-only patterns.
+  - The `card` shortcode rendering change is called out as a breaking/action
+    review item.
 - Follow-up needed:
-  - Confirm which [#2504][] checklist items remain before calling doc-rooted
-    support complete.
+  - Use 0.16+ issues for any remaining doc-rooted refinements.
 
 ### Community and Footer Link Behavior
 
@@ -188,22 +184,22 @@ Raw commits in scope without PR numbers in their commit subjects:
     site-relative; use the default language code prefix to force a default
     language target.
 - Docs impact:
-  - Status: 0.
-  - No dedicated user-guide update found in the first pass.
+  - Status: rel.
+  - Release guidance links to the existing community-page configuration docs.
 - Changelog impact:
-  - Status: WIP.
-  - Draft 0.15 changelog entry includes this as a breaking change.
+  - Status: done.
+  - The 0.15 changelog entry includes this as a breaking change.
 - Blog inclusion:
-  - Status: WIP.
-  - Include in the breaking/action section as a potentially breaking change.
+  - Status: done.
+  - Included in the breaking/action section.
 - Guidance:
   - Review community and footer link path values on multilingual sites.
   - Paths are now interpreted as site-relative so they resolve correctly under
     custom permalinks.
   - To force a link to the default language, prefix the path with the default
     language code.
-- Follow-up needed: add this guidance to release notes and, if appropriate,
-  user-guide examples for multilingual path prefixes.
+- Follow-up needed: consider user-guide examples for multilingual path prefixes
+  after 0.15 if more detail is needed.
 
 ### Version and Variant Menus
 
@@ -265,8 +261,9 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Draft 0.15 changelog entry briefly mentions deployment and branch-model
     docs.
 - Blog inclusion:
-  - Status: WIP.
-  - Include only if the 0.15 post has an "Other notable docs updates" section.
+  - Status: done for 0.15.
+  - Omitted from the refreshed 0.15 post except where relevant as supporting
+    links. The changelog carries the terse process-docs note.
 - Follow-up needed: none identified for release blockers.
 
 ### Dependencies and Tooling
@@ -278,19 +275,16 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Updates Hugo to 0.157.0.
   - Drops `cpy-cli` in favor of a shell `cp` call.
 - Docs impact:
-  - Status: WIP.
-  - Supported-version references need review before final release.
+  - Status: done.
+  - Supported-version references were refreshed in [#2616][].
 - Changelog impact:
-  - Status: WIP.
-  - Draft 0.15 changelog entry mentions `hugo-extended` 0.157.0, but final
-    supported-version wording needs confirmation.
+  - Status: done.
+  - The 0.15 changelog entry mentions `hugo-extended` 0.157.0.
 - Blog inclusion:
-  - Status: WIP.
-  - Include in upgrade/runtime section if Hugo 0.157.0 becomes the official 0.15
-    Hugo requirement.
+  - Status: done.
+  - The upgrade section now lists Docsy 0.15.0, Hugo 0.157.0, and Node LTS 24.
 - Follow-up needed:
-  - Confirm final Hugo and Node support matrix before release.
-  - Check whether `cpy-cli` removal affects consumers or only repo tooling.
+  - Replace release-page placeholders when tagging.
 
 ### Internationalization
 
@@ -307,11 +301,11 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Status: done for 0.15.
   - No release-blocking docs found.
 - Changelog impact:
-  - Status: WIP.
-  - Draft 0.15 changelog entry includes i18n highlights.
+  - Status: done.
+  - The 0.15 changelog entry includes i18n highlights.
 - Blog inclusion:
-  - Status: WIP.
-  - Include as "Internationalization" under other notable changes.
+  - Status: done.
+  - Included as "Internationalization" under other notable changes.
 - Follow-up needed: invite native-speaker review for generated or assisted
   translations if desired.
 
@@ -321,8 +315,8 @@ Raw commits in scope without PR numbers in their commit subjects:
   the 0.15 release report.
 - Omit 0.14.3-only fixes from 0.15 highlights. They are covered by the 0.14
   release resources, including the v0.14.3 changelog entry.
-- Check [#2504][] before finalizing 0.15. It is expected to close, but confirm
-  whether any remaining tasks need separate follow-up.
+- [#2504][] and [#2596][] are now closed for 0.15. Use [#2614][] and the 0.16
+  tracker for follow-up that should not block the tag.
 
 ## References
 
@@ -374,6 +368,9 @@ Raw commits in scope without PR numbers in their commit subjects:
 [#2605]: https://github.com/google/docsy/pull/2605
 [#2606]: https://github.com/google/docsy/pull/2606
 [#2610]: https://github.com/google/docsy/pull/2610
+[#2611]: https://github.com/google/docsy/pull/2611
+[#2614]: https://github.com/google/docsy/issues/2614
+[#2616]: https://github.com/google/docsy/pull/2616
 [#726]: https://github.com/google/docsy/issues/726
-[343d6154]: https://github.com/google/docsy/commit/343d6154
+[7a0b370f]: https://github.com/google/docsy/commit/7a0b370f
 [v0.14.3...main]: https://github.com/google/docsy/compare/v0.14.3...main

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -43,53 +43,56 @@ Each PR and commit in scope of this release may require updates to the docs, or
 require an entry in the changelog or blog. Here is a summary of the status of
 each of these for Docs, Blog, and Changelog (CL). Table entry values include:
 
-- 0: not started
-- done: full done
-- N/A: not applicable
-- rel: the work scoped for this release is complete, but more work is needed
-- WIP: work in progress
+- **0**: not started
+- **done**: Shipped for this release **and** no further planned work on **that
+  channel** (docs, blog, or changelog) to carry into a later release.
+- **rel**: Shipped for this release **and** follow-up on **that channel** is
+  expected or tracked for a future release (see audit detail **Follow-up
+  needed**).
+- **N/A**: not applicable
+- **WIP**: work in progress
 
 | Item                                                       | Docs | Blog | CL   | Notes                                      |
 | ---------------------------------------------------------- | ---- | ---- | ---- | ------------------------------------------ |
-| [#2082][]: Add Azerbaijan language                         | rel  | done | done | Internationalization                       |
+| [#2082][]: Add Azerbaijan language                         | done | done | done | Internationalization                       |
 | [#2555][]: Set version to 0.14.3-dev                       | N/A  | N/A  | N/A  | Release-prep maintenance                   |
-| [#2556][]: Reorg deployment docs, normalize links          | done | done | rel  | Documentation/process cleanup              |
-| [#2557][]: Add version menu to site                        | done | rel  | rel  | No client-facing release-note impact       |
-| [#2558][]: Replace placeholder locale by French            | rel  | rel  | rel  | Site-only i18n setup                       |
-| [#2559][]: Document `deploy/prod` branch                   | done | done | rel  | Documentation/process cleanup              |
+| [#2556][]: Reorg deployment docs, normalize links          | done | done | done | Documentation/process cleanup              |
+| [#2557][]: Add version menu to site                        | done | done | done | No client-facing release-note impact       |
+| [#2558][]: Replace placeholder locale by French            | done | done | done | Site-only i18n setup                       |
+| [#2559][]: Document `deploy/prod` branch                   | done | done | done | Documentation/process cleanup              |
 | [#2560][]: Update bug report template                      | N/A  | N/A  | N/A  | Admin                                      |
-| [#2562][]: Ensure `.td-main > .row` grows vertically       | rel  | rel  | done | Already covered by v0.14.3                 |
+| [#2562][]: Ensure `.td-main > .row` grows vertically       | done | done | done | Already covered by v0.14.3                 |
 | [#2563][]: Add doc-rooted example version and guidance     | done | done | done | Doc-rooted sites                           |
 | [#2564][]: Use `TD_BUILD_CTX` for doc-rooted builds        | rel  | done | done | Doc-rooted sites                           |
 | [#2565][]: Update doc-rooted configs and `card` rendering  | rel  | done | done | Includes client-impacting `card` change    |
 | [#2567][]: Remove `sidebar_root_for` user-guide docs       | rel  | done | done | Doc-rooted cleanup                         |
 | [#2568][]: Dedup site homepages for doc-rooted sites       | rel  | done | done | Doc-rooted sites                           |
 | [#2571][]: Update `deploy/prod` to 0.14.3                  | N/A  | N/A  | N/A  | Branch maintenance                         |
-| [#2572][]: Clarify release process and branch model        | done | done | rel  | Documentation/process cleanup              |
+| [#2572][]: Clarify release process and branch model        | done | done | done | Documentation/process cleanup              |
 | [#2573][]: Sync `release` and `deploy/prod` branches       | N/A  | N/A  | N/A  | Branch maintenance                         |
 | [#2574][]: Link release branches back into main ancestry   | N/A  | N/A  | N/A  | Branch maintenance                         |
-| [#2575][]: Format project about docs and add project link  | done | done | rel  | Documentation/process cleanup              |
-| [#2576][]: Fix footer/community link target and `rel`      | rel  | done | done | Community/footer links                     |
+| [#2575][]: Format project about docs and add project link  | done | done | done | Documentation/process cleanup              |
+| [#2576][]: Fix footer/community link target and `rel`      | done | done | done | Community/footer links                     |
 | [#2577][]: Record ancestry with release branches           | N/A  | N/A  | N/A  | Branch ancestry                            |
-| [#2579][]: Use canonical URL to contributing page          | done | done | rel  | Documentation/process cleanup              |
-| [#2580][]: Resolve community/footer links under permalinks | rel  | done | done | Potentially breaking multilingual behavior |
-| [#2583][]: Add Romanian locale                             | rel  | done | done | Internationalization                       |
-| [#2584][]: Add site-local URL markdownlint rule            | done | done | rel  | Documentation/process cleanup              |
+| [#2579][]: Use canonical URL to contributing page          | done | done | done | Documentation/process cleanup              |
+| [#2580][]: Resolve community/footer links under permalinks | done | done | done | Potentially breaking multilingual behavior |
+| [#2583][]: Add Romanian locale                             | done | done | done | Internationalization                       |
+| [#2584][]: Add site-local URL markdownlint rule            | done | done | done | Documentation/process cleanup              |
 | [#2585][]: Update NPM packages and Hugo tooling            | done | done | done | Final versions reflected in blog           |
-| [#2586][]: Update version and variant menu                 | done | rel  | rel  | No client-facing release-note impact       |
+| [#2586][]: Update version and variant menu                 | done | done | done | No client-facing release-note impact       |
 | [#2587][]: Finalize doc-rooted configuration explanation   | done | done | done | Doc-rooted sites                           |
-| [#2591][]: Add German alert-label translations             | rel  | done | done | Internationalization                       |
+| [#2591][]: Add German alert-label translations             | done | done | done | Internationalization                       |
 | [#2597][]: Add Markdown output phase 1                     | done | done | done | Experimental agent support                 |
 | [#2599][]: Drop Docsy-defined `Markdown` output format     | done | done | done | Experimental agent support                 |
 | [#2600][]: Trim Markdown output titles and descriptions    | done | done | done | Experimental agent support                 |
 | [#2601][]: Add View Markdown page-meta link                | done | done | done | Experimental agent support                 |
 | [#2602][]: Add `post_view_markdown` to i18n files          | done | done | done | Agent support and i18n                     |
-| [#2603][]: Add Romanian View Markdown translation          | rel  | done | done | Internationalization                       |
-| [#2604][]: Create `az.yaml` from TOML                      | rel  | done | done | Internationalization                       |
+| [#2603][]: Add Romanian View Markdown translation          | done | done | done | Internationalization                       |
+| [#2604][]: Create `az.yaml` from TOML                      | done | done | done | Internationalization                       |
 | [#2605][]: Add LLMS output and `llms.txt`                  | done | done | done | Experimental agent support                 |
 | [#2606][]: Allow Markdown output for project docs          | done | done | done | Experimental agent support                 |
-| [#2610][]: 0.15 release-prep omnibus                       | done | rel  | rel  | Blog, changelog, refcache, reports, links  |
-| [#2611][]: Agent support UG and release-prep refresh       | done | rel  | rel  | Resolves agent-support blog-link blocker   |
+| [#2610][]: 0.15 release-prep omnibus                       | done | done | done | Blog, changelog, refcache, reports, links  |
+| [#2611][]: Agent support UG and release-prep refresh       | done | done | done | Resolves agent-support blog-link blocker   |
 | [#2616][]: Update 0.15 release blog, CL, and docs          | done | done | done | Final release-content refresh              |
 
 Raw commits in scope without PR numbers in their commit subjects:
@@ -98,9 +101,9 @@ Raw commits in scope without PR numbers in their commit subjects:
 | ---------------------------------------------------- | ---- | ---- | ---- | ----------------------------- |
 | `40bef3c7`: Record ancestry with release             | N/A  | N/A  | N/A  | Covered by branch maintenance |
 | `21a1ff37`: Record ancestry with deploy/prod         | N/A  | N/A  | N/A  | Covered by branch maintenance |
-| `5f0b2c86`: Use canonical URL to contributing page   | done | done | rel  | Covered by [#2579][]          |
-| `df519b49`: Resolve community and footer links paths | rel  | done | done | Covered by [#2580][]          |
-| `e91cf749`: Add markdownlint rule and fix link       | done | done | rel  | Covered by [#2584][]          |
+| `5f0b2c86`: Use canonical URL to contributing page   | done | done | done | Covered by [#2579][]          |
+| `df519b49`: Resolve community and footer links paths | done | done | done | Covered by [#2580][]          |
+| `e91cf749`: Add markdownlint rule and fix link       | done | done | done | Covered by [#2584][]          |
 | `ca5deb63`: Update NPM packages and Hugo to 0.157.0  | done | done | done | Covered by [#2585][]          |
 | `2ad607a8`: Update package.json                      | done | done | done | Covered by [#2585][]          |
 | `28d44d1f`: Use bash `cp` instead of NPM `cpy-cli`   | done | done | done | Covered by [#2585][]          |
@@ -120,21 +123,23 @@ Raw commits in scope without PR numbers in their commit subjects:
     exists.
   - Includes new i18n key `post_view_markdown`.
 - Docs impact:
-  - Status: done. Feature planning is in `tasks/0.15/agent-support.plan.md`.
+  - Status: **done** for phase 1 (no further docs/blog/changelog carry-forward
+    required for this release).
+  - Feature planning is in `tasks/0.15/agent-support.plan.md`.
   - Golden-test planning exists in `tasks/0.15/md-output-golden-tests.plan.md`.
   - `docsy.dev` is configured to enable Markdown and LLMS outputs.
   - Dedicated user-guide page `docsy.dev/content/en/docs/content/agent-support/`
     exists on `main` via [#2611][].
 - Changelog impact:
-  - Status: done.
+  - Status: **done** for phase 1.
   - The 0.15 changelog entry includes this under Experimental.
 - Blog inclusion:
-  - Status: done.
+  - Status: **done** for phase 1.
   - Included as a major experimental feature, with a link to the user guide and
-    [#2614][] follow-up tracker.
+    [#2614][] for later phases.
 - Release-post treatment: experimental.
-- Follow-up needed:
-  - Use [#2614][] for post-0.15 improvements.
+- Follow-up (later releases, not release-channel carry-forward for 0.15):
+  - Track further agent-support work in [#2614][].
 
 ### Doc-rooted site support
 
@@ -151,7 +156,8 @@ Raw commits in scope without PR numbers in their commit subjects:
     affect clients that depend on the previous rendering behavior or override
     the shortcode.
 - Docs impact:
-  - Status: done for 0.15.
+  - Status: **rel** on the summary table for ongoing doc-rooted refinements;
+    baseline guidance and examples shipped for 0.15.
   - `docsy.dev/content/en/docs/content/adding-content.md` now documents
     doc-rooted sites and links the doc-rooted example.
   - `docsy.dev/config/doc-rooted/` adds a doc-rooted site configuration.
@@ -184,8 +190,8 @@ Raw commits in scope without PR numbers in their commit subjects:
     site-relative; use the default language code prefix to force a default
     language target.
 - Docs impact:
-  - Status: rel.
-  - Release guidance links to the existing community-page configuration docs.
+  - Status: **done** (guidance links to the existing community-page configuration
+    docs).
 - Changelog impact:
   - Status: done.
   - The 0.15 changelog entry includes this as a breaking change.
@@ -198,8 +204,8 @@ Raw commits in scope without PR numbers in their commit subjects:
     custom permalinks.
   - To force a link to the default language, prefix the path with the default
     language code.
-- Follow-up needed: consider user-guide examples for multilingual path prefixes
-  after 0.15 if more detail is needed.
+- Follow-up (optional polish): richer multilingual examples only if triage
+  requests them; not required on docs/blog/changelog channels for 0.15.
 
 ### Version and Variant Menus
 

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -190,8 +190,8 @@ Raw commits in scope without PR numbers in their commit subjects:
     site-relative; use the default language code prefix to force a default
     language target.
 - Docs impact:
-  - Status: **done** (guidance links to the existing community-page configuration
-    docs).
+  - Status: **done** (guidance links to the existing community-page
+    configuration docs).
 - Changelog impact:
   - Status: done.
   - The 0.15 changelog entry includes this as a breaking change.

--- a/tasks/0.15/release-prep/issue-mapping.md
+++ b/tasks/0.15/release-prep/issue-mapping.md
@@ -1,15 +1,15 @@
 ---
 title: 0.15 issue mapping
 date: 2026-04-25
-lastmod: 2026-04-26
+lastmod: 2026-04-30
 range: v0.14.3..main
-last-main-commit: 343d6154
+last-main-commit: 7a0b370f
 cSpell:ignore: opentelemetry
 ---
 
 ## Scope
 
-Mapping covers first-parent commits in [v0.14.3...main][] through [343d6154][].
+Mapping covers first-parent commits in [v0.14.3...main][] through [7a0b370f][].
 
 ## Mapping
 
@@ -53,12 +53,16 @@ Mapping covers first-parent commits in [v0.14.3...main][] through [343d6154][].
 | [#2605][]: Add LLMS output and `llms.txt` support                      | [#2596][] (PR body)                                | Experimental agent support                           |
 | [#2606][]: Project docs: allow default outputs, including Markdown     | [#2596][] (PR body)                                | Raises measured AFDocs score                         |
 | [#2610][]: 0.15 release notes, audit, and wrapup content               | [#2501][] (Release prep scope)                     | Blog draft, changelog, refcache, link sweep, reports |
+| [#2611][]: Add Agent support UG page and refresh 0.15 release prep     | [#2596][], [#2501][] (PR body)                     | Completes agent-support docs for phase 1             |
+| [#2616][]: Update 0.15 release blog, CL, and docs                      | [#2501][], [#2614][] (PR body)                     | Final release-content pass before tag                |
 
 ## Linked Issues
 
 - [#2501][]: Release 0.15.0 preparation, open.
-- [#2504][]: Reintroduce support for doc-rooted sites, open.
-- [#2596][]: Add support for agent-friendly content generation, open.
+- [#2504][]: Reintroduce support for doc-rooted sites, closed.
+- [#2596][]: Add support for agent-friendly content generation, phase 1, closed.
+- [#2614][]: Improve support for AI-agent doc consumption, open as follow-up
+  tracker.
 - [#726][]: Add golden tests, open.
 - [#2492][]: Top-level section landing pages are always rooted in a docs-only
   site, closed.
@@ -115,6 +119,9 @@ Mapping covers first-parent commits in [v0.14.3...main][] through [343d6154][].
 [#2605]: https://github.com/google/docsy/pull/2605
 [#2606]: https://github.com/google/docsy/pull/2606
 [#2610]: https://github.com/google/docsy/pull/2610
+[#2611]: https://github.com/google/docsy/pull/2611
+[#2614]: https://github.com/google/docsy/issues/2614
+[#2616]: https://github.com/google/docsy/pull/2616
 [#726]: https://github.com/google/docsy/issues/726
-[343d6154]: https://github.com/google/docsy/commit/343d6154
+[7a0b370f]: https://github.com/google/docsy/commit/7a0b370f
 [v0.14.3...main]: https://github.com/google/docsy/compare/v0.14.3...main

--- a/tasks/0.15/release-prep/wrapup-report.md
+++ b/tasks/0.15/release-prep/wrapup-report.md
@@ -1,22 +1,22 @@
 ---
 title: 0.15 release-prep wrapup report
 date: 2026-04-25
-lastmod: 2026-04-26
+lastmod: 2026-04-30
 range: v0.14.3..main
-last-main-commit: 343d6154
+last-main-commit: 7a0b370f
 cSpell:ignore: afdocs
 ---
 
-> Report prepared for commits in [v0.14.3...main][] through [343d6154][].
+> Report prepared for commits in [v0.14.3...main][] through [7a0b370f][].
 
 ## Release Themes
 
 - **Experimental agent support**: Markdown alternate outputs, a visible "View
   Markdown" page-meta link, `llms.txt`, and golden tests are implemented for the
-  first 0.15 pass. Treat this as experimental in release content.
+  first 0.15 pass. The user guide and AFDocs scorecard are also on `main`. Treat
+  this as experimental in release content.
 - **Doc-rooted sites**: Docsy now has a documented doc-rooted site pattern and a
-  `doc-rooted` example variant. The [#2504][] tracker is expected to close, but
-  check before final publication.
+  `doc-rooted` example variant. The [#2504][] tracker is closed for 0.15.
 - **Community and footer links**: Link handling is more accurate under custom
   permalinks, footer links support `rel`, and external-link target behavior is
   fixed.
@@ -37,33 +37,35 @@ cSpell:ignore: afdocs
   `card` shortcode rendering should review header, title, subtitle, and footer
   output because those fields now use `$.Page.RenderString`.
 - **Runtime check**: Confirm final Hugo and Node support values before
-  publishing 0.15. The repo currently uses `hugo-extended` 0.157.0 in
-  `docsy.dev`.
+  publishing 0.15. The refreshed blog currently says Hugo 0.157.0 and Node
+  LTS 24.
 
 ## Release Content Status
 
 - Created draft release report:
   [0.15.0 release report](../../../docsy.dev/content/en/blog/2026/0.15.0.md)
   ([#2610][]).
-- Updated changelog "Next release" section with 0.15 highlights and links.
+- Added the Agent support user-guide page and refreshed the release prep reports
+  ([#2611][]).
+- Updated changelog "Next release" section with 0.15 highlights and links; the
+  latest release-content pass is [#2616][].
 - Omit 0.14.3-only fixes from 0.15 highlights. The 0.14 release resources
   already cover the v0.14.3 layout fix.
-- **Before publishing the blog**: merge the branch that adds
-  `docs/content/agent-support/` so the post’s [Agent support][] link is not a
-  404 on `main`.
+- The earlier Agent support blog-link blocker is resolved: [Agent support][] is
+  present on `main`.
 
 ## Follow-Up Checklist
 
-- [ ] Merge Agent support user-guide page (`docs/content/agent-support/`) before
-      publishing the 0.15.0 post, or temporarily retarget the blog link.
-- [ ] Check [#2504][] and close it, or move any remaining doc-rooted work to
+- [x] Merge Agent support user-guide page (`docs/content/agent-support/`) before
+      publishing the 0.15.0 post.
+- [x] Check [#2504][] and close it, or move any remaining doc-rooted work to
       follow-up issues, before finalizing 0.15.
-- [ ] Decide whether additional [#2596][] work lands before 0.15; otherwise keep
-      remaining agent support work as post-release follow-up.
-- [ ] Confirm final supported Hugo and Node versions and update the blog,
+- [x] Decide whether additional [#2596][] work lands before 0.15; remaining
+      agent support work now tracks under [#2614][].
+- [x] Confirm final supported Hugo and Node versions and update the blog,
       changelog, and release checklist if needed.
-- [ ] Review the 0.15 release report for user-guide links and action guidance.
-- [ ] Review the changelog entry after the blog draft is final so it stays terse
+- [x] Review the 0.15 release report for user-guide links and action guidance.
+- [x] Review the changelog entry after the blog draft is final so it stays terse
       and points to the release report for detail.
 - [ ] Decide whether a docsy-example follow-up PR is needed.
 
@@ -81,6 +83,9 @@ cSpell:ignore: afdocs
 [#2504]: https://github.com/google/docsy/issues/2504
 [#2596]: https://github.com/google/docsy/issues/2596
 [#2610]: https://github.com/google/docsy/pull/2610
-[343d6154]: https://github.com/google/docsy/commit/343d6154
+[#2611]: https://github.com/google/docsy/pull/2611
+[#2614]: https://github.com/google/docsy/issues/2614
+[#2616]: https://github.com/google/docsy/pull/2616
+[7a0b370f]: https://github.com/google/docsy/commit/7a0b370f
 [Agent support]: ../../../docsy.dev/content/en/docs/content/agent-support/
 [v0.14.3...main]: https://github.com/google/docsy/compare/v0.14.3...main


### PR DESCRIPTION
- Aligns the repo with **Hugo 0.157.0** using a small **`set-hugo-version`** helper and maintainer notes so pins stay consistent and easier to update.
- Sets **package / prerelease versioning** to **0.15.0-dev** so the tree clearly tracks the upcoming minor before the tag.
- Fixes **`get-build-id`** so **semver from `package.json` is not overridden** by an older tag-derived version when the package is already ahead (avoids wrong **build/version IDs** in shipped metadata).
- Writes **build/version-related params** on `docsy.dev` so local and CI builds reflect the intended identifiers.
- Refreshes **0.15 release-prep task docs** (plan, issue audit/mapping, inventory, wrapup) so milestone work and channel status stay accurate for reviewers.
- Tweaks **published-facing copy** (0.15 blog post, changelog snippet, agent-support page, spelling/copyedits) so the release narrative matches the branch.
- Updates **`refcache.json`** where link checks require it.