### PR TITLE
fix double v on version documentation

### DIFF
--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -24,7 +24,7 @@ site from scratch.
 At your Unix shell or Windows command line, run the following command:
 
 ```bash
-git clone --depth 1 --branch v{{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
+git clone --depth 1 --branch {{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
 cd  my-new-site
 hugo server
 ```
@@ -55,7 +55,7 @@ make a local working copy of the example site directly using `git clone`. As
 last parameter, give your chosen local repo name (here: `my-new-site`):
 
 ```bash
-git clone --depth 1 --branch v{{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
+git clone --depth 1 --branch {{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
 ```
 
 #### Option 2: Using the GitHub UI (local copy + associated GitHub repo)
@@ -69,7 +69,7 @@ easy:
    [Docsy example site](https://github.com/google/docsy-example).
 
 1. Use the dropdown for switching branches/tags to change to the latest released
-   tag `v{{% param "version" %}}`.
+   tag `{{% param "version" %}}`.
 
 1. Click the button **Use this template** and select the option
    `Create a new repository` from the dropdown.

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -45,7 +45,7 @@ hugo server
 hugo new site my-new-site
 cd  my-new-site
 hugo mod init github.com/me/my-new-site
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 (echo [module]^
 
 proxy = "direct"^
@@ -103,7 +103,7 @@ which holds the checksums for module verification.
 Next declare the Docsy theme module as a dependency for your site.
 
 ```bash
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 ```
 
 This command adds the `docsy` theme module to your definition file `go.mod`.

--- a/docsy.dev/content/en/docs/updating/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/updating/convert-site-to-module.md
@@ -14,7 +14,7 @@ Run the following from the command line:
 {{< tab header="Unix shell" lang="Bash" >}}
 cd /path/to/my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 sed -i '/theme = \["docsy"\]/d' config.toml
 mv config.toml hugo.toml
 cat >> hugo.toml <<EOL
@@ -28,7 +28,7 @@ hugo server
 {{< tab header="Windows command line" lang="Batchfile" >}}
 cd  my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 findstr /v /c:"theme = [\"docsy\"]" config.toml > hugo.toml
 (echo [module]^
 
@@ -63,7 +63,7 @@ This creates two new files, `go.mod` for the module definitions and `go.sum` whi
 Next declare the Docsy theme module as a dependency for your site.
 
 ```bash
-hugo mod get github.com/google/docsy@v{{% param "version" %}}
+hugo mod get github.com/google/docsy@{{% param "version" %}}
 ```
 
 This command adds the `docsy` theme module to your definition file `go.mod`.
@@ -176,9 +176,9 @@ To make sure that your configuration settings are correct, run the command `hugo
 ```bash
 hugo mod graph
 hugo: collected modules in 1092 ms
-github.com/me/my-existing-site github.com/google/docsy@v{{% param "version" %}}
-github.com/google/docsy@v{{% param "version" %}} github.com/twbs/bootstrap@v5.2.3+incompatible
-github.com/google/docsy@v{{% param "version" %}} github.com/FortAwesome/Font-Awesome@ v0.0.0-20230802202706-f0c25837a3fe
+github.com/me/my-existing-site github.com/google/docsy@{{% param "version" %}}
+github.com/google/docsy@{{% param "version" %}} github.com/twbs/bootstrap@v5.2.3+incompatible
+github.com/google/docsy@{{% param "version" %}} github.com/FortAwesome/Font-Awesome@ v0.0.0-20230802202706-f0c25837a3fe
 ```
 
 Make sure that three lines with dependencies `docsy`, `bootstrap` and `Font-Awesome` are listed. If not, please double check your config settings.

--- a/docsy.dev/content/en/docs/updating/updating-hugo-module.md
+++ b/docsy.dev/content/en/docs/updating/updating-hugo-module.md
@@ -28,7 +28,7 @@ done!
 > updating your theme, for example:
 >
 > ```bash
-> hugo mod get -u github.com/google/docsy@v{{% param "version" %}}
+> hugo mod get -u github.com/google/docsy@{{% param "version" %}}
 > ```
 >
 > Instead of a version tag, you can also specify a commit hash, for example:


### PR DESCRIPTION
- Supersedes https://github.com/google/docsy/pull/2635
- Right now docs shows: github.com/google/docsy@**vv**0.15.0.
- So drooping de `v` on `v{{% param "version" %}}` should fix the issue.