### PR TITLE
fix: remove sidebar margins on mobile devices to prevent layout overflow

### DIFF
--- a/assets/scss/td/_sidebar-tree.scss
+++ b/assets/scss/td/_sidebar-tree.scss
@@ -212,3 +212,10 @@
     }
   }
 }
+
+@include media-breakpoint-down(md) {
+  .td-sidebar-nav {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+}


### PR DESCRIPTION
<img width="777" height="635" alt="image" src="https://github.com/user-attachments/assets/b8a79e1f-991e-43df-b3b1-bc4820239bf4" />
