### PR TITLE
Adjust 0.15.0 release docs and add upgrade manifest

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -46,7 +46,6 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}}
     [Community and footer links](#community-footer-links)
-  - {{% _param BREAKING %}} [Card shortcode rendering](#card-shortcode)
   - {{% _param BREAKING %}} [Version menu entries](#version-menu), if your site
     customizes the version menu markup, styling, or mobile navbar layout
 - Optionally skim:
@@ -162,7 +161,7 @@ community or footer links with site-local paths.
 - Recheck generated community and footer links in each language to ensure they
   target the desired site.
 
-## {{% _param BREAKING %}} Card shortcode rendering {#card-shortcode}
+## {{% _param NEW %}} Card shortcode rendering {#card-shortcode}
 
 Docsy 0.15.0 changes how the [`card` shortcode][] renders the following fields:
 
@@ -174,13 +173,23 @@ Docsy 0.15.0 changes how the [`card` shortcode][] renders the following fields:
 These fields now use `$.Page.RenderString` instead of `markdownify`, so they
 render in the page context ([#2565][]). In practice, this means a relative link
 or image inside an affected field now resolves relative to the page that
-includes the `card` (rather than the site root), and Markdown render hooks fire
-in the page context.
+includes the `card`, and Markdown render hooks fire in the page context — a
+capability that wasn't available before.
 
-### Actions {#card-shortcode-actions}
+> [!NOTE]
+>
+> We're treating this as **new behavior** rather than a breaking change: to the
+> best of our knowledge, no client project relied on the previous resolution
+> behavior in a way that would break under 0.15.0. If you do hit a regression,
+> please [open an issue][docsy-issues] and we'll reconsider (and reclassify, if
+> need be).
 
-{{% _param BREAKING %}} **Applies if** your project uses `card` shortcode
-parameters with Markdown, images, links, or custom shortcode overrides.
+[docsy-issues]: https://github.com/google/docsy/issues/new/choose
+
+### Verify {#card-shortcode-actions}
+
+**Applies if** your project uses the `card` shortcode with Markdown, images,
+links, or maintains a custom override.
 
 - Review rendered cards that use any of the affected fields listed above.
 - If you maintain a local `layouts/_shortcodes/card.html` override, diff it

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -119,12 +119,15 @@ longer hidden on smaller viewports.
 and customizes the version menu or navbar.
 
 - Review custom CSS that targets the version menu dropdown.
-- Check any local `layouts/_partials/navbar-version-selector.html` or
-  `layouts/_partials/navbar.html` override against the current Docsy templates.
+- If you maintain a local `layouts/_partials/navbar-version-selector.html` or
+  `layouts/_partials/navbar.html` override, diff it against the
+  [v0.15.0 navbar partials][navbar-partials-v0.15.0].
 - Recheck the navbar on both desktop and mobile viewports.
 
 For configuration and styling details, see the [Version menu][] and [Adding a
 version drop-down menu][].
+
+[navbar-partials-v0.15.0]: https://github.com/google/docsy/tree/v0.15.0/layouts/_partials
 
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Community and footer links {#community-footer-links}
 
@@ -169,7 +172,10 @@ Docsy 0.15.0 changes how the [`card` shortcode][] renders the following fields:
 - `footer`
 
 These fields now use `$.Page.RenderString` instead of `markdownify`, so they
-render in the page context ([#2565][]).
+render in the page context ([#2565][]). In practice, this means a relative link
+or image inside an affected field now resolves relative to the page that
+includes the `card` (rather than the site root), and Markdown render hooks fire
+in the page context.
 
 ### Actions {#card-shortcode-actions}
 
@@ -177,8 +183,10 @@ render in the page context ([#2565][]).
 parameters with Markdown, images, links, or custom shortcode overrides.
 
 - Review rendered cards that use any of the affected fields listed above.
-- Check any local `layouts/_shortcodes/card.html` override against the current
-  Docsy shortcode.
+- If you maintain a local `layouts/_shortcodes/card.html` override, diff it
+  against the [v0.15.0 `card` shortcode][card-shortcode-v0.15.0].
+
+[card-shortcode-v0.15.0]: https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
 
 ## Other notable changes {#other-notable-changes}
 
@@ -194,6 +202,14 @@ Summary of changes:
 
 ## {{% _param FAS rocket primary %}} Upgrade to 0.15.0 {#upgrade}
 
+> {{% _param FAS robot info %}} **Upgrading with AI?** 0.15.0 ships an
+> experimental machine-readable [upgrade manifest](/upgrades/0.15.0.yaml) with
+> breaking-change detect rules, applies-if gates, and per-item references —
+> designed for agent consumption. For background on AI-assisted Docsy upgrades,
+> see [Upgrade procedure and AI help][] in the 0.13.0 release report.
+
+[Upgrade procedure and AI help]: /blog/2025/0.13.0/#upgrading-and-ai
+
 Some upgrade steps are the same for each Docsy release (for example, updating
 your Docsy NPM package or Hugo module). Those steps are described in [Upgrade to
 Docsy 0.12.0][]: follow them, using version **0.15.0** where the guide refers to
@@ -206,6 +222,12 @@ Docsy 0.12.0][]: follow them, using version **0.15.0** where the guide refers to
 [^vers-note]:
     Matches `docsy.dev` declared `params.hugoMinVersion` and `hugo-extended`.
     Later Hugo or Node versions may work but are not officially supported.
+
+> [!NOTE]
+>
+> **Need to roll back?** Re-pin Docsy to [0.14.3][] (with Hugo 0.155.3) using
+> the standard package-update procedure from [Upgrade to Docsy 0.12.0][],
+> applied in reverse.
 
 ### {{% _param FAS square-check primary %}} Sanity checks
 

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -130,19 +130,19 @@ version drop-down menu][].
 
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Community and footer links {#community-footer-links}
 
-New behavior:
+New behavior and fixes:
 
 - Footer links support `rel` attributes, see [Adding a community page][]
   ([#2576][]).
+- Community and footer links now open in a new browser target only for external
+  links, fixing [#2133][] ([#2576][]).
 - Site-local community and footer links resolve under any [permalinks][] scheme
   ([#2580][]).
 
 [permalinks]: https://gohugo.io/configuration/permalinks/
 
-Breaking changes:
+Breaking change:
 
-- Community and footer links only open in a new target for external links
-  ([#2576][]). Previously, site-local links opened in a new target as well.
 - For multilingual sites, link paths are now interpreted as site-relative paths.
   ([#2580][]).
 
@@ -177,7 +177,7 @@ page context, which allows:
 - Relative link paths can be used in `card` argument Markdown
 - Markdown render hooks will fire in the page context
 
-Relative links paths are an important capability to have in [multilingual
+Relative link paths are an important capability to have in [multilingual
 sites][]. Executing render hooks in a page context allows for more flexible hook
 behavior.
 
@@ -291,6 +291,7 @@ About this release:
 <!-- prettier-ignore-start -->
 [.Page.RenderString]: https://gohugo.io/methods/page/renderstring/
 [#2082]: https://github.com/google/docsy/pull/2082
+[#2133]: https://github.com/google/docsy/issues/2133
 [#2501]: https://github.com/google/docsy/issues/2501
 [#2565]: https://github.com/google/docsy/pull/2565
 [#2576]: https://github.com/google/docsy/pull/2576

--- a/docsy.dev/content/en/blog/2026/0.15.0.md
+++ b/docsy.dev/content/en/blog/2026/0.15.0.md
@@ -48,6 +48,8 @@ cSpell:ignore: afdocs doc-rooted llms markdownify RenderString
     [Community and footer links](#community-footer-links)
   - {{% _param BREAKING %}} [Version menu entries](#version-menu), if your site
     customizes the version menu markup, styling, or mobile navbar layout
+  - {{% _param BREAKING %}} [Card shortcode rendering](#card-shortcode)
+    (low-risk of breaking)
 - Optionally skim:
   - {{% _param NEW %}} New features (look for the green checkmark icon)
   - {{% _param CLEANUP %}} Cleanup / improvement opportunities (look for this
@@ -119,14 +121,12 @@ and customizes the version menu or navbar.
 
 - Review custom CSS that targets the version menu dropdown.
 - If you maintain a local `layouts/_partials/navbar-version-selector.html` or
-  `layouts/_partials/navbar.html` override, diff it against the
-  [v0.15.0 navbar partials][navbar-partials-v0.15.0].
+  `layouts/_partials/navbar.html` override, diff it against the [v0.15.0 navbar
+  partials][].
 - Recheck the navbar on both desktop and mobile viewports.
 
 For configuration and styling details, see the [Version menu][] and [Adding a
 version drop-down menu][].
-
-[navbar-partials-v0.15.0]: https://github.com/google/docsy/tree/v0.15.0/layouts/_partials
 
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Community and footer links {#community-footer-links}
 
@@ -161,41 +161,48 @@ community or footer links with site-local paths.
 - Recheck generated community and footer links in each language to ensure they
   target the desired site.
 
-## {{% _param NEW %}} Card shortcode rendering {#card-shortcode}
+## {{% _param BREAKING %}} / {{% _param NEW %}} Card shortcode rendering {#card-shortcode}
 
-Docsy 0.15.0 changes how the [`card` shortcode][] renders the following fields:
-
-- `header`
-- `title`
-- `subtitle`
-- `footer`
-
-These fields now use `$.Page.RenderString` instead of `markdownify`, so they
-render in the page context ([#2565][]). In practice, this means a relative link
-or image inside an affected field now resolves relative to the page that
-includes the `card`, and Markdown render hooks fire in the page context — a
-capability that wasn't available before.
-
-> [!NOTE]
+> [!NOTE] **TL;DR** - low-risk of breaking
 >
-> We're treating this as **new behavior** rather than a breaking change: to the
-> best of our knowledge, no client project relied on the previous resolution
-> behavior in a way that would break under 0.15.0. If you do hit a regression,
-> please [open an issue][docsy-issues] and we'll reconsider (and reclassify, if
-> need be).
+> Technically, `card` arguments are now rendered using [.Page.RenderString][]
+> instead of [markdownify][]. We do not expect this change to be breaking, but
+> if something breaks, please let us know by [opening an issue][new-issue].
 
-[docsy-issues]: https://github.com/google/docsy/issues/new/choose
+While the [card shortcode][] has always supported Markdown content in its
+arguments, the arguments are now rendered in the context of the page that
+includes the `card`. This means that argument values (Markdown) resolve in the
+page context, which allows:
 
-### Verify {#card-shortcode-actions}
+- Relative link paths can be used in `card` argument Markdown
+- Markdown render hooks will fire in the page context
 
-**Applies if** your project uses the `card` shortcode with Markdown, images,
-links, or maintains a custom override.
+Relative links paths are an important capability to have in [multilingual
+sites][]. Executing render hooks in a page context allows for more flexible hook
+behavior.
 
-- Review rendered cards that use any of the affected fields listed above.
-- If you maintain a local `layouts/_shortcodes/card.html` override, diff it
-  against the [v0.15.0 `card` shortcode][card-shortcode-v0.15.0].
+For example, the following `card` footer argument illustrates the use of a
+relative path to an image page-bundle resource:
 
-[card-shortcode-v0.15.0]: https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
+```go-html-template
+{{</* card
+  header="**Imagine**" ...
+  footer="![John's signature](card-pane/john-lennon-signature.png)"
+*/>}}
+...
+{{</* /card */>}}
+```
+
+For the complete example, see [card shortcode][].
+
+### Actions {#card-shortcode-actions}
+
+{{% _param BREAKING %}} **Applies if** your project uses the [card.html][]
+shortcode or maintains a custom override.
+
+- Ensure that cards still render as expected.
+- Update your site's `card` override if you want to take advantage of new
+  capabilities.
 
 ## Other notable changes {#other-notable-changes}
 
@@ -238,20 +245,40 @@ Docsy 0.12.0][]: follow them, using version **0.15.0** where the guide refers to
 > the standard package-update procedure from [Upgrade to Docsy 0.12.0][],
 > applied in reverse.
 
+<section class="td-checkbox-list-wrapper">
+
 ### {{% _param FAS square-check primary %}} Sanity checks
 
-- Build your site locally.
-- Check community and footer links for multilingual sites.
-- If you use `params.versions`, check the version menu on desktop and mobile.
-- Check pages that use the `card` shortcode.
-- If you enable Markdown outputs or `llms.txt`, inspect the generated `.md`
-  pages and `/llms.txt`.
-- If you use a doc-rooted configuration, run Hugo with `--printPathWarnings`.
+- [ ] **Build your site** locally:
+  - Run `hugo` with `--printPathWarnings` if your site is a
+    [doc-rooted site](#doc-rooted-sites).
+- [ ] [Check community and footer links](#community-footer-links) for
+      multilingual sites.
+- [ ] [Check the version menu](#version-menu-actions) on desktop and mobile, if
+      your site has one.
+- [ ] [Check pages that use the `card` shortcode](#card-shortcode-actions).
+- [ ] Inspect generated `*.md` and `/llms.txt` pages, if you
+      [enabled agent support](#agent-support).
+
+</section>
 
 ## What's next?
 
 For general work items _tentatively_ planned for the next release, see [Release
 0.16.0 preparation (#2615)][#2615].
+
+<!-- prettier-ignore -->
+> [!INFO]- Your opinion counts!
+>
+> - {{% _param FAS thumbs-up success %}} If you'd like a feature or fix to be
+>   considered for inclusion in an upcoming release, **upvote** (with a thumbs up)
+>   the associated issue or PR.
+>
+> - {{% _param FAS star warning %}} If you find Docsy useful, consider [starring
+>   the repository][star-the-repo] to show your support.
+{._list-unstyled}
+
+[star-the-repo]: https://github.com/google/docsy
 
 ## References
 
@@ -262,7 +289,7 @@ About this release:
 - [Release 0.15.0 preparation issue (#2501)][#2501]
 
 <!-- prettier-ignore-start -->
-
+[.Page.RenderString]: https://gohugo.io/methods/page/renderstring/
 [#2082]: https://github.com/google/docsy/pull/2082
 [#2501]: https://github.com/google/docsy/issues/2501
 [#2565]: https://github.com/google/docsy/pull/2565
@@ -274,18 +301,22 @@ About this release:
 [#2603]: https://github.com/google/docsy/pull/2603
 [#2604]: https://github.com/google/docsy/pull/2604
 [#2615]: https://github.com/google/docsy/issues/2615
-[`card` shortcode]: /docs/content/shortcodes/#shortcode-card-textual-content
 [0.14.3]: https://github.com/google/docsy/releases/v0.14.3
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.155.3]: https://github.com/gohugoio/hugo/releases/tag/v0.155.3
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [Adding a community page]: /docs/content/adding-content/#adding-a-community-page
 [Adding a version drop-down menu]: /docs/content/versioning/#adding-a-version-drop-down-menu
+[card shortcode]: /docs/content/shortcodes/#shortcode-card-textual-content
+[card.html]: https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
 [CL@0.15.0]: /project/about/changelog/#v0.15.0
 [Doc-rooted example]: https://doc-rooted--docsydocs.netlify.app
 [Doc-rooted sites]: /docs/content/adding-content/#doc-rooted-sites
 [experimental]: /project/about/changelog/#experimental
+[markdownify]: https://gohugo.io/functions/transform/markdownify/
+[multilingual sites]: /docs/language/
+[new-issue]: https://github.com/google/docsy/issues/new/choose
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/
+[v0.15.0 navbar partials]: https://github.com/google/docsy/tree/v0.15.0/layouts/_partials
 [Version menu]: /docs/content/navigation/#version-menu
-
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/content/agent-support/index.md
+++ b/docsy.dev/content/en/docs/content/agent-support/index.md
@@ -1,5 +1,6 @@
 ---
-title: Agent support
+title: AI-agent support
+linkTitle: Agent support
 description: >-
   Opt-in features that help AI agents and automated tools discover and use your
   site content, including Markdown output, alternate links in HTML, and

--- a/docsy.dev/content/en/docs/content/shortcodes/index.md
+++ b/docsy.dev/content/en/docs/content/shortcodes/index.md
@@ -794,7 +794,7 @@ demonstrates how to code a card element:
   header="**Imagine**"
   title="Artist and songwriter: John Lennon"
   subtitle="Co-writer: Yoko Ono"
-  footer="![SignatureJohnLennon](https://server.tld/…/signature.png)"
+  footer="![SignatureJohnLennon](card-pane/john-lennon-signature.png)"
 */>}}
 
 Imagine there's no heaven, It's easy if you try<br/>
@@ -849,7 +849,7 @@ text, images, videos, … . If your content is markdown, use the percent sign `%
 as outermost delimiter of your `card` shortcode, your markup should look like
 `{{%/* card */%}}Your **markdown** content{{%/* /card */%}}`. In case of HTML
 content, use square brackets `<>` as outermost delimiters:
-`{{</* card */>}}Your <b>HTML</b> content{{</* /card */>}}`
+`{{</* card */>}} Your <b>HTML</b> content {{</* /card */>}}`
 
 {{% /card %}}
 

--- a/docsy.dev/content/en/docs/language.md
+++ b/docsy.dev/content/en/docs/language.md
@@ -7,7 +7,8 @@ cSpell:ignore: rtlcss subdir operativsystem skyen Norsk
 
 If you'd like to provide site content in multiple languages, the Docsy theme and
 Hugo make it easy to both add your translated content and for your users to
-navigate between language versions.
+navigate between language versions. For details about Hugo's multi-language
+support, see the [Multilingual mode][].
 
 ## Content and configuration
 
@@ -170,9 +171,8 @@ If your chosen language isn't currently in the theme and you create your own
 `.yaml` file for all the common UI strings (for example, if you translate the UI
 text into Esperanto and create a copy of `en.yaml` called `eo.yaml`), we
 recommend you do this **in the theme** rather than in your own project. You can
-then open a
-[pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
-to contribute your translation to the Docsy community.
+then open a [pull request][PR] to contribute your translation to the Docsy
+community.
 
 > [!TIP] Hugo Tip
 >
@@ -184,10 +184,15 @@ to contribute your translation to the Docsy community.
 If any of the Docsy theme UI strings in your chosen language aren't suitable for
 your project, or if you need additional strings for your site, you can create
 your own project-specific internationalization file in your project's `/i18n`
-directory. For example, if you want to override any of Docsy's
-[English-language strings](https://github.com/google/docsy/blob/main/i18n/en.yaml),
-create your own `/i18n/en.yaml` with just your custom strings. Any values you
-specify in this file will override the theme versions, while the remaining
-strings will come from the theme's corresponding internationalization bundle.
+directory. For example, if you want to override any of Docsy's [English-language
+strings][en.yaml], create your own `/i18n/en.yaml` with just your custom
+strings. Any values you specify in this file will override the theme versions,
+while the remaining strings will come from the theme's corresponding
+internationalization bundle.
 
+<!-- prettier-ignore-start -->
 [Docsy example]: https://example.docsy.dev/
+[en.yaml]: https://github.com/google/docsy/blob/main/i18n/en.yaml
+[Multilingual mode]: https://gohugo.io/content-management/multilingual/
+[PR]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -121,12 +121,12 @@ full list of changes, see the [0.15.0][] release page.
 [**Breaking changes**](#breaking-change):
 
 - **Community and footer link paths** changed for multilingual sites; see
-  [Community and footer links][0.15.0-blog-community-footer] ([#2580][]).
+  [blog][0.15.0-blog-community-footer] ([#2580][]).
 - **Version menu markup and mobile visibility** changed for sites using
   `params.versions`; see [Version menu entries][0.15.0-blog-version-menu]
   ([#2557][], [#2586][]).
-- **`card` shortcode rendering** has a low-risk of breaking.
-  [Details][0.15.0-blog-card].
+- **`card` shortcode rendering** changed for Markdown arguments; breakage risk
+  is low. See [blog][0.15.0-blog-card].
 
 **New**:
 
@@ -135,16 +135,28 @@ full list of changes, see the [0.15.0][] release page.
 - **[Version menu entries][0.15.0-blog-version-menu]**: added support for
   headings, separators, per-entry page-link behavior, and kind-specific styling
   ([#2557][], [#2586][]).
-- **`card` shortcode rendering**: Markdown in card arguments now renders in the
-  _including page's context_, enabling use of relative Markdown link paths and
-  more flexible render-hook behavior. [Details][0.15.0-blog-card] ([#2565][]).
-- Footer `params.links` support optional `rel` attribute values ([#2576][]); see
-  [Community and footer links][0.15.0-blog-community-footer].
+- **`card` shortcode rendering**: changed Markdown rendering in card arguments
+  to use the _including page's context_, enabling relative Markdown link paths
+  and more flexible render-hook behavior. [Details][0.15.0-blog-card]
+  ([#2565][]).
+- Added optional `rel` attribute values for footer `params.links` ([#2576][]);
+  see [Community and footer links][0.15.0-blog-community-footer].
 
 **Other changes**:
 
 - **Internationalization**: [added and updated
   translations][0.15.0-blog-internationalization].
+- Fixed community/footer links so site-local links no longer open in a new
+  browser target ([#2576][], [#2133][]).
+
+[**Experimental**](#experimental):
+
+- **[Agent support][0.15.0-blog-agent-support]**: added Markdown alternate
+  outputs, "View Markdown" links, and `llms.txt` ([#2597][], [#2601][],
+  [#2605][], [#2606][]).
+
+For maintainers:
+
 - Split deployment docs into focused pages and clarified release branch-model
   docs ([#2556][], [#2572][]).
 - Updated NPM packages and `docsy.dev` tooling, including `hugo-extended`
@@ -152,12 +164,6 @@ full list of changes, see the [0.15.0][] release page.
 - Added `siteGetPage` shortcode ([#2586][]) — **internal** to `docsy.dev`; not
   part of Docsy's [public customization surface](#public) and may change or be
   removed without notice.
-
-[**Experimental**](#experimental):
-
-- **[Agent support][0.15.0-blog-agent-support]**: added Markdown alternate
-  outputs, "View Markdown" links, and `llms.txt` ([#2597][], [#2601][],
-  [#2605][], [#2606][]).
 
 [#2556]: https://github.com/google/docsy/pull/2556
 [#2557]: https://github.com/google/docsy/pull/2557

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -122,8 +122,6 @@ full list of changes, see the [0.15.0][] release page.
 
 - **Community and footer link paths** changed for multilingual sites; see
   [Community and footer links][0.15.0-blog-community-footer] ([#2580][]).
-- **`card` shortcode rendering** changed for selected fields; see [`card`
-  shortcode rendering][0.15.0-blog-card] ([#2565][]).
 - **Version menu markup and mobile visibility** changed for sites using
   `params.versions`; see [Version menu entries][0.15.0-blog-version-menu]
   ([#2557][], [#2586][]).
@@ -135,6 +133,12 @@ full list of changes, see the [0.15.0][] release page.
 - **[Version menu entries][0.15.0-blog-version-menu]**: added support for
   headings, separators, per-entry page-link behavior, and kind-specific styling
   ([#2557][], [#2586][]).
+- **[`card` shortcode rendering][0.15.0-blog-card]**: selected fields
+  (`header`, `title`, `subtitle`, `footer`) now render in the page context via
+  `$.Page.RenderString`, enabling page-relative link/image resolution and
+  page-context Markdown render hooks ([#2565][]). Classified as new behavior
+  rather than breaking; see the linked blog section for the rationale and
+  reclassification advisory.
 - Footer `params.links` support optional `rel` attribute values ([#2576][]); see
   [Community and footer links][0.15.0-blog-community-footer].
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -125,6 +125,8 @@ full list of changes, see the [0.15.0][] release page.
 - **Version menu markup and mobile visibility** changed for sites using
   `params.versions`; see [Version menu entries][0.15.0-blog-version-menu]
   ([#2557][], [#2586][]).
+- **`card` shortcode rendering** has a low-risk of breaking.
+  [Details][0.15.0-blog-card].
 
 **New**:
 
@@ -133,12 +135,9 @@ full list of changes, see the [0.15.0][] release page.
 - **[Version menu entries][0.15.0-blog-version-menu]**: added support for
   headings, separators, per-entry page-link behavior, and kind-specific styling
   ([#2557][], [#2586][]).
-- **[`card` shortcode rendering][0.15.0-blog-card]**: selected fields
-  (`header`, `title`, `subtitle`, `footer`) now render in the page context via
-  `$.Page.RenderString`, enabling page-relative link/image resolution and
-  page-context Markdown render hooks ([#2565][]). Classified as new behavior
-  rather than breaking; see the linked blog section for the rationale and
-  reclassification advisory.
+- **`card` shortcode rendering**: Markdown in card arguments now renders in the
+  _including page's context_, enabling use of relative Markdown link paths and
+  more flexible render-hook behavior. [Details][0.15.0-blog-card] ([#2565][]).
 - Footer `params.links` support optional `rel` attribute values ([#2576][]); see
   [Community and footer links][0.15.0-blog-community-footer].
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -147,7 +147,7 @@ full list of changes, see the [0.15.0][] release page.
 - **Internationalization**: [added and updated
   translations][0.15.0-blog-internationalization].
 - Fixed community/footer links so site-local links no longer open in a new
-  browser target ([#2576][], [#2133][]).
+  browser target ([#2133][], [#2576][]).
 
 [**Experimental**](#experimental):
 
@@ -165,6 +165,7 @@ For maintainers:
   part of Docsy's [public customization surface](#public) and may change or be
   removed without notice.
 
+[#2133]: https://github.com/google/docsy/issues/2133
 [#2556]: https://github.com/google/docsy/pull/2556
 [#2557]: https://github.com/google/docsy/pull/2557
 [#2563]: https://github.com/google/docsy/pull/2563

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -935,6 +935,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:09.005756-05:00"
   },
+  "https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T15:13:13.398577-04:00"
+  },
   "https://github.com/google/docsy/blob/v0.7.0/assets/scss/main.scss": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:19:09.115871-05:00"
@@ -1122,6 +1126,10 @@
   "https://github.com/google/docsy/issues/2116": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:14:31.429537-05:00"
+  },
+  "https://github.com/google/docsy/issues/2133": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T15:33:54.425775-04:00"
   },
   "https://github.com/google/docsy/issues/2173": {
     "StatusCode": 206,
@@ -1779,6 +1787,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:54.307861-05:00"
   },
+  "https://github.com/google/docsy/tree/v0.15.0/layouts/_partials": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T15:13:12.750809-04:00"
+  },
   "https://github.com/googleforgames/agones/tree/main/site": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:53.339518-05:00"
@@ -2215,6 +2227,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:51.88846-05:00"
   },
+  "https://gohugo.io/functions/transform/markdownify/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T15:13:12.959528-04:00"
+  },
   "https://gohugo.io/getting-started/configuration/#configuration-file": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:14:23.651029-05:00"
@@ -2278,6 +2294,10 @@
   "https://gohugo.io/methods/page/outputformats/#canonical": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:58.028592-05:00"
+  },
+  "https://gohugo.io/methods/page/renderstring/": {
+    "StatusCode": 206,
+    "LastSeen": "2026-04-30T15:13:12.875771-04:00"
   },
   "https://gohugo.io/methods/page/tableofcontents/": {
     "StatusCode": 206,

--- a/docsy.dev/static/upgrades/0.15.0.yaml
+++ b/docsy.dev/static/upgrades/0.15.0.yaml
@@ -1,15 +1,15 @@
 # Docsy upgrade manifest — 0.15.0
 #
-# Machine-readable companion to the 0.15.0 release blog. Lists breaking
-# changes with detect rules so an agent (or human) can quickly determine
-# which items apply to a given site, and surface anchored references back
-# into the human-readable release blog and changelog.
+# Machine-readable companion to the 0.15.0 release blog. Lists breaking-style
+# review items (with detect rules), optional experimental features, and sanity
+# checks so an agent (or human) can determine applicability and jump back to the
+# blog, changelog, and user guide.
 #
 # Status: experimental. Schema is expected to evolve through 0.16.0+;
 # see the tracking issue for the planned DRY/data-driven approach.
 #
-# Authoritative for: detect predicates, version pins, breaking-item ids.
-# Authoritative narrative remains in the release blog.
+# Authoritative for: detect predicates, version pins, item ids.
+# Authoritative narrative remains in the release blog and user guide.
 
 schema: docsy-upgrade-manifest/v0
 from: 0.14.3
@@ -28,39 +28,10 @@ peer:
     to: lts/24
     notes: Later Node versions may work but are not officially supported.
 
-# Breaking changes — items that may require a client-project change.
-# Each item is independently gated by a `detect` rule so callers can
-# evaluate applicability against the consuming project.
+# Breaking changes — items flagged as breaking in the release blog (some also
+# introduce new behavior; see blog). Low-risk items note that in title or summary.
+# Each item is gated by a `detect` rule where applicable.
 breaking:
-  - id: card-shortcode-rendering
-    title: card shortcode rendering
-    summary: >-
-      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
-      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
-      they render in the page context. Shortcode invocations inside those fields
-      now execute (previously passed through `markdownify`'s escape behavior).
-    applies-if: >-
-      Your project uses the `card` shortcode with Markdown, images, links,
-      shortcode invocations inside the affected fields, or a custom
-      `layouts/_shortcodes/card.html` override.
-    detect:
-      any:
-        - kind: grep
-          pattern: '\{\{[<%][[:space:]]*card\b'
-          paths: [content/, layouts/]
-        - kind: file-exists
-          path: layouts/_shortcodes/card.html
-        - kind: file-exists
-          path: layouts/shortcodes/card.html
-    actions:
-      - Review rendered cards that use any of the affected fields.
-      - Diff any local card-shortcode override against the v0.15.0 partial.
-    references:
-      blog: /blog/2026/0.15.0/#card-shortcode
-      partials:
-        - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
-      prs: [2565]
-
   - id: community-footer-multilingual-paths
     title: community and footer link paths (multilingual)
     summary: >-
@@ -90,29 +61,9 @@ breaking:
       - Recheck generated community/footer links in each language.
     references:
       blog: /blog/2026/0.15.0/#community-footer-links
-      prs: [2576, 2580]
-
-  - id: community-footer-link-target
-    title: community and footer link target attribute
-    summary: >-
-      Community and footer links now only open in a new browser target for
-      external links. Previously, site-local links also opened in a new target.
-    applies-if: >-
-      Your site relied on community or footer links opening in a new tab/window
-      for site-local URLs.
-    detect:
-      kind: grep
-      pattern: '^\s*(user|developer)\s*[:=]'
-      paths: [config/, hugo.toml, hugo.yaml, hugo.json]
-      context: under params.links
-    actions:
-      - >-
-        If your design depended on site-local community/footer links opening in
-        a new target, plan to surface those links elsewhere or accept the new
-        same-target behavior.
-    references:
-      blog: /blog/2026/0.15.0/#community-footer-links
-      prs: [2576]
+      user-guide:
+        - /docs/content/adding-content/#adding-a-community-page
+      prs: [2580]
 
   - id: version-menu-customization
     title: version menu markup, classes, and mobile visibility
@@ -152,28 +103,25 @@ breaking:
         - /docs/content/versioning/#adding-a-version-drop-down-menu
         - /docs/content/navigation/#version-menu
       partials:
+        - https://github.com/google/docsy/tree/v0.15.0/layouts/_partials
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar-version-selector.html
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar.html
       prs: [2557, 2586]
 
-# New behavior
-new:
   - id: card-shortcode-rendering
-    title: card shortcode rendering — page-context resolution
+    title: Card shortcode rendering (low-risk)
     summary: >-
-      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
-      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
-      relative links and images inside those fields resolve relative to the page
-      that includes the `card`, and Markdown render hooks fire in the page
-      context — capabilities that weren't available before.
-    classification-note: >-
-      Treated as new behavior rather than breaking based on a judgement call: to
-      the project's best knowledge, no client relied on the previous resolution
-      behavior in a way that would break under 0.15.0. Reclassify to `breaking`
-      if a regression is reported. See blog rationale for details.
+      Markdown in the `header`, `title`, `subtitle`, and `footer` arguments is
+      rendered with `.Page.RenderString` instead of `markdownify`, so it runs in
+      the including page's context. Relative Markdown links (including images)
+      and Markdown render hooks behave like body content—especially useful for
+      multilingual sites. Shortcodes inside those arguments may execute where
+      they previously did not under `markdownify`. Breakage should be rare; see
+      the blog NOTE.
     applies-if: >-
-      Your project uses the `card` shortcode with Markdown, images, links, or
-      maintains a custom `layouts/_shortcodes/card.html` override.
+      Your project uses the `card` shortcode or maintains a custom
+      `layouts/_shortcodes/card.html` or `layouts/shortcodes/card.html`
+      override.
     detect:
       any:
         - kind: grep
@@ -184,32 +132,69 @@ new:
         - kind: file-exists
           path: layouts/shortcodes/card.html
     actions:
-      - Review rendered cards that use any of the affected fields.
-      - Diff any local card-shortcode override against the v0.15.0 partial.
+      - Ensure that cards still render as expected.
+      - >-
+        Diff any local `card` override against the v0.15.0 theme partial; update
+        it intentionally if you want page-context resolution, relative paths, or
+        render hooks in those arguments.
     references:
       blog: /blog/2026/0.15.0/#card-shortcode
+      user-guide:
+        - /docs/content/shortcodes/#shortcode-card-textual-content
       partials:
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
       prs: [2565]
 
+# Fixes and other user-visible changes that do not require upgrade action.
+fixes:
+  - id: community-footer-link-target
+    title: community and footer link target attribute
+    summary: >-
+      Community and footer links now open in a new browser target only for
+      external links, fixing site-local links that previously behaved like
+      external links.
+    references:
+      blog: /blog/2026/0.15.0/#community-footer-links
+      user-guide:
+        - /docs/content/adding-content/#adding-a-community-page
+      issues: [2133]
+      prs: [2576]
+
+# Experimental features — opt-in; enablement is site-specific.
+experimental:
+  - id: agent-support-phase-1
+    title: Agent support (phase 1)
+    summary: >-
+      Opt-in Markdown alternate outputs, a _View Markdown_ page-meta link when a
+      Markdown alternate exists, and generated `llms.txt`. Phased evolution is
+      tracked in https://github.com/google/docsy/issues/2614.
+    references:
+      blog: /blog/2026/0.15.0/#agent-support
+      user-guide:
+        - /docs/content/agent-support/
+      prs: [2597, 2601, 2605, 2606]
+
 # Sanity checks to run after upgrading. These are project-agnostic.
 sanity:
-  - run: hugo --gc
-    description: Build the site and surface any errors.
+  - run: hugo
+    description: >-
+      Build the site locally and surface errors (baseline: release blog sanity
+      checklist).
   - run: hugo --printPathWarnings
-    description:
-      Surface path collisions; especially relevant for doc-rooted sites.
-    applies-if: doc-rooted-or-custom-permalinks
+    description: >-
+      Same as the blog nested bullet under "Build your site locally": use when
+      your site is doc-rooted (see blog Doc-rooted sites section).
+    applies-if: doc-rooted-site
   - check:
-      Verify community and footer links resolve correctly in each configured
-      language.
+      For multilingual sites, verify community and footer links (see blog
+      community/footer actions).
   - check:
       If `params.versions` is configured, check the version menu on desktop and
       mobile viewports.
   - check: Inspect pages that use the `card` shortcode.
   - check:
-      If Markdown outputs / `llms.txt` are enabled, inspect the generated `.md`
-      pages and `/llms.txt`.
+      If agent support is enabled, inspect generated `*.md` pages and
+      `/llms.txt`.
 
 # Rollback guidance: pin Docsy to the previous stable release if upgrading
 # blocks shipping. See: https://github.com/google/docsy/releases/v0.14.3

--- a/docsy.dev/static/upgrades/0.15.0.yaml
+++ b/docsy.dev/static/upgrades/0.15.0.yaml
@@ -32,6 +32,35 @@ peer:
 # Each item is independently gated by a `detect` rule so callers can
 # evaluate applicability against the consuming project.
 breaking:
+  - id: card-shortcode-rendering
+    title: card shortcode rendering
+    summary: >-
+      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
+      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
+      they render in the page context. Shortcode invocations inside those fields
+      now execute (previously passed through `markdownify`'s escape behavior).
+    applies-if: >-
+      Your project uses the `card` shortcode with Markdown, images, links,
+      shortcode invocations inside the affected fields, or a custom
+      `layouts/_shortcodes/card.html` override.
+    detect:
+      any:
+        - kind: grep
+          pattern: '\{\{[<%][[:space:]]*card\b'
+          paths: [content/, layouts/]
+        - kind: file-exists
+          path: layouts/_shortcodes/card.html
+        - kind: file-exists
+          path: layouts/shortcodes/card.html
+    actions:
+      - Review rendered cards that use any of the affected fields.
+      - Diff any local card-shortcode override against the v0.15.0 partial.
+    references:
+      blog: /blog/2026/0.15.0/#card-shortcode
+      partials:
+        - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
+      prs: [2565]
+
   - id: community-footer-multilingual-paths
     title: community and footer link paths (multilingual)
     summary: >-
@@ -127,26 +156,21 @@ breaking:
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar.html
       prs: [2557, 2586]
 
-# New behavior — items that introduce a capability that wasn't available
-# before. Listed here (rather than under `breaking`) when, to the best of
-# the project's knowledge, no client project relied on the previous
-# behavior in a way that would break under the new release. If a regression
-# is reported, an item may be reclassified to `breaking`.
+# New behavior
 new:
   - id: card-shortcode-rendering
     title: card shortcode rendering — page-context resolution
     summary: >-
       The `card` shortcode now renders the `header`, `title`, `subtitle`, and
       `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
-      relative links and images inside those fields resolve relative to the
-      page that includes the `card`, and Markdown render hooks fire in the
-      page context — capabilities that weren't available before.
+      relative links and images inside those fields resolve relative to the page
+      that includes the `card`, and Markdown render hooks fire in the page
+      context — capabilities that weren't available before.
     classification-note: >-
-      Treated as new behavior rather than breaking based on a judgement call:
-      to the project's best knowledge, no client relied on the previous
-      resolution behavior in a way that would break under 0.15.0. Reclassify
-      to `breaking` if a regression is reported. See blog rationale for
-      details.
+      Treated as new behavior rather than breaking based on a judgement call: to
+      the project's best knowledge, no client relied on the previous resolution
+      behavior in a way that would break under 0.15.0. Reclassify to `breaking`
+      if a regression is reported. See blog rationale for details.
     applies-if: >-
       Your project uses the `card` shortcode with Markdown, images, links, or
       maintains a custom `layouts/_shortcodes/card.html` override.

--- a/docsy.dev/static/upgrades/0.15.0.yaml
+++ b/docsy.dev/static/upgrades/0.15.0.yaml
@@ -32,35 +32,6 @@ peer:
 # Each item is independently gated by a `detect` rule so callers can
 # evaluate applicability against the consuming project.
 breaking:
-  - id: card-shortcode-rendering
-    title: card shortcode rendering
-    summary: >-
-      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
-      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
-      they render in the page context. Shortcode invocations inside those fields
-      now execute (previously passed through `markdownify`'s escape behavior).
-    applies-if: >-
-      Your project uses the `card` shortcode with Markdown, images, links,
-      shortcode invocations inside the affected fields, or a custom
-      `layouts/_shortcodes/card.html` override.
-    detect:
-      any:
-        - kind: grep
-          pattern: '\{\{[<%][[:space:]]*card\b'
-          paths: [content/, layouts/]
-        - kind: file-exists
-          path: layouts/_shortcodes/card.html
-        - kind: file-exists
-          path: layouts/shortcodes/card.html
-    actions:
-      - Review rendered cards that use any of the affected fields.
-      - Diff any local card-shortcode override against the v0.15.0 partial.
-    references:
-      blog: /blog/2026/0.15.0/#card-shortcode
-      partials:
-        - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
-      prs: [2565]
-
   - id: community-footer-multilingual-paths
     title: community and footer link paths (multilingual)
     summary: >-
@@ -155,6 +126,47 @@ breaking:
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar-version-selector.html
         - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar.html
       prs: [2557, 2586]
+
+# New behavior — items that introduce a capability that wasn't available
+# before. Listed here (rather than under `breaking`) when, to the best of
+# the project's knowledge, no client project relied on the previous
+# behavior in a way that would break under the new release. If a regression
+# is reported, an item may be reclassified to `breaking`.
+new:
+  - id: card-shortcode-rendering
+    title: card shortcode rendering — page-context resolution
+    summary: >-
+      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
+      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
+      relative links and images inside those fields resolve relative to the
+      page that includes the `card`, and Markdown render hooks fire in the
+      page context — capabilities that weren't available before.
+    classification-note: >-
+      Treated as new behavior rather than breaking based on a judgement call:
+      to the project's best knowledge, no client relied on the previous
+      resolution behavior in a way that would break under 0.15.0. Reclassify
+      to `breaking` if a regression is reported. See blog rationale for
+      details.
+    applies-if: >-
+      Your project uses the `card` shortcode with Markdown, images, links, or
+      maintains a custom `layouts/_shortcodes/card.html` override.
+    detect:
+      any:
+        - kind: grep
+          pattern: '\{\{[<%][[:space:]]*card\b'
+          paths: [content/, layouts/]
+        - kind: file-exists
+          path: layouts/_shortcodes/card.html
+        - kind: file-exists
+          path: layouts/shortcodes/card.html
+    actions:
+      - Review rendered cards that use any of the affected fields.
+      - Diff any local card-shortcode override against the v0.15.0 partial.
+    references:
+      blog: /blog/2026/0.15.0/#card-shortcode
+      partials:
+        - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
+      prs: [2565]
 
 # Sanity checks to run after upgrading. These are project-agnostic.
 sanity:

--- a/docsy.dev/static/upgrades/0.15.0.yaml
+++ b/docsy.dev/static/upgrades/0.15.0.yaml
@@ -1,0 +1,185 @@
+# Docsy upgrade manifest — 0.15.0
+#
+# Machine-readable companion to the 0.15.0 release blog. Lists breaking
+# changes with detect rules so an agent (or human) can quickly determine
+# which items apply to a given site, and surface anchored references back
+# into the human-readable release blog and changelog.
+#
+# Status: experimental. Schema is expected to evolve through 0.16.0+;
+# see the tracking issue for the planned DRY/data-driven approach.
+#
+# Authoritative for: detect predicates, version pins, breaking-item ids.
+# Authoritative narrative remains in the release blog.
+
+schema: docsy-upgrade-manifest/v0
+from: 0.14.3
+to: 0.15.0
+references:
+  blog: /blog/2026/0.15.0/
+  changelog: /project/about/changelog/#v0.15.0
+  release: https://github.com/google/docsy/releases/v0.15.0
+  tag: https://github.com/google/docsy/tree/v0.15.0
+peer:
+  hugo:
+    from: '>=0.155.3'
+    to: '>=0.157.0'
+    notes: Matches docsy.dev `params.hugoMinVersion` and `hugo-extended`.
+  node:
+    to: lts/24
+    notes: Later Node versions may work but are not officially supported.
+
+# Breaking changes — items that may require a client-project change.
+# Each item is independently gated by a `detect` rule so callers can
+# evaluate applicability against the consuming project.
+breaking:
+  - id: card-shortcode-rendering
+    title: card shortcode rendering
+    summary: >-
+      The `card` shortcode now renders the `header`, `title`, `subtitle`, and
+      `footer` fields with `$.Page.RenderString` instead of `markdownify`, so
+      they render in the page context. Shortcode invocations inside those fields
+      now execute (previously passed through `markdownify`'s escape behavior).
+    applies-if: >-
+      Your project uses the `card` shortcode with Markdown, images, links,
+      shortcode invocations inside the affected fields, or a custom
+      `layouts/_shortcodes/card.html` override.
+    detect:
+      any:
+        - kind: grep
+          pattern: '\{\{[<%][[:space:]]*card\b'
+          paths: [content/, layouts/]
+        - kind: file-exists
+          path: layouts/_shortcodes/card.html
+        - kind: file-exists
+          path: layouts/shortcodes/card.html
+    actions:
+      - Review rendered cards that use any of the affected fields.
+      - Diff any local card-shortcode override against the v0.15.0 partial.
+    references:
+      blog: /blog/2026/0.15.0/#card-shortcode
+      partials:
+        - https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html
+      prs: [2565]
+
+  - id: community-footer-multilingual-paths
+    title: community and footer link paths (multilingual)
+    summary: >-
+      For multilingual sites, community and footer link paths
+      (`params.links.user`, `params.links.developer`) are now interpreted as
+      site-relative rather than always resolving under the default language. To
+      force the default-language target, prefix the path with the default
+      language code (e.g. `/en/community/` instead of `/community/`).
+    applies-if: >-
+      Your site is multilingual and configures `params.links.user` or
+      `params.links.developer` with site-local paths.
+    detect:
+      all:
+        - kind: config-multilingual
+          description: Site has more than one language configured.
+        - kind: grep
+          pattern: '^\s*(user|developer)\s*[:=]'
+          paths: [config/, hugo.toml, hugo.yaml, hugo.json]
+          context: under params.links
+    actions:
+      - >-
+        Review each path and decide whether it should be site-relative or target
+        the default language.
+      - >-
+        For default-language targets, prefix with the default-language code
+        (e.g. `/en/community/`).
+      - Recheck generated community/footer links in each language.
+    references:
+      blog: /blog/2026/0.15.0/#community-footer-links
+      prs: [2576, 2580]
+
+  - id: community-footer-link-target
+    title: community and footer link target attribute
+    summary: >-
+      Community and footer links now only open in a new browser target for
+      external links. Previously, site-local links also opened in a new target.
+    applies-if: >-
+      Your site relied on community or footer links opening in a new tab/window
+      for site-local URLs.
+    detect:
+      kind: grep
+      pattern: '^\s*(user|developer)\s*[:=]'
+      paths: [config/, hugo.toml, hugo.yaml, hugo.json]
+      context: under params.links
+    actions:
+      - >-
+        If your design depended on site-local community/footer links opening in
+        a new target, plan to surface those links elsewhere or accept the new
+        same-target behavior.
+    references:
+      blog: /blog/2026/0.15.0/#community-footer-links
+      prs: [2576]
+
+  - id: version-menu-customization
+    title: version menu markup, classes, and mobile visibility
+    summary: >-
+      The version menu uses updated markup and CSS classes
+      (`.td-navbar__version-menu` wrapper, `.td-version-menu` dropdown,
+      kind-specific classes per entry) and is no longer hidden on smaller
+      viewports.
+    applies-if: >-
+      Your site configures `params.versions` AND customizes the version menu
+      partial, navbar partial, or related CSS.
+    detect:
+      all:
+        - kind: config-key-present
+          path: params.versions
+        - any:
+            - kind: file-exists
+              path: layouts/_partials/navbar-version-selector.html
+            - kind: file-exists
+              path: layouts/partials/navbar-version-selector.html
+            - kind: file-exists
+              path: layouts/_partials/navbar.html
+            - kind: file-exists
+              path: layouts/partials/navbar.html
+            - kind: grep
+              pattern: 'td-(navbar|version-menu)'
+              paths: [assets/]
+    actions:
+      - Review custom CSS that targets the version menu dropdown.
+      - >-
+        Diff local `navbar-version-selector.html` or `navbar.html` overrides
+        against the v0.15.0 partials.
+      - Recheck the navbar on both desktop and mobile viewports.
+    references:
+      blog: /blog/2026/0.15.0/#version-menu
+      user-guide:
+        - /docs/content/versioning/#adding-a-version-drop-down-menu
+        - /docs/content/navigation/#version-menu
+      partials:
+        - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar-version-selector.html
+        - https://github.com/google/docsy/blob/v0.15.0/layouts/_partials/navbar.html
+      prs: [2557, 2586]
+
+# Sanity checks to run after upgrading. These are project-agnostic.
+sanity:
+  - run: hugo --gc
+    description: Build the site and surface any errors.
+  - run: hugo --printPathWarnings
+    description:
+      Surface path collisions; especially relevant for doc-rooted sites.
+    applies-if: doc-rooted-or-custom-permalinks
+  - check:
+      Verify community and footer links resolve correctly in each configured
+      language.
+  - check:
+      If `params.versions` is configured, check the version menu on desktop and
+      mobile viewports.
+  - check: Inspect pages that use the `card` shortcode.
+  - check:
+      If Markdown outputs / `llms.txt` are enabled, inspect the generated `.md`
+      pages and `/llms.txt`.
+
+# Rollback guidance: pin Docsy to the previous stable release if upgrading
+# blocks shipping. See: https://github.com/google/docsy/releases/v0.14.3
+rollback:
+  docsy: 0.14.3
+  hugo: '>=0.155.3'
+  notes: >-
+    Re-pin via npm and Hugo module dependencies. See `Upgrade to Docsy 0.12.0`
+    for the standard package-update procedure, applied in reverse.

--- a/docsy.dev/tests/md-output/goldens/docs/content/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/content/index.md
@@ -11,7 +11,7 @@ LLMS index: [llms.txt](/llms.txt)
 Section pages:
 
 - [Adding Content](/docs/content/adding-content/): Add different types of content to your Docsy site.
-- [Agent support](/docs/content/agent-support/): Opt-in features that help AI agents and automated tools discover and use your site content, including Markdown output, alternate links in HTML, and llms.txt.
+- [AI-agent support](/docs/content/agent-support/): Opt-in features that help AI agents and automated tools discover and use your site content, including Markdown output, alternate links in HTML, and llms.txt.
 - [Analytics, User Feedback, and SEO](/docs/content/feedback/): Add Google Analytics tracking to your site, collect user feedback and learn about the page description meta tag.
 - [Diagrams and Formulae](/docs/content/diagrams-and-formulae/): Add generated diagrams and scientific formulae to your site.
 - [Logos and Images](/docs/content/iconsimages/): Add and customize logos, icons, and images in your project.

--- a/tasks/0.15/release-prep/commit-inventory.md
+++ b/tasks/0.15/release-prep/commit-inventory.md
@@ -1,7 +1,7 @@
 ---
 title: 0.15 commit inventory
 date: 2026-04-25
-lastmod: 2026-05-01
+lastmod: 2026-04-30
 range: v0.14.3..main
 last-main-commit: 466bd327
 ---
@@ -111,11 +111,10 @@ uses first-parent commits as the release-audit spine.
 ## Mixed-change commits needing review
 
 - [#2565][] includes doc-rooted config work and a `card` shortcode rendering
-  change: the shortcode now uses `$.Page.RenderString` instead of `markdownify`,
-  enabling page-context resolution of relative links/images and page-context
-  Markdown render hooks. **Reclassified during release prep** from breaking to
-  new behavior — see the Summary section of `issue-audit.md` for the rationale
-  and reclassification advisory.
+  change: named arguments use `$.Page.RenderString` instead of `markdownify`,
+  enabling page-context relative links/images and render hooks — treated as
+  **new** and **low-risk potentially breaking** in the [0.15.0
+  blog][0.15.0-blog-card]. See the Summary section of `issue-audit.md`.
 - [#2580][] includes a likely breaking behavior change for multilingual
   community/footer paths.
 - [#2586][] combines version/variant menu UX, `tdVersion` config structure,
@@ -139,6 +138,7 @@ uses first-parent commits as the release-audit spine.
   tooling/metadata, audit guidance, npm `-C docsy.dev` ergonomics, and Prettier
   ignore/format hygiene (see commits above).
 
+[0.15.0-blog-card]: /blog/2026/0.15.0/#card-shortcode
 [#2082]: https://github.com/google/docsy/pull/2082
 [#2555]: https://github.com/google/docsy/pull/2555
 [#2556]: https://github.com/google/docsy/pull/2556

--- a/tasks/0.15/release-prep/commit-inventory.md
+++ b/tasks/0.15/release-prep/commit-inventory.md
@@ -111,11 +111,11 @@ uses first-parent commits as the release-audit spine.
 ## Mixed-change commits needing review
 
 - [#2565][] includes doc-rooted config work and a `card` shortcode rendering
-  change: the shortcode now uses `$.Page.RenderString` instead of
-  `markdownify`, enabling page-context resolution of relative links/images and
-  page-context Markdown render hooks. **Reclassified during release prep**
-  from breaking to new behavior — see the Summary section of `issue-audit.md`
-  for the rationale and reclassification advisory.
+  change: the shortcode now uses `$.Page.RenderString` instead of `markdownify`,
+  enabling page-context resolution of relative links/images and page-context
+  Markdown render hooks. **Reclassified during release prep** from breaking to
+  new behavior — see the Summary section of `issue-audit.md` for the rationale
+  and reclassification advisory.
 - [#2580][] includes a likely breaking behavior change for multilingual
   community/footer paths.
 - [#2586][] combines version/variant menu UX, `tdVersion` config structure,

--- a/tasks/0.15/release-prep/commit-inventory.md
+++ b/tasks/0.15/release-prep/commit-inventory.md
@@ -110,10 +110,12 @@ uses first-parent commits as the release-audit spine.
 
 ## Mixed-change commits needing review
 
-- [#2565][] includes doc-rooted config work and an internally meaningful `card`
-  shortcode rendering change: the shortcode now uses `$.Page.RenderString`
-  instead of `markdownify`, which may affect some client overrides or shortcode
-  content rendering.
+- [#2565][] includes doc-rooted config work and a `card` shortcode rendering
+  change: the shortcode now uses `$.Page.RenderString` instead of
+  `markdownify`, enabling page-context resolution of relative links/images and
+  page-context Markdown render hooks. **Reclassified during release prep**
+  from breaking to new behavior — see the Summary section of `issue-audit.md`
+  for the rationale and reclassification advisory.
 - [#2580][] includes a likely breaking behavior change for multilingual
   community/footer paths.
 - [#2586][] combines version/variant menu UX, `tdVersion` config structure,

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -30,16 +30,15 @@ blog post, or changelog updates.
 - Reclassified during release prep:
   - [#2565][] (`card` shortcode rendering: `markdownify` →
     `$.Page.RenderString`) was originally listed as **breaking** but was
-    reclassified to **new behavior** during release prep. Rationale: the
-    change enables page-context resolution of relative links/images and
-    page-context Markdown render hooks — a capability that wasn't available
-    before. To the project's best knowledge, no client relied on the previous
-    resolution behavior in a way that would break under 0.15.0, and no issue
-    requested the new capability prior to its inclusion in [#2565][]. The
-    judgement call is documented in the 0.15.0 release blog (Card shortcode
-    rendering section) and the upgrade manifest's `new[]` entry, both of
-    which note that the item will be reclassified back to **breaking** if a
-    regression is reported.
+    reclassified to **new behavior** during release prep. Rationale: the change
+    enables page-context resolution of relative links/images and page-context
+    Markdown render hooks — a capability that wasn't available before. To the
+    project's best knowledge, no client relied on the previous resolution
+    behavior in a way that would break under 0.15.0, and no issue requested the
+    new capability prior to its inclusion in [#2565][]. The judgement call is
+    documented in the 0.15.0 release blog (Card shortcode rendering section) and
+    the upgrade manifest's `new[]` entry, both of which note that the item will
+    be reclassified back to **breaking** if a regression is reported.
 - Changelog / blog: refreshed for **0.15** through [#2616][] and follow-on prep
   ([#2618][], [#2619][], [#2620][], [#2621][]). Final tagging pass still
   replaces prerelease/release-page placeholders as needed.
@@ -170,9 +169,9 @@ Raw commits in scope without PR numbers in their commit subjects:
     `markdownify`, which renders shortcode fields in the page context — a
     capability (page-relative link/image resolution and page-context Markdown
     render hooks) that wasn't available before. **Reclassified during release
-    prep** from breaking to new behavior; see the Summary section of this
-    audit for the rationale. Override authors may still want to diff their
-    local `card.html` against the v0.15.0 partial.
+    prep** from breaking to new behavior; see the Summary section of this audit
+    for the rationale. Override authors may still want to diff their local
+    `card.html` against the v0.15.0 partial.
 - Docs impact:
   - Status: **rel** on the summary table for ongoing doc-rooted refinements;
     baseline guidance and examples shipped for 0.15.

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -1,7 +1,7 @@
 ---
 title: 0.15 issue audit
 date: 2026-04-25
-lastmod: 2026-05-01
+lastmod: 2026-04-30
 range: v0.14.3..main
 last-main-commit: 466bd327
 cSpell:ignore: afdocs overpromising
@@ -27,18 +27,15 @@ blog post, or changelog updates.
     site-relative paths.
   - [#2585][] raises the repository-supported Hugo version to 0.157.0 and keeps
     release guidance on Node LTS 24.
-- Reclassified during release prep:
-  - [#2565][] (`card` shortcode rendering: `markdownify` →
-    `$.Page.RenderString`) was originally listed as **breaking** but was
-    reclassified to **new behavior** during release prep. Rationale: the change
-    enables page-context resolution of relative links/images and page-context
-    Markdown render hooks — a capability that wasn't available before. To the
-    project's best knowledge, no client relied on the previous resolution
-    behavior in a way that would break under 0.15.0, and no issue requested the
-    new capability prior to its inclusion in [#2565][]. The judgement call is
-    documented in the 0.15.0 release blog (Card shortcode rendering section) and
-    the upgrade manifest's `new[]` entry, both of which note that the item will
-    be reclassified back to **breaking** if a regression is reported.
+- Final messaging for [#2565][] (`card` shortcode rendering: `markdownify` →
+  `$.Page.RenderString`): **both** a **new** capability (page-context relative
+  links/images and Markdown render hooks) and a **low-risk potentially
+  breaking** change for sites affected by the new rendering behavior. The
+  [0.15.0 release blog card section][0.15.0-blog-card] uses BREAKING/NEW; the
+  changelog lists it under **Breaking** and **New**;
+  `docsy.dev/static/upgrades/0.15.0.yaml` models it under `breaking[]` with a
+  low-risk title for agent-oriented detect rules. If something breaks, file an
+  issue (see blog NOTE).
 - Changelog / blog: refreshed for **0.15** through [#2616][] and follow-on prep
   ([#2618][], [#2619][], [#2620][], [#2621][]). Final tagging pass still
   replaces prerelease/release-page placeholders as needed.
@@ -166,12 +163,12 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Adds a concrete configuration pattern for documentation-first sites.
   - May affect users with custom docs-only/doc-rooted configurations.
   - `card` shortcode rendering now uses `$.Page.RenderString` instead of
-    `markdownify`, which renders shortcode fields in the page context — a
-    capability (page-relative link/image resolution and page-context Markdown
-    render hooks) that wasn't available before. **Reclassified during release
-    prep** from breaking to new behavior; see the Summary section of this audit
-    for the rationale. Override authors may still want to diff their local
-    `card.html` against the v0.15.0 partial.
+    `markdownify`, which renders Markdown in named arguments in the page context
+    — enabling page-relative link/image resolution and page-context Markdown
+    render hooks. Release messaging treats this as **new** behavior **and** a
+    **low-risk** potentially breaking review item (see Summary above and [Card
+    shortcode rendering][0.15.0-blog-card] in the 0.15.0 blog). Override authors
+    should diff local `card.html` against the v0.15.0 partial.
 - Docs impact:
   - Status: **rel** on the summary table for ongoing doc-rooted refinements;
     baseline guidance and examples shipped for 0.15.
@@ -188,8 +185,9 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Status: done.
   - Included as a major improvement, with migration notes for projects that
     previously used docs-only patterns.
-  - The `card` shortcode rendering change is called out as a breaking/action
-    review item.
+  - The `card` shortcode change appears in **Ready to Upgrade** as breaking
+    (low-risk) and in the dedicated section as BREAKING/NEW, aligned with the
+    changelog.
 - Follow-up needed:
   - Use 0.16+ issues for any remaining doc-rooted refinements.
 
@@ -330,6 +328,7 @@ Raw commits in scope without PR numbers in their commit subjects:
 
 - [Release 0.15.0 preparation #2501][#2501]
 
+[0.15.0-blog-card]: /blog/2026/0.15.0/#card-shortcode
 [#1380]: https://github.com/google/docsy/issues/1380
 [#2082]: https://github.com/google/docsy/pull/2082
 [#2133]: https://github.com/google/docsy/issues/2133

--- a/tasks/0.15/release-prep/issue-audit.md
+++ b/tasks/0.15/release-prep/issue-audit.md
@@ -25,11 +25,21 @@ blog post, or changelog updates.
 - Known likely breaking or action-requiring items:
   - [#2580][] changes multilingual community/footer path interpretation to
     site-relative paths.
-  - [#2565][] changes `card` shortcode rendering from `markdownify` to
-    `$.Page.RenderString`, which may affect some client overrides or shortcode
-    content rendering.
   - [#2585][] raises the repository-supported Hugo version to 0.157.0 and keeps
     release guidance on Node LTS 24.
+- Reclassified during release prep:
+  - [#2565][] (`card` shortcode rendering: `markdownify` →
+    `$.Page.RenderString`) was originally listed as **breaking** but was
+    reclassified to **new behavior** during release prep. Rationale: the
+    change enables page-context resolution of relative links/images and
+    page-context Markdown render hooks — a capability that wasn't available
+    before. To the project's best knowledge, no client relied on the previous
+    resolution behavior in a way that would break under 0.15.0, and no issue
+    requested the new capability prior to its inclusion in [#2565][]. The
+    judgement call is documented in the 0.15.0 release blog (Card shortcode
+    rendering section) and the upgrade manifest's `new[]` entry, both of
+    which note that the item will be reclassified back to **breaking** if a
+    regression is reported.
 - Changelog / blog: refreshed for **0.15** through [#2616][] and follow-on prep
   ([#2618][], [#2619][], [#2620][], [#2621][]). Final tagging pass still
   replaces prerelease/release-page placeholders as needed.
@@ -157,9 +167,12 @@ Raw commits in scope without PR numbers in their commit subjects:
   - Adds a concrete configuration pattern for documentation-first sites.
   - May affect users with custom docs-only/doc-rooted configurations.
   - `card` shortcode rendering now uses `$.Page.RenderString` instead of
-    `markdownify`, which renders shortcode fields in the page context. This may
-    affect clients that depend on the previous rendering behavior or override
-    the shortcode.
+    `markdownify`, which renders shortcode fields in the page context — a
+    capability (page-relative link/image resolution and page-context Markdown
+    render hooks) that wasn't available before. **Reclassified during release
+    prep** from breaking to new behavior; see the Summary section of this
+    audit for the rationale. Override authors may still want to diff their
+    local `card.html` against the v0.15.0 partial.
 - Docs impact:
   - Status: **rel** on the summary table for ongoing doc-rooted refinements;
     baseline guidance and examples shipped for 0.15.

--- a/tasks/0.15/release-prep/issue-mapping.md
+++ b/tasks/0.15/release-prep/issue-mapping.md
@@ -25,7 +25,7 @@ Mapping covers first-parent commits in [v0.14.3...main][] through [7a0b370f][].
 | [#2562][]: Ensure `.td-main > .row` grows vertically                   | [#2561][] (PR body, closing issue)                 | Fixed in 0.14.3 release path; still in current range |
 | [#2563][]: Add doc-rooted site example version, update guidance        | #2504, #2499, [#2492][] (PR body, closing issues)  | Part of doc-rooted tracker                           |
 | [#2564][]: Use `TD_BUILD_CTX` for doc-rooted builds                    | [#2504][] (Inferred from neighboring tracker work) | Build-support follow-up                              |
-| [#2565][]: Update doc-rooted configs to avoid root index render clash  | [#2504][] (PR body)                                | `card` now uses `$.Page.RenderString`                |
+| [#2565][]: Update doc-rooted configs to avoid root index render clash  | [#2504][] (PR body)                                | `card` args: new + low-risk breaking                 |
 | [#2567][]: Remove `sidebar_root_for` user-guide docs                   | None found (N/A)                                   | Follow-up docs cleanup                               |
 | [#2568][]: Dedup site homepages for doc-rooted sites                   | [#2504][] (PR body)                                | Doc-rooted support                                   |
 | [#2571][]: Update `deploy/prod` to 0.14.3                              | [#2501][] (Release prep scope)                     | Branch maintenance                                   |


### PR DESCRIPTION
- Clarifies 0.15.0 release guidance for community/footer links, version menu overrides, card shortcode rendering, AI-assisted upgrades, and sanity checks.
- Updates the 0.15.0 changelog entry to keep breaking changes, new behavior, fixes, experimental work, and maintainer-facing changes lean and distinct.
- Refreshes related user-guide and release-prep notes for agent support, multilingual docs, card shortcode examples, and release-audit consistency.
- Adds an experimental machine-readable 0.15.0 upgrade manifest with breaking-change gates, fixes, references, sanity checks, and rollback guidance.
