### PR TITLE
Discover and link site favicons from the default partial, and add an icon-generation helper

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -22,6 +22,7 @@
     "docsy",
     "Docsy",
     "errorf",
+    "favicons",
     "fontawesome",
     "fortawesome",
     "Gantt",

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -93,6 +93,10 @@ writes `favicon.ico` and `apple-touch-icon.png` for you:
 path/to/docsy/scripts/gen-favicons.sh favicon.svg static/
 ```
 
+The script writes only the raster icons (`favicon.ico` and
+`apple-touch-icon.png`). If you also want an SVG favicon, copy your source SVG
+to `static/favicon.svg` yourself -- the partial links it directly.
+
 [ImageMagick]: https://imagemagick.org
 [rfg]: https://realfavicongenerator.net
 

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -64,23 +64,36 @@ in your text.
 
 ## Add your favicons
 
-The theme ships no default favicons. To add your own, create a set of favicon
-files, put them in your site project's `static` directory so they publish at the
-site root (where browsers probe for them), and link them by adding a
-`layouts/_partials/favicons.html` partial. For example:
+The theme ships no favicon files, but it **discovers and links** a set of
+conventionally named icons when you supply them: create your favicon files and
+put them in your site project's `static` directory so they publish at the site
+root (where browsers probe for them). The theme links whichever of these files
+it finds, in this order, with no partial or configuration required:
 
-```go-html-template
-<link rel="icon" href="{{ "favicon.ico" | relURL }}" sizes="16x16 32x32 48x48" />
-<link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml" />
-<link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | relURL }}" />
+| File                   | Link                                               |
+| ---------------------- | -------------------------------------------------- |
+| `favicon.ico`          | `rel="icon"` with `sizes="16x16 32x32 48x48"`      |
+| `favicon.svg`          | `rel="icon"` with `type="image/svg+xml"`           |
+| `favicon-32x32.png`    | `rel="icon"` with `type="image/png" sizes="32x32"` |
+| `favicon-16x16.png`    | `rel="icon"` with `type="image/png" sizes="16x16"` |
+| `apple-touch-icon.png` | `rel="apple-touch-icon"`                           |
+
+A modern `favicon.ico` plus an SVG and an `apple-touch-icon.png` covers
+practically every browser. To customize the links -- for example to add a web
+app manifest -- override the theme by adding your own
+`layouts/_partials/favicons.html` partial; use `relURL` so links stay correct
+when your site's `baseURL` includes a subpath.
+
+You can generate favicons from a single image with an online tool such as
+[favicon.io](https://favicon.io) or [RealFaviconGenerator][rfg]. If you have a
+source SVG and [ImageMagick][] installed, Docsy also ships a helper script that
+writes `favicon.ico` and `apple-touch-icon.png` for you:
+
+```sh
+path/to/docsy/scripts/gen-favicons.sh favicon.svg static/
 ```
 
-Using `relURL` keeps the links correct when your site's `baseURL` includes a
-subpath.
-
-You can generate favicons from a single image with a tool such as
-[favicon.io](https://favicon.io) or [RealFaviconGenerator][rfg].
-
+[ImageMagick]: https://imagemagick.org
 [rfg]: https://realfavicongenerator.net
 
 ## Add images

--- a/docsy.dev/content/en/docs/content/iconsimages.md
+++ b/docsy.dev/content/en/docs/content/iconsimages.md
@@ -78,9 +78,9 @@ it finds, in this order, with no partial or configuration required:
 | `favicon-16x16.png`    | `rel="icon"` with `type="image/png" sizes="16x16"` |
 | `apple-touch-icon.png` | `rel="apple-touch-icon"`                           |
 
-A modern `favicon.ico` plus an SVG and an `apple-touch-icon.png` covers
-practically every browser. To customize the links -- for example to add a web
-app manifest -- override the theme by adding your own
+A modern `favicon.ico` plus an SVG and an `apple-touch-icon.png` covers common
+browser and platform favicon needs. To customize the links -- for example to add
+a web app manifest -- override the theme by adding your own
 `layouts/_partials/favicons.html` partial; use `relURL` so links stay correct
 when your site's `baseURL` includes a subpath.
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -129,7 +129,12 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 
 **New**:
 
-- ...
+- **Favicon discovery**: the theme now discovers and links a site's
+  conventionally named favicon files (`favicon.ico`, `favicon.svg`,
+  `apple-touch-icon.png`, and optional 16/32px PNGs) when you place them in
+  `static/` -- no favicons partial required. A new `scripts/gen-favicons.sh`
+  helper generates the raster icons from a source SVG. See [Add your
+  favicons][favicons] ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
@@ -151,6 +156,7 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
   minimum supported Hugo version remains 0.158.0.
 
 [#2594]: https://github.com/google/docsy/pull/2594
+[#2357]: https://github.com/google/docsy/issues/2357
 [#2653]: https://github.com/google/docsy/pull/2653
 [#2578]: https://github.com/google/docsy/pull/2578
 [favicons]: /docs/content/iconsimages/#add-your-favicons

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -129,17 +129,20 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 
 **New**:
 
-- **Favicon discovery**: the theme now discovers and links a site's
-  conventionally named favicon files (`favicon.ico`, `favicon.svg`,
-  `apple-touch-icon.png`, and optional 16/32px PNGs) when you place them in
-  `static/` -- no favicons partial required. A new `scripts/gen-favicons.sh`
-  helper generates the raster icons from a source SVG. See [Add your
-  favicons][favicons] ([#2357][]).
+- **Favicon discovery**: you can now drop a site's conventionally named favicon
+  files (`favicon.ico`, `favicon.svg`, `apple-touch-icon.png`, and optional
+  16/32px PNGs) into `static/` and the theme discovers and links them -- no
+  favicons partial required. A new `scripts/gen-favicons.sh` helper generates
+  the raster icons from a source SVG. See [Add your favicons][favicons]
+  ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
-- **Default favicons** removed from the theme; sites now supply their own. See
-  [Add your favicons][favicons] ([#2653][]).
+- **Default favicons** removed from the theme; sites now supply their own.
+  Conventional `static/` filenames are discovered and linked automatically (see
+  **Favicon discovery** under **New** above), so a custom partial is only needed
+  for non-default filenames or extra links. See [Add your favicons][favicons]
+  ([#2653][]).
 - Raised the theme's minimum supported Hugo version to
   **[0.158.0][hugo-0.158.0]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
   Theme templates now use the language APIs introduced in Hugo 0.158.0. Note:

--- a/docsy.dev/layouts/_partials/favicons.html
+++ b/docsy.dev/layouts/_partials/favicons.html
@@ -1,3 +1,0 @@
-<link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />
-<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-<link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -1207,6 +1207,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:19:18.890513-05:00"
   },
+  "https://github.com/google/docsy/issues/2357": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-14T05:53:49.272122-04:00"
+  },
   "https://github.com/google/docsy/issues/2390": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:59.671894-05:00"
@@ -2454,6 +2458,10 @@
   "https://help.github.com/articles/about-pull-requests/": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:18:49.951907-05:00"
+  },
+  "https://imagemagick.org": {
+    "StatusCode": 200,
+    "LastSeen": "2026-06-14T05:53:48.743381-04:00"
   },
   "https://in-toto.io": {
     "StatusCode": 206,

--- a/docsy.dev/tests/favicons/theme-defaults.test.mjs
+++ b/docsy.dev/tests/favicons/theme-defaults.test.mjs
@@ -102,7 +102,7 @@ test('theme emits no favicon links when the site supplies none', () => {
   assert.equal(buildSiteFavicons(), '');
 });
 
-// The smart default partial discovers conventionally named files a site drops
+// The default partial discovers conventionally named files a site drops
 // in `static/` and links them, with no partial or config of its own.
 test('theme discovers and links a site favicon from static/ with no partial', () => {
   const links = buildSiteFavicons(undefined, 'http://localhost/', [
@@ -136,6 +136,23 @@ test('theme does not link favicon files a site has not supplied', () => {
     'favicon.ico',
   ]);
   assert.doesNotMatch(links, /apple-touch-icon|favicon\.svg/);
+});
+
+// Lock the optional PNG-variant rows of the discovery table: when a site
+// supplies the 16/32px PNGs, the partial links both with the right type/sizes.
+test('theme discovers and links the optional 16/32px PNG variants from static/', () => {
+  const links = buildSiteFavicons(undefined, 'http://localhost/', [
+    'favicon-32x32.png',
+    'favicon-16x16.png',
+  ]);
+  assert.match(
+    links,
+    /rel="icon" href="\/favicon-32x32\.png" type="image\/png" sizes="32x32"/,
+  );
+  assert.match(
+    links,
+    /rel="icon" href="\/favicon-16x16\.png" type="image\/png" sizes="16x16"/,
+  );
 });
 
 test('discovered favicons pick up a baseURL subpath via relURL', () => {

--- a/docsy.dev/tests/favicons/theme-defaults.test.mjs
+++ b/docsy.dev/tests/favicons/theme-defaults.test.mjs
@@ -32,9 +32,14 @@ before(() => {
 });
 
 // Build a throwaway site that uses the theme, optionally with a site-supplied
-// favicons partial, and return the favicon `<link>` tags it emits. Guards #2595:
-// the theme must ship no default favicons of its own.
-function buildSiteFavicons(partial, baseURL = 'http://localhost/') {
+// favicons partial and/or files in `static/`, and return the favicon `<link>`
+// tags it emits. Guards #2595: the theme ships no icon files of its own, only
+// the logic that links the ones a site supplies.
+function buildSiteFavicons(
+  partial,
+  baseURL = 'http://localhost/',
+  staticFiles = [],
+) {
   const dir = mkdtempSync(join(tmpdir(), 'docsy-theme-favicons-'));
   try {
     writeFileSync(
@@ -49,6 +54,13 @@ function buildSiteFavicons(partial, baseURL = 'http://localhost/') {
     );
     mkdirSync(join(dir, 'content'));
     writeFileSync(join(dir, 'content', '_index.md'), '---\ntitle: Home\n---\n');
+    if (staticFiles.length) {
+      mkdirSync(join(dir, 'static'), { recursive: true });
+      // Existence is all the partial checks; content is irrelevant here.
+      for (const file of staticFiles) {
+        writeFileSync(join(dir, 'static', file), '');
+      }
+    }
     if (partial !== undefined) {
       mkdirSync(join(dir, 'layouts', '_partials'), { recursive: true });
       writeFileSync(
@@ -86,8 +98,51 @@ function buildSiteFavicons(partial, baseURL = 'http://localhost/') {
   }
 }
 
-test('theme emits no favicon links without a site override', () => {
+test('theme emits no favicon links when the site supplies none', () => {
   assert.equal(buildSiteFavicons(), '');
+});
+
+// The smart default partial discovers conventionally named files a site drops
+// in `static/` and links them, with no partial or config of its own.
+test('theme discovers and links a site favicon from static/ with no partial', () => {
+  const links = buildSiteFavicons(undefined, 'http://localhost/', [
+    'favicon.ico',
+  ]);
+  assert.equal(
+    links,
+    '<link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48" />\n',
+  );
+});
+
+test('theme discovers and links the full conventional favicon set from static/', () => {
+  const links = buildSiteFavicons(undefined, 'http://localhost/', [
+    'favicon.ico',
+    'favicon.svg',
+    'apple-touch-icon.png',
+  ]);
+  assert.match(
+    links,
+    /rel="icon" href="\/favicon\.ico" sizes="16x16 32x32 48x48"/,
+  );
+  assert.match(
+    links,
+    /rel="icon" href="\/favicon\.svg" type="image\/svg\+xml"/,
+  );
+  assert.match(links, /rel="apple-touch-icon" href="\/apple-touch-icon\.png"/);
+});
+
+test('theme does not link favicon files a site has not supplied', () => {
+  const links = buildSiteFavicons(undefined, 'http://localhost/', [
+    'favicon.ico',
+  ]);
+  assert.doesNotMatch(links, /apple-touch-icon|favicon\.svg/);
+});
+
+test('discovered favicons pick up a baseURL subpath via relURL', () => {
+  const links = buildSiteFavicons(undefined, 'https://example.org/sub/path/', [
+    'favicon.ico',
+  ]);
+  assert.match(links, /href="\/sub\/path\/favicon\.ico"/);
 });
 
 // Sanity check: a site-supplied partial is emitted and detected, so the

--- a/scripts/gen-favicons.sh
+++ b/scripts/gen-favicons.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Generate the raster favicons that Docsy's default favicons partial discovers
+# (favicon.ico and apple-touch-icon.png) from a single source SVG. Hugo cannot
+# rasterize SVG or write .ico, so these are built ahead of time with ImageMagick.
+# Keep your favicon.svg alongside the output; the partial links it directly.
+#
+# Usage:
+#   scripts/gen-favicons.sh SOURCE.svg [OUTPUT_DIR]
+#
+# OUTPUT_DIR defaults to the current directory; point it at your site's static/.
+
+set -euo pipefail
+
+src="${1:-}"
+out="${2:-.}"
+
+if [[ -z "${src}" ]]; then
+  echo "Usage: $0 SOURCE.svg [OUTPUT_DIR]" >&2
+  exit 2
+fi
+
+if ! command -v magick >/dev/null 2>&1; then
+  echo "error: ImageMagick (magick) not found; install it from https://imagemagick.org" >&2
+  exit 1
+fi
+
+if [[ ! -f "${src}" ]]; then
+  echo "error: source SVG not found: ${src}" >&2
+  exit 1
+fi
+
+mkdir -p "${out}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# favicon.ico: 16/32/48, transparent.
+for s in 16 32 48; do
+  magick -background none "${src}" -resize "${s}x${s}" "${tmp}/ico_${s}.png"
+done
+magick "${tmp}/ico_16.png" "${tmp}/ico_32.png" "${tmp}/ico_48.png" "${out}/favicon.ico"
+
+# apple-touch-icon: 180x180, opaque white. iOS masks the corners and composites
+# transparency against black, so the background must be opaque.
+magick -background white "${src}" -resize 160x160 \
+  -gravity center -extent 180x180 -depth 8 -strip "${out}/apple-touch-icon.png"
+
+echo "wrote: ${out}/favicon.ico ${out}/apple-touch-icon.png"

--- a/scripts/gen-favicons.test.mjs
+++ b/scripts/gen-favicons.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./gen-favicons.sh', import.meta.url));
+const hasMagick =
+  spawnSync('magick', ['-version'], { encoding: 'utf8' }).status === 0;
+
+// Derives the raster favicons Hugo can't generate (favicon.ico, apple-touch).
+test(
+  'gen-favicons.sh derives root icon assets from an SVG',
+  { skip: hasMagick ? false : 'ImageMagick (magick) not installed' },
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'docsy-gen-favicons-'));
+    const svg = join(dir, 'favicon.svg');
+    writeFileSync(
+      svg,
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">' +
+        '<rect width="16" height="16" fill="#0099cc"/></svg>\n',
+    );
+    const res = spawnSync('bash', [script, svg, dir], { encoding: 'utf8' });
+    assert.equal(res.status, 0, res.stderr);
+    assert.ok(existsSync(join(dir, 'favicon.ico')), 'favicon.ico created');
+    assert.ok(
+      existsSync(join(dir, 'apple-touch-icon.png')),
+      'apple-touch-icon.png created',
+    );
+  },
+);
+
+test('gen-favicons.sh fails clearly without a source argument', () => {
+  const res = spawnSync('bash', [script], { encoding: 'utf8' });
+  assert.equal(res.status, 2);
+  assert.match(res.stderr, /Usage:/);
+});

--- a/scripts/gen-favicons.test.mjs
+++ b/scripts/gen-favicons.test.mjs
@@ -1,3 +1,4 @@
+// cSpell:ignore magick
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';

--- a/scripts/gen-favicons.test.mjs
+++ b/scripts/gen-favicons.test.mjs
@@ -25,11 +25,35 @@ test(
     );
     const res = spawnSync('bash', [script, svg, dir], { encoding: 'utf8' });
     assert.equal(res.status, 0, res.stderr);
-    assert.ok(existsSync(join(dir, 'favicon.ico')), 'favicon.ico created');
-    assert.ok(
-      existsSync(join(dir, 'apple-touch-icon.png')),
-      'apple-touch-icon.png created',
+
+    const ico = join(dir, 'favicon.ico');
+    const apple = join(dir, 'apple-touch-icon.png');
+    assert.ok(existsSync(ico), 'favicon.ico created');
+    assert.ok(existsSync(apple), 'apple-touch-icon.png created');
+
+    // Guard the script's contract: the .ico bundles 16/32/48px frames and the
+    // Apple touch icon is the expected 180x180.
+    const frames = spawnSync(
+      'magick',
+      ['identify', '-format', '%wx%h\n', ico],
+      {
+        encoding: 'utf8',
+      },
     );
+    assert.equal(frames.status, 0, frames.stderr);
+    for (const size of ['16x16', '32x32', '48x48']) {
+      assert.ok(
+        frames.stdout.includes(size),
+        `favicon.ico missing ${size} frame; got:\n${frames.stdout}`,
+      );
+    }
+    const appleSize = spawnSync(
+      'magick',
+      ['identify', '-format', '%wx%h', apple],
+      { encoding: 'utf8' },
+    );
+    assert.equal(appleSize.status, 0, appleSize.stderr);
+    assert.equal(appleSize.stdout, '180x180');
   },
 );
 

--- a/theme/layouts/_partials/favicons.html
+++ b/theme/layouts/_partials/favicons.html
@@ -1,1 +1,23 @@
-{{/* No default favicons: sites supply their own. */ -}}
+{{- /*
+  Discover the conventionally named favicons a site publishes at its root via
+  `static/` and emit a `<link>` for each one present. The theme ships no icon
+  files of its own (#2595); a site that drops these files in `static/` gets the
+  matching `<link>` tags with no partial and no config. `relURL` keeps hrefs
+  correct under a `baseURL` subpath. Override by adding your own
+  `layouts/_partials/favicons.html`.
+*/ -}}
+{{- $icons := slice
+  (dict "file" "favicon.ico" "rel" "icon" "sizes" "16x16 32x32 48x48")
+  (dict "file" "favicon.svg" "rel" "icon" "type" "image/svg+xml")
+  (dict "file" "favicon-32x32.png" "rel" "icon" "type" "image/png" "sizes" "32x32")
+  (dict "file" "favicon-16x16.png" "rel" "icon" "type" "image/png" "sizes" "16x16")
+  (dict "file" "apple-touch-icon.png" "rel" "apple-touch-icon")
+-}}
+{{- range $icons -}}
+{{- if os.FileExists (printf "static/%s" .file) -}}
+{{- $attrs := printf `rel=%q href=%q` .rel (.file | relURL) -}}
+{{- with .type }}{{ $attrs = printf "%s type=%q" $attrs . }}{{ end -}}
+{{- with .sizes }}{{ $attrs = printf "%s sizes=%q" $attrs . }}{{ end -}}
+{{ printf "<link %s />" $attrs | safeHTML }}
+{{ end -}}
+{{- end -}}


### PR DESCRIPTION
- Contributes to #2357
- Closes #2652 by superseding it
  - Replaces that draft's in-Hugo generation approach (resize one source image, publish via `resources.Copy`) with a simpler pass-through partial, after research showed Hugo cannot rasterize SVG or emit true `.ico`, so the most-probed icons (`/favicon.ico` ~49% of probes) can never be generated and must be supplied as files anyway
- Builds on the merged #2653 (empty default partial), keeping the theme free of bundled favicon artwork (#2595) while removing the need for most sites to write a partial at all

**What changed**:

- Replaces the theme's empty `favicons.html` with a default partial that **discovers and links** the conventionally named favicons a site publishes via `static/` (`favicon.ico`, `favicon.svg`, `favicon-32x32.png`, `favicon-16x16.png`, `apple-touch-icon.png`); a site that drops these files in `static/` gets the matching `<link>` tags with no partial and no config
  - Uses `relURL` so hrefs stay correct under a `baseURL` subpath
  - Emits links via `safeHTML` so the `+` in `image/svg+xml` is not escaped to `&#43;`
- Adds `scripts/gen-favicons.sh`, which derives `favicon.ico` and `apple-touch-icon.png` from a single source SVG via ImageMagick (the formats Hugo cannot produce), with a companion test that skips when ImageMagick is absent
- Converges docsy.dev onto the theme default by dropping its bespoke partial; the existing golden test confirms the built output is byte-identical
- Extends the theme-defaults tests with discovery cases (single file, full set, absent files, `baseURL` subpath)
- Rewrites the "Add your favicons" user guide for the zero-partial convention and adds a changelog entry
