### PR TITLE
Add release-prep audit guidance; document missed 0.15.0 user-visible changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ resources/
 /.vscode/**
 !/.vscode/cspell.json
 /.cursor
+
+# Claude Code
+/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ resources/
 !/.vscode/cspell.json
 /.cursor
 
-# Claude Code
-/.claude
+# cSpell:ignore worktrees
+/.claude/worktrees
+/.claude/settings.local.json

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -20,6 +20,9 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
 - {{% _param FAS_LG diagram-project success %}}
   <span>**[Doc-rooted sites](#doc-rooted-sites)**: improved support for
   publishing docs at the site root</span>
+- {{% _param FAS_LG code-branch primary %}}
+  <span>**[Version menus](#version-menu)**: richer entries and updated navbar
+  rendering</span>
 
 {{% /card %}}
 
@@ -31,6 +34,8 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
   - "View Markdown" page-meta link
 - **[Doc-rooted sites](#doc-rooted-sites)**: documented pattern and example
   variant for sites whose `docs` section is published at the site root
+- **[Version menu entries](#version-menu)**: headings, separators, per-entry
+  page-link behavior, and kind-specific styling
 - **Content, shortcodes, and internationalization**:
   - [Community and footer links](#community-footer-links)
   - [`card` shortcode rendering](#card-shortcode)
@@ -42,6 +47,8 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
   - {{% _param BREAKING %}}
     [Community and footer links](#community-footer-links)
   - {{% _param BREAKING %}} [Card shortcode rendering](#card-shortcode)
+  - {{% _param BREAKING %}} [Version menu entries](#version-menu), if your site
+    customizes the version menu markup, styling, or mobile navbar layout
 - Optionally skim:
   - {{% _param NEW %}} New features (look for the green checkmark icon)
   - {{% _param CLEANUP %}} Cleanup / improvement opportunities (look for this
@@ -93,6 +100,31 @@ matter `cascade` or `type` changes.
 
 [old-docs-only-config]:
   https://web.archive.org/web/20260216125700/https://www.docsy.dev/docs/content/adding-content/#alternative-site-structure
+
+## {{% _param BREAKING %}} / {{% _param NEW %}} Version menu entries {#version-menu}
+
+Docsy's navbar [version menu][] now has richer entry handling so your site can
+use text headings, separators, per-entry page-link behavior, and kind-specific
+styling for menu entries. For configuration details, see [Adding a version
+drop-down menu][].
+
+Existing simple `version` and `url` entries continue to work. The change is
+potentially breaking if your project customizes the version menu partial, CSS,
+or mobile navbar layout: the menu uses updated markup and classes, and it is no
+longer hidden on smaller viewports.
+
+### Actions {#version-menu-actions}
+
+{{% _param BREAKING %}} **Applies if** your project configures `params.versions`
+and customizes the version menu or navbar.
+
+- Review custom CSS that targets the version menu dropdown.
+- Check any local `layouts/_partials/navbar-version-selector.html` or
+  `layouts/_partials/navbar.html` override against the current Docsy templates.
+- Recheck the navbar on both desktop and mobile viewports.
+
+For configuration and styling details, see the [Version menu][] and [Adding a
+version drop-down menu][].
 
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Community and footer links {#community-footer-links}
 
@@ -179,6 +211,7 @@ Docsy 0.12.0][]: follow them, using version **0.15.0** where the guide refers to
 
 - Build your site locally.
 - Check community and footer links for multilingual sites.
+- If you use `params.versions`, check the version menu on desktop and mobile.
 - Check pages that use the `card` shortcode.
 - If you enable Markdown outputs or `llms.txt`, inspect the generated `.md`
   pages and `/llms.txt`.
@@ -197,6 +230,8 @@ About this release:
 - Release page for [0.15.0][]
 - [Release 0.15.0 preparation issue (#2501)][#2501]
 
+<!-- prettier-ignore-start -->
+
 [#2082]: https://github.com/google/docsy/pull/2082
 [#2501]: https://github.com/google/docsy/issues/2501
 [#2565]: https://github.com/google/docsy/pull/2565
@@ -210,12 +245,16 @@ About this release:
 [#2615]: https://github.com/google/docsy/issues/2615
 [`card` shortcode]: /docs/content/shortcodes/#shortcode-card-textual-content
 [0.14.3]: https://github.com/google/docsy/releases/v0.14.3
+[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.155.3]: https://github.com/gohugoio/hugo/releases/tag/v0.155.3
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
-[0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [Adding a community page]: /docs/content/adding-content/#adding-a-community-page
+[Adding a version drop-down menu]: /docs/content/versioning/#adding-a-version-drop-down-menu
 [CL@0.15.0]: /project/about/changelog/#v0.15.0
 [Doc-rooted example]: https://doc-rooted--docsydocs.netlify.app
 [Doc-rooted sites]: /docs/content/adding-content/#doc-rooted-sites
 [experimental]: /project/about/changelog/#experimental
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/
+[Version menu]: /docs/content/navigation/#version-menu
+
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/content/navigation.md
+++ b/docsy.dev/content/en/docs/content/navigation.md
@@ -126,9 +126,27 @@ menu:
 Docsy adds a version selector menu to the top-level navbar if you have doc
 versions configured as explained in [Doc versioning][].
 
-To style the version menu, apply your custom CSS to `.td-navbar__version-menu`.
+The version menu is visible in the navbar for all screen sizes. Version entries
+can include text headings, separators, per-entry page-link behavior, and
+kind-specific styling. For configuration details, see [Doc versioning][].
+
+To style the version menu wrapper, apply your custom CSS to
+`.td-navbar__version-menu`. To style the dropdown itself, use
+`.td-version-menu`. Entries with a configured `kind` also get a
+`dropdown-item-<kind>` class. These kind-specific class names and styles are
+[experimental][].
+
+Docsy includes built-in styling for these kinds:
+
+- `latest`: adds a **(latest)** label and semibold text.
+- `next`: adds a **(next)** label.
+- `home`: adds a home icon.
+
+Other `kind` values still add a matching `dropdown-item-<kind>` class, but do
+not have built-in Docsy styling.
 
 [Doc versioning]: /docs/content/versioning/
+[experimental]: /project/about/changelog/#experimental
 
 ### Language menu
 

--- a/docsy.dev/content/en/docs/content/versioning.md
+++ b/docsy.dev/content/en/docs/content/versioning.md
@@ -108,8 +108,40 @@ of the main page. This can be useful if the document doesn't change much between
 the different versions. Note that if the current page doesn't exist in the other
 version, the link will be broken.
 
-To learn more about Docsy menus, see
-[Navigation and menus](/docs/content/navigation/).
+You can also configure individual menu entries:
+
+- Use `name` instead of `version` when the menu label is not a version number.
+- Set `name` to `---` to add a menu separator.
+- Omit `url` to render a disabled text item, such as a group heading.
+- Set `kind` to add a kind-specific class for styling. For details, see
+  [Navigation and menus][].
+- Set `pagelinks: false` on an entry to link to that version's main URL even
+  when the global `version_menu_pagelinks` parameter is `true`.
+
+For example:
+
+```yaml
+params:
+  version_menu: v1.2
+  version_menu_pagelinks: true
+  versions:
+    - name: '**Versions**'
+    - version: v1.3-dev
+      kind: next
+      url: https://next.example.com
+    - version: v1.2
+      kind: latest
+      url: https://docs.example.com
+    - name: ---
+    - name: Preview variant
+      kind: home
+      pagelinks: false
+      url: https://preview.example.com
+```
+
+To learn more about Docsy menus, see [Navigation and menus][].
+
+[Navigation and menus]: /docs/content/navigation/#version-menu
 
 ## Displaying a banner on archived doc sites
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -124,11 +124,17 @@ full list of changes, see the [0.15.0][] release page.
   [Community and footer links][0.15.0-blog-community-footer] ([#2580][]).
 - **`card` shortcode rendering** changed for selected fields; see [`card`
   shortcode rendering][0.15.0-blog-card] ([#2565][]).
+- **Version menu markup and mobile visibility** changed for sites using
+  `params.versions`; see [Version menu entries][0.15.0-blog-version-menu]
+  ([#2557][], [#2586][]).
 
 **New**:
 
 - **[Doc-rooted sites][0.15.0-blog-doc-rooted]**: added a documented pattern and
   example variant for documentation-first sites ([#2563][], [#2587][]).
+- **[Version menu entries][0.15.0-blog-version-menu]**: added support for
+  headings, separators, per-entry page-link behavior, and kind-specific styling
+  ([#2557][], [#2586][]).
 - Footer `params.links` support optional `rel` attribute values ([#2576][]); see
   [Community and footer links][0.15.0-blog-community-footer].
 
@@ -140,6 +146,9 @@ full list of changes, see the [0.15.0][] release page.
   docs ([#2556][], [#2572][]).
 - Updated NPM packages and `docsy.dev` tooling, including `hugo-extended`
   0.157.0 ([#2585][]).
+- Added `siteGetPage` shortcode ([#2586][]) — **internal** to `docsy.dev`; not
+  part of Docsy's [public customization surface](#public) and may change or be
+  removed without notice.
 
 [**Experimental**](#experimental):
 
@@ -148,12 +157,14 @@ full list of changes, see the [0.15.0][] release page.
   [#2605][], [#2606][]).
 
 [#2556]: https://github.com/google/docsy/pull/2556
+[#2557]: https://github.com/google/docsy/pull/2557
 [#2563]: https://github.com/google/docsy/pull/2563
 [#2565]: https://github.com/google/docsy/pull/2565
 [#2572]: https://github.com/google/docsy/pull/2572
 [#2576]: https://github.com/google/docsy/pull/2576
 [#2580]: https://github.com/google/docsy/pull/2580
 [#2585]: https://github.com/google/docsy/pull/2585
+[#2586]: https://github.com/google/docsy/pull/2586
 [#2587]: https://github.com/google/docsy/pull/2587
 [#2597]: https://github.com/google/docsy/pull/2597
 [#2601]: https://github.com/google/docsy/pull/2601
@@ -165,6 +176,7 @@ full list of changes, see the [0.15.0][] release page.
 [0.15.0-blog-community-footer]: /blog/2026/0.15.0/#community-footer-links
 [0.15.0-blog-doc-rooted]: /blog/2026/0.15.0/#doc-rooted-sites
 [0.15.0-blog-internationalization]: /blog/2026/0.15.0/#internationalization
+[0.15.0-blog-version-menu]: /blog/2026/0.15.0/#version-menu
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 
 ## v0.14.3 {#v0.14.3}

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -8,6 +8,32 @@ cSpell:ignore: hugo creatordate
 For our main contributing page covering license agreements, code of conduct and
 more, see [Contributing][]. This page is for **maintainers only**.
 
+## PR descriptions
+
+Generally speaking, a PR opening comment should be a Markdown list that explains
+the “why” behind the changes, and at a very high level what was changed. Start
+each item with a verb in the present tense, 3rd person singular.
+
+PR authors are _encouraged_ to flag the **scope of changes** when a PR touches
+Docsy's [public customization surface][public] -- especially for [breaking
+changes][breaking change] -- to help reviewers and release-time audits. For
+example:
+
+```markdown
+- Scope: breaking (removal), user-facing (new)
+```
+
+Suggested scope labels (use one or more):
+
+- **breaking**, **user-facing**, **internal-only**, **docs-only**.
+
+Optionally qualify with **kinds** in parentheses, mapping to release-blog and
+changelog sections: **new**, **change**, **fix**, **removal**, **deprecation**.
+
+The release-time audit (see [Release-prep audit](#release-prep-audit)) is the
+source of truth for what gets documented; PR-level scope labels are a hint, not
+a substitute.
+
 ## Hugo version pins
 
 From the repo root:
@@ -26,15 +52,46 @@ This updates:
   - Note: `module.hugoVersion.min` stays as `*hugoMinVersion`
 - [docsy.dev/package.json][]: `hugo-extended`
 
+## Release-prep audit
+
+Before drafting the changelog entry and release blog post, run a careful audit
+of every PR and raw commit in the release range so nothing user-visible slips
+through (motivated by the version-menu near-miss during 0.15.0 prep).
+
+For each PR/commit in `git log v<prev>..main`:
+
+1. Inspect the actual diff (not just the title or PR description). Use
+   `gh pr view <num>` and `git show <sha>` as needed.
+2. Classify the change: **breaking**, **user-facing**, **internal-only**, or
+   **docs-only** (see definitions in [Public customization surface][public] and
+   [Breaking change][breaking change]).
+3. For every **breaking** or **user-facing** item, verify it appears in **both**
+   the [changelog][] and the release blog post — with cross-links to the
+   relevant user-guide sections where applicable.
+4. Be especially alert to: new/renamed params, partials, shortcodes, layouts,
+   CSS classes, i18n keys, default-behavior shifts, and changes to the version
+   menu, navigation, or other rendered output.
+
+Capture the audit as a working document under `tasks/<release>/release-prep/`
+(see prior releases for examples) so reviewers can sanity-check the
+classifications. Treat the audit — not PR-level scope hints — as the source of
+truth for what the changelog and release blog must cover.
+
 ## Publishing a release
 
 These notes are WIP for creating a **release** from a local copy of the repo.
 These instructions assume the release is {{% param version %}}, if not adjust
 accordingly.
 
+> [!IMPORTANT]
+>
+> Before creating a release, do a [release-prep audit](#release-prep-audit) and
+> use it to drive the changelog and release-blog updates in the next two steps.
+
 1.  **Change directory** to your local Docsy repo.
 
 2.  **Create or update a [changelog][] entry** for {{% param version %}}.
+    - This step is driven by the [release-prep audit](#release-prep-audit).
     - The section should provide a brief summary of breaking changes using the
       section template at the end of the file.
     - Ensure to remove the UNRELEASED note, if still present.
@@ -356,6 +413,7 @@ before any further changes are merged into the `main` branch:
 
 <!-- prettier-ignore-start -->
 
+[breaking change]: /project/about/changelog/#breaking-change
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/
 [deploy/prod]: <{{% param github_repo %}}/tree/deploy/prod>
@@ -365,9 +423,11 @@ before any further changes are merged into the `main` branch:
 [docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>
 [docsy.dev/package.json]: <{{% param github_repo %}}/blob/main/docsy.dev/package.json>
 [Draft a new release]: <{{% param github_repo %}}/releases/new>
+[experimental]: /project/about/changelog/#experimental
 [go.mod]: <{{% param github_repo %}}/blob/main/go.mod>
 [install-hugo.sh]: <{{% param github_repo %}}/blob/main/docsy.dev/scripts/install-hugo.sh>
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
+[public]: /project/about/changelog/#public
 [tags]: <{{% param github_repo %}}/tags>
 
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -423,7 +423,6 @@ before any further changes are merged into the `main` branch:
 [docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>
 [docsy.dev/package.json]: <{{% param github_repo %}}/blob/main/docsy.dev/package.json>
 [Draft a new release]: <{{% param github_repo %}}/releases/new>
-[experimental]: /project/about/changelog/#experimental
 [go.mod]: <{{% param github_repo %}}/blob/main/go.mod>
 [install-hugo.sh]: <{{% param github_repo %}}/blob/main/docsy.dev/scripts/install-hugo.sh>
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1519,6 +1519,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-04-25T21:19:44.47029-04:00"
   },
+  "https://github.com/google/docsy/pull/2557": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T06:32:49.029274-04:00"
+  },
   "https://github.com/google/docsy/pull/2563": {
     "StatusCode": 206,
     "LastSeen": "2026-04-25T21:19:43.366139-04:00"
@@ -1554,6 +1558,10 @@
   "https://github.com/google/docsy/pull/2585": {
     "StatusCode": 206,
     "LastSeen": "2026-04-25T21:19:45.619732-04:00"
+  },
+  "https://github.com/google/docsy/pull/2586": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T06:32:49.719367-04:00"
   },
   "https://github.com/google/docsy/pull/2587": {
     "StatusCode": 206,

--- a/layouts/_shortcodes/siteGetPage.html
+++ b/layouts/_shortcodes/siteGetPage.html
@@ -1,3 +1,13 @@
+{{- /*
+
+  Returns a property (RelPermalink or Permalink) of the page at the given
+  site-relative path. Internal to docsy.dev test pages; not part of Docsy's
+  public customization surface and may change or be removed without notice.
+
+  Usage: {{% siteGetPage "/path/to/page" "RelPermalink" %}}
+
+*/ -}}
+
 {{ $path := .Get 0 -}}
 {{ $propertyName := .Get 1 -}}
 {{ if or (not $path) (not $propertyName) -}}

