### PR TITLE
Upgrade Hugo to 0.163.1

### DIFF
--- a/docsy.dev/config/_default/hugo.yaml
+++ b/docsy.dev/config/_default/hugo.yaml
@@ -18,7 +18,10 @@ outputs:
 
 imaging:
   resampleFilter: CatmullRom # cSpell:disable-line
-  quality: 75
+  jpeg:
+    quality: 75
+  webp:
+    quality: 75
   anchor: Smart
 
 languages:

--- a/docsy.dev/config/_default/hugo.yaml
+++ b/docsy.dev/config/_default/hugo.yaml
@@ -18,11 +18,6 @@ outputs:
 
 imaging:
   resampleFilter: CatmullRom # cSpell:disable-line
-  jpeg:
-    quality: 75
-  webp:
-    quality: 75
-  anchor: Smart
 
 languages:
   en:

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 010-over-main-5c5733de
+  buildId: &tdBuildId 011-over-main-3e76f1f2
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 010-over-main-5c5733de
+  buildId: &tdBuildId 011-over-main-3e76f1f2
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 010-over-main-5c5733de
+  buildId: &tdBuildId 011-over-main-3e76f1f2
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -145,12 +145,12 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
-- Upgraded the project's Hugo build to [0.163.0][hugo-0.163.0]. The theme's
+- Upgraded the project's Hugo build to [0.163.1][hugo-0.163.1]. The theme's
   minimum supported Hugo version remains 0.158.0.
 
 [#2594]: https://github.com/google/docsy/pull/2594
 [#2578]: https://github.com/google/docsy/pull/2578
-[hugo-0.163.0]: https://github.com/gohugoio/hugo/releases/tag/v0.163.0
+[hugo-0.163.1]: https://github.com/gohugoio/hugo/releases/tag/v0.163.1
 
 [**Experimental**](#experimental):
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -145,12 +145,12 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
-- Upgraded the project's Hugo build to [0.160.1][hugo-0.160.1]. The theme's
+- Upgraded the project's Hugo build to [0.163.0][hugo-0.163.0]. The theme's
   minimum supported Hugo version remains 0.158.0.
 
 [#2594]: https://github.com/google/docsy/pull/2594
 [#2578]: https://github.com/google/docsy/pull/2578
-[hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
+[hugo-0.163.0]: https://github.com/gohugoio/hugo/releases/tag/v0.163.0
 
 [**Experimental**](#experimental):
 

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -49,7 +49,7 @@
     "afdocs": "^0.9.2",
     "autoprefixer": "^10.4.27",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.160.1",
+    "hugo-extended": "0.163.0",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "postcss-cli": "^11.0.1",

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -49,7 +49,7 @@
     "afdocs": "^0.9.2",
     "autoprefixer": "^10.4.27",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.0",
+    "hugo-extended": "0.163.1",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "postcss-cli": "^11.0.1",

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -695,6 +695,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-12T09:21:33.077187-04:00"
   },
+  "https://github.com/gohugoio/hugo/releases/tag/v0.163.1": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-12T10:47:00.544108-04:00"
+  },
   "https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:07.239646-05:00"

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -691,6 +691,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-12T05:59:50.245978-04:00"
   },
+  "https://github.com/gohugoio/hugo/releases/tag/v0.163.0": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-12T09:21:33.077187-04:00"
+  },
   "https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:07.239646-05:00"

--- a/docsy.dev/tests/md-output/goldens/fr/index.md
+++ b/docsy.dev/tests/md-output/goldens/fr/index.md
@@ -8,15 +8,15 @@ LLMS index: [llms.txt](/llms.txt)
 
 ---
 
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg" media="(max-width: 1200px)">
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg" media="(min-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_ac3e76417c708174.jpg" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_1a0ad6f9205bc79d.jpg" media="(min-width: 1200px)">
 <style>
 #td-cover-block-0 {
-  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg);
+  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_ac3e76417c708174.jpg);
 }
 @media only screen and (min-width: 1200px) {
   #td-cover-block-0 {
-    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg);
+    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_1a0ad6f9205bc79d.jpg);
   }
 }
 </style>

--- a/docsy.dev/tests/md-output/goldens/fr/index.md
+++ b/docsy.dev/tests/md-output/goldens/fr/index.md
@@ -8,15 +8,15 @@ LLMS index: [llms.txt](/llms.txt)
 
 ---
 
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_c1778660d89e69fa.jpg" media="(max-width: 1200px)">
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_48736da419c52e48.jpg" media="(min-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg" media="(min-width: 1200px)">
 <style>
 #td-cover-block-0 {
-  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_c1778660d89e69fa.jpg);
+  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg);
 }
 @media only screen and (min-width: 1200px) {
   #td-cover-block-0 {
-    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_48736da419c52e48.jpg);
+    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg);
   }
 }
 </style>

