### PR TITLE
Upgrade Hugo to 0.163.2

### DIFF
--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -155,7 +155,7 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
-- Upgraded the project's Hugo build to [0.163.1][hugo-0.163.1]. The theme's
+- Upgraded the project's Hugo build to [0.163.2][hugo-0.163.2]. The theme's
   minimum supported Hugo version remains 0.158.0.
 
 [#2594]: https://github.com/google/docsy/pull/2594
@@ -163,7 +163,7 @@ For the full list of changes, see the [0.15.1][] or [0.16.0][] release page.
 [#2653]: https://github.com/google/docsy/pull/2653
 [#2578]: https://github.com/google/docsy/pull/2578
 [favicons]: /docs/content/iconsimages/#add-your-favicons
-[hugo-0.163.1]: https://github.com/gohugoio/hugo/releases/tag/v0.163.1
+[hugo-0.163.2]: https://github.com/gohugoio/hugo/releases/tag/v0.163.2
 
 [**Experimental**](#experimental):
 

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -51,7 +51,7 @@
     "afdocs": "^0.9.2",
     "autoprefixer": "^10.4.27",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.1",
+    "hugo-extended": "0.163.2",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "postcss-cli": "^11.0.1",

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -699,6 +699,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-12T10:47:00.544108-04:00"
   },
+  "https://github.com/gohugoio/hugo/releases/tag/v0.163.2": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-16T12:57:45.131513-04:00"
+  },
   "https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:07.239646-05:00"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^3.8.1"
   },
   "config": {
-    "hugo_version": "0.163.1"
+    "hugo_version": "0.163.2"
   },
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
- Contributes to #2581
- Upgrades the project's Hugo build from 0.163.1 to 0.163.2:
  - Updates root `config.hugo_version` and docsy.dev `hugo-extended` pins.
  - Keeps the theme's minimum supported Hugo version at 0.158.0, since no new syntax or features are adopted.
- Updates the changelog entry and refreshes the refcache (caches the new v0.163.2 release link).
- Verifies the bump with a full, green `npm run ci:test`: the build logs no Hugo deprecation notices, and the only generated-file change is the cached refcache entry.
- Notes that 0.163.2 is a patch over 0.163.1 with two upstream changes, neither of which affects behavior the theme exercises:
  - Fixes a PostCSS `ERR_ACCESS_DENIED` regression from the 0.161 Node-permission model.
  - Standardizes Hugo's behavior when external markup converters (e.g. Pandoc, rst) are missing.

```console
$ (cd public && git diff -bw --ignore-blank-lines -I 'Hugo 0.16|buildDate|0\.163\.' -- ':(exclude)*.xml') | grep ^diff
diff --git a/fr/project/about/changelog/index.html b/fr/project/about/changelog/index.html
diff --git a/project/about/changelog/index.html b/project/about/changelog/index.html
diff --git a/refcache.json b/refcache.json
```