### PR TITLE
Update start-from-scratch.md

### DIFF
--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -32,7 +32,7 @@ At your command prompt, run the following:
 hugo new site my-new-site
 cd  my-new-site
 hugo mod init github.com/me/my-new-site
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 cat >> hugo.toml <<EOL
 [module]
 proxy = "direct"


### PR DESCRIPTION
In the "TL;DR" section the line

`hugo mod get github.com/google/docsy@vv0.15.0`

failed. There was an extra v. Removing it succeeds.