### PR TITLE
Update examples page to 0.15.0, adjust maintainer notes

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 001-over-main-01c827ea
+  buildId: &tdBuildId 002-over-main-ce9942b8
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 001-over-main-01c827ea
+  buildId: &tdBuildId 002-over-main-ce9942b8
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 001-over-main-01c827ea
+  buildId: &tdBuildId 002-over-main-ce9942b8
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/examples/index.md
+++ b/docsy.dev/content/en/examples/index.md
@@ -63,8 +63,8 @@ The Docsy project provides two site starter templates:
 
 | Site                               | Repo                                      | Docsy            |
 | ---------------------------------- | ----------------------------------------- | ---------------- |
-| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | v0.14.1 (latest) |
-| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | v0.14.1 (latest) |
+| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | v0.15.0 (latest) |
+| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | v0.15.0 (latest) |
 
 In addition to these example starters, there are several live sites using the
 theme. Consider adding your Docsy-based site to this page once you have a

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -189,7 +189,8 @@ If not adjust accordingly.
 
 10. **Pull the PR** to get the last changes.
 
-11. **Test Docsy** from [docsy-example][], for example.
+11. **Test Docsy** from [docsy-example][] and the docsy-starter. (Consider
+    updating the Docsy version for these examples in the examples page.)
 
 12. **Ensure** that you're:
     - On the target `$BASE` branch
@@ -378,6 +379,9 @@ with the following modifications:
       to the new release.
     - To create a new release draft, visit [Docsy-example release draft][].
 
+3.  **Update the [Examples page][]** Docsy version in the Starter templates
+    table to {{% dev-version final %}}.
+
 [Docsy-example release draft]:
   https://github.com/google/docsy-example/releases/new
 [example.docsy.dev]: https://example.docsy.dev
@@ -458,6 +462,7 @@ before any further changes are merged into the `main` branch:
 [docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>
 [docsy.dev/package.json]: <{{% param github_repo %}}/blob/main/docsy.dev/package.json>
 [Draft a new release]: <{{% param github_repo %}}/releases/new>
+[Examples page]: /examples/
 [go.mod]: <{{% param github_repo %}}/blob/main/go.mod>
 [install-hugo.sh]: <{{% param github_repo %}}/blob/main/docsy.dev/scripts/install-hugo.sh>
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+001-over-main-01c827ea",
+  "version": "0.15.1-dev+002-over-main-ce9942b8",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixes #2631
- Refreshes **`package.json`** and **`tdVersion.buildId`** 
- Updates the Examples starter table to **v0.15.0 (latest)**
- Expands **maintainer-notes** so release testing explicitly covers **docsy-starter**, calls out refreshing pinned Docsy versions on the examples page.
- Scope: docs-only, internal-only
- **Preview**: https://deploy-preview-2632--docsydocs.netlify.app/examples/