### PR TITLE
chore(site): switch Netlify badge to the documented canonical URL

### DIFF
--- a/docsy.dev/content/en/_index.md
+++ b/docsy.dev/content/en/_index.md
@@ -42,7 +42,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/content/en/tests/blocks-cover/color-gradient/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/color-gradient/index.md
@@ -43,7 +43,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-auto/index.md
@@ -43,7 +43,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-full/index.md
@@ -43,7 +43,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
+++ b/docsy.dev/content/en/tests/blocks-cover/height-min/index.md
@@ -45,7 +45,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/content/fr/_index.md
+++ b/docsy.dev/content/fr/_index.md
@@ -44,7 +44,7 @@ concentrer sur la création de contenu pour vos utilisateurs.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 {{% /blocks/lead %}}
 

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -3443,6 +3443,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:14:23.74052-05:00"
   },
+  "https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-12T21:31:34.241182-04:00"
+  },
   "https://www.netlify.com/docs/continuous-deployment/": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:49.228342-05:00"

--- a/docsy.dev/tests/md-output/goldens/fr/index.md
+++ b/docsy.dev/tests/md-output/goldens/fr/index.md
@@ -75,7 +75,7 @@ concentrer sur la création de contenu pour vos utilisateurs.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 
 </div>

--- a/docsy.dev/tests/md-output/goldens/index.md
+++ b/docsy.dev/tests/md-output/goldens/index.md
@@ -75,7 +75,7 @@ on creating great content for your users.
 [Hugo]: https://gohugo.io/
 [netlify]: https://www.netlify.com/
 [netlify-badge]:
-  https://www.netlify.com/img/global/badges/netlify-color-accent.svg
+  https://www.netlify.com/assets/badges/netlify-badge-color-accent.svg
 
 
 </div>


### PR DESCRIPTION
- Fixes #2598
- The badge previously pointed at the legacy `img/global/badges/netlify-color-accent.svg` path, which now `301`-redirects to Netlify's documented canonical badge URL. This switches our references to the canonical `assets/badges/netlify-badge-color-accent.svg` URL (per Netlify's [press/badges](https://www.netlify.com/press/#badges)), skipping the redirect hop and future-proofing the link.
- Changes:
  - Homepage badge link defs (en, fr)
  - The `blocks-cover` test pages that reference the badge
  - Regenerated md-output goldens and refcache