--- a/docsy.dev/tests/md-output/goldens/index.md
+++ b/docsy.dev/tests/md-output/goldens/index.md
@@ -8,15 +8,15 @@ LLMS index: [llms.txt](/llms.txt)
 
 ---
 
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg" media="(max-width: 1200px)">
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg" media="(min-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_ac3e76417c708174.jpg" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_1a0ad6f9205bc79d.jpg" media="(min-width: 1200px)">
 <style>
 #td-cover-block-0 {
-  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg);
+  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_ac3e76417c708174.jpg);
 }
 @media only screen and (min-width: 1200px) {
   #td-cover-block-0 {
-    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg);
+    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_1a0ad6f9205bc79d.jpg);
   }
 }
 </style>

--- a/docsy.dev/tests/md-output/goldens/index.md
+++ b/docsy.dev/tests/md-output/goldens/index.md
@@ -8,15 +8,15 @@ LLMS index: [llms.txt](/llms.txt)
 
 ---
 
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_c1778660d89e69fa.jpg" media="(max-width: 1200px)">
-<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_48736da419c52e48.jpg" media="(min-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg" media="(max-width: 1200px)">
+<link rel="preload" as="image" href="/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg" media="(min-width: 1200px)">
 <style>
 #td-cover-block-0 {
-  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_c1778660d89e69fa.jpg);
+  background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_28cf822f25b6f961.jpg);
 }
 @media only screen and (min-width: 1200px) {
   #td-cover-block-0 {
-    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_48736da419c52e48.jpg);
+    background-image: url(/background-pexels-quang-nguyen-vinh-222549-2131841_hu_d1a634809060463b.jpg);
   }
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+010-over-main-5c5733de",
+  "version": "0.15.1-dev+011-over-main-3e76f1f2",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prettier": "^3.8.1"
   },
   "config": {
-    "hugo_version": "0.160.1"
+    "hugo_version": "0.163.0"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prettier": "^3.8.1"
   },
   "config": {
-    "hugo_version": "0.163.0"
+    "hugo_version": "0.163.1"
   },
   "engines": {
     "node": ">=24"

--- a/theme/assets/scss/td/chroma/_light.scss
+++ b/theme/assets/scss/td/chroma/_light.scss
@@ -58,6 +58,7 @@
 /* LiteralNumberOct */ .chroma .mo { color:#40a070 }
 /* Operator */ .chroma .o { color:#666 }
 /* OperatorWord */ .chroma .ow { color:#007020;font-weight:bold }
+/* OperatorReserved */ .chroma .or { color:#666 }
 /* Comment */ .chroma .c { color:#60a0b0;font-style:italic }
 /* CommentHashbang */ .chroma .ch { color:#60a0b0;font-style:italic }
 /* CommentMultiline */ .chroma .cm { color:#60a0b0;font-style:italic }


### PR DESCRIPTION
- Contributes to #2581
- Upgrades the project's Hugo build from 0.160.1 to 0.163.1 (0.163.1 carries security fixes over 0.163.0):
  - Updates root `config.hugo_version` and docsy.dev `hugo-extended` pins.
  - Leaves the theme's minimum supported Hugo version at 0.158.0 - nothing in 0.159 through 0.163 is required by the theme.
- Migrates docsy.dev off the global `imaging.quality` config (deprecated in Hugo 0.163.0), then streamlines: drops quality/anchor settings that match Hugo's defaults (jpeg/webp quality 75, anchor Smart), keeping only the genuine override `resampleFilter: CatmullRom`. Generated images verified byte-identical before/after.
- Regenerates md-output goldens: Hugo 0.161 through 0.163 changed resized-image cache keys (`*_hu_<hash>` filenames); verified the churn is independent of the imaging config migration and content is otherwise byte-identical.
- Adds a lean changelog entry and refreshes the refcache.

Verification: baseline build at 0.163.0 showed exactly one deprecation notice (`imaging.quality`, as predicted), zero after migration; full `npm run test` green, including the mono-site and md-output suites. Risk surfaces from the 0.161 through 0.163 range checked empirically: PostCSS under the Node permission sandbox, npm-workspace/symlink handling, and `resources.GetRemote` under the stricter URL parsing - all clean.