--- a/tasks/0.15/release-prep/commit-inventory.md
+++ b/tasks/0.15/release-prep/commit-inventory.md
@@ -110,8 +110,10 @@ uses first-parent commits as the release-audit spine.
 - [#2580][] includes a likely breaking behavior change for multilingual
   community/footer paths.
 - [#2586][] combines version/variant menu UX, `tdVersion` config structure,
-  `siteGetPage`, scripts, tests, and docs. Current review treats these changes
-  as not client-facing for 0.15 release notes.
+  `siteGetPage`, scripts, tests, and docs. Current review treats the menu UX and
+  configuration surface as user-facing and potentially breaking for sites that
+  customize version menu markup, CSS, or mobile navbar layout; the script
+  changes remain release tooling.
 - [#2597][] combines the Markdown output feature, `docsy.dev` enablement, tests,
   and task plans.
 - [#2605][] combines `llms.txt`, Markdown output refinements, tests,

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -57,7 +57,7 @@ each of these for Docs, Blog, and Changelog (CL). Table entry values include:
 | [#2082][]: Add Azerbaijan language                         | done | done | done | Internationalization                       |
 | [#2555][]: Set version to 0.14.3-dev                       | N/A  | N/A  | N/A  | Release-prep maintenance                   |
 | [#2556][]: Reorg deployment docs, normalize links          | done | done | done | Documentation/process cleanup              |
-| [#2557][]: Add version menu to site                        | done | done | done | No client-facing release-note impact       |
+| [#2557][]: Add version menu to site                        | done | done | done | New / potentially breaking [^ver-menu]     |
 | [#2558][]: Replace placeholder locale by French            | done | done | done | Site-only i18n setup                       |
 | [#2559][]: Document `deploy/prod` branch                   | done | done | done | Documentation/process cleanup              |
 | [#2560][]: Update bug report template                      | N/A  | N/A  | N/A  | Admin                                      |
@@ -79,7 +79,7 @@ each of these for Docs, Blog, and Changelog (CL). Table entry values include:
 | [#2583][]: Add Romanian locale                             | done | done | done | Internationalization                       |
 | [#2584][]: Add site-local URL markdownlint rule            | done | done | done | Documentation/process cleanup              |
 | [#2585][]: Update NPM packages and Hugo tooling            | done | done | done | Final versions reflected in blog           |
-| [#2586][]: Update version and variant menu                 | done | done | done | No client-facing release-note impact       |
+| [#2586][]: Update version and variant menu                 | done | done | done | New / potentially breaking [^ver-menu]     |
 | [#2587][]: Finalize doc-rooted configuration explanation   | done | done | done | Doc-rooted sites                           |
 | [#2591][]: Add German alert-label translations             | done | done | done | Internationalization                       |
 | [#2597][]: Add Markdown output phase 1                     | done | done | done | Experimental agent support                 |
@@ -94,6 +94,12 @@ each of these for Docs, Blog, and Changelog (CL). Table entry values include:
 | [#2610][]: 0.15 release-prep omnibus                       | done | done | done | Blog, changelog, refcache, reports, links  |
 | [#2611][]: Agent support UG and release-prep refresh       | done | done | done | Resolves agent-support blog-link blocker   |
 | [#2616][]: Update 0.15 release blog, CL, and docs          | done | done | done | Final release-content refresh              |
+
+[^ver-menu]:
+    The docsy.dev navbar **version / variant** menu was visible (including
+    **`main`** / **`0.14.4-dev`**) before any Blog/changelog note; **0.15**
+    documents it ([#2616][]):
+    [Version menu entries](/blog/2026/0.15.0/#version-menu).
 
 Raw commits in scope without PR numbers in their commit subjects:
 
@@ -209,30 +215,15 @@ Raw commits in scope without PR numbers in their commit subjects:
 
 ### Version and Variant Menus
 
-- Evidence: [#2557][], [#2586][].
-- Status: implemented; no linked issue found except [#2586][] contributes to
-  [#2504][].
-- Downstream/client impact:
-  - No client-facing release-note impact expected for 0.15.
-  - Updates version/variant menu behavior and markup.
-  - Introduces `tdVersion` YAML structure.
-  - Version v-prefix use changed: old config used bare values such as
-    `0.14.4-dev`; new config consistently uses values such as `v0.14.4-dev`.
-- Docs impact:
-  - Status: done.
-  - `docsy.dev/content/en/docs/content/navigation.md` includes version menu
-    guidance.
-  - `docsy.dev/content/en/project/about/maintainer-notes.md` and package version
-    scripts were updated.
-- Changelog impact:
-  - Status: done for 0.15.
-  - Omit from client-facing release notes unless later release review identifies
-    a downstream effect.
-- Blog inclusion:
-  - Status: done for 0.15.
-  - Omit from client-facing highlights unless later release review identifies a
-    downstream effect.
-- Follow-up needed: none for release notes.
+- Evidence: [#2557][], [#2586][]; [#2586][] contributes to [#2504][].
+- Downstream/client impact: Version/variant menu markup; `tdVersion` structure;
+  v-prefix normalization (`0.14.4-dev` → `v0.14.4-dev`); version menu is no
+  longer hidden on smaller viewports. Blog/CL timing for docsy.dev: [^ver-menu].
+- Docs impact: done — `docsy.dev/content/en/docs/content/versioning.md`,
+  `docsy.dev/content/en/docs/content/navigation.md`, maintainer-notes, version
+  scripts.
+- Changelog / Blog: done for **0.15** — [^ver-menu].
+- Follow-up: none.
 
 ### Layout Fixes
 

--- a/tasks/0.15/release-prep/issue-mapping.md
+++ b/tasks/0.15/release-prep/issue-mapping.md
@@ -40,7 +40,7 @@ Mapping covers first-parent commits in [v0.14.3...main][] through [7a0b370f][].
 | [#2583][]: Add Romanian locale                                         | External: opentelemetry.io#4593 (PR body)          | Locale contribution                                  |
 | [#2584][]: Add markdownlint rule for no site-local external URLs       | None found (N/A)                                   | Link hygiene                                         |
 | [#2585][]: Update NPM packages, Hugo to 0.157.0, drop `cpy-cli`        | None found (N/A)                                   | Dependency/tooling bundle                            |
-| [#2586][]: Update version+variant menu, add `siteGetPage`, `tdVersion` | [#2504][] (PR body)                                | Not client-facing for release notes                  |
+| [#2586][]: Update version+variant menu, add `siteGetPage`, `tdVersion` | [#2504][] (PR body)                                | User-facing; potentially breaking for custom menus   |
 | [#2587][]: Finalize doc-rooted configuration explanation               | [#2504][] (PR body)                                | Documentation follow-up                              |
 | [#2591][]: Add missing German alert label translations                 | None found (N/A)                                   | i18n fix                                             |
 | [#2597][]: Agent-friendly support plan and Markdown output phase 1     | #2596, #726 (PR body)                              | Experimental Markdown outputs and tests              |


### PR DESCRIPTION
- Documents the 0.15.0 version-menu and navigation user-visible changes in the release blog, changelog, and user docs (navigation, versioning) — the changes themselves shipped earlier on this release branch; this PR fills in the missing documentation/release-notes coverage and re-routes the blog's version-menu section to the user-guide pages instead of the PRs.
- Adds a "Release-prep audit" section to the maintainer notes — a checklist for inspecting every PR/commit in the release range, classifying changes against Docsy's public customization surface, and verifying changelog + release-blog coverage. Links the audit step from the publishing-a-release flow as the source of truth (motivated by the version-menu changes missed during 0.15.0 prep).
- Adds a complementary, non-mandatory "PR descriptions" note encouraging authors to flag the scope of changes (breaking / user-facing / internal-only / docs-only, with optional kinds) for PRs that touch the public surface.
- Flags the `siteGetPage` shortcode (#2586) as internal to docsy.dev in the 0.15.0 changelog and adds a header comment to the shortcode itself describing its purpose and internal-only status.
- Updates 0.15 release-prep task notes (issue-audit, commit-inventory, issue-mapping) to reflect the additional coverage.

- Scope: docs/internal-only