### PR TITLE
Upgrade project Hugo build to 0.163.3

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 024-over-main-b3ce9274
+  buildId: &tdBuildId 025-over-main-5998cf5e
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 024-over-main-b3ce9274
+  buildId: &tdBuildId 025-over-main-5998cf5e
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 024-over-main-b3ce9274
+  buildId: &tdBuildId 025-over-main-5998cf5e
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -161,7 +161,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
-- Upgraded the project's Hugo build to [0.163.2][hugo-0.163.2]. The theme's
+- Upgraded the project's Hugo build to [0.163.3][hugo-0.163.3]. The theme's
   minimum supported Hugo version remains 0.158.0. See [Hugo 0.158+ upgrade
   guide][] ([#2581][], [#2648][], [#2649][], [#2658][]).
 - Reorganized the repository package boundary: `theme/package.json` owns theme
@@ -202,7 +202,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
 [hugo-0.158.0]: https://github.com/gohugoio/hugo/releases/tag/v0.158.0
-[hugo-0.163.2]: https://github.com/gohugoio/hugo/releases/tag/v0.163.2
+[hugo-0.163.3]: https://github.com/gohugoio/hugo/releases/tag/v0.163.3
 <!-- prettier-ignore-end -->
 
 ## v0.15.0 {#v0.15.0}

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -55,7 +55,7 @@
     "afdocs": "^0.9.2",
     "autoprefixer": "^10.4.27",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.2",
+    "hugo-extended": "0.163.3",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "postcss-cli": "^11.0.1",

--- a/docsy.dev/static/refcache.json
+++ b/docsy.dev/static/refcache.json
@@ -707,6 +707,10 @@
     "StatusCode": 206,
     "LastSeen": "2026-06-16T12:57:45.131513-04:00"
   },
+  "https://github.com/gohugoio/hugo/releases/tag/v0.163.3": {
+    "StatusCode": 206,
+    "LastSeen": "2026-06-26T10:30:47.005126-04:00"
+  },
   "https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md": {
     "StatusCode": 206,
     "LastSeen": "2026-02-11T11:24:07.239646-05:00"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+024-over-main-b3ce9274",
+  "version": "0.15.1-dev+025-over-main-5998cf5e",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -92,7 +92,7 @@
     "prettier": "^3.8.1"
   },
   "config": {
-    "hugo_version": "0.163.2"
+    "hugo_version": "0.163.3"
   },
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
- **Preview(s)**:
  - [Changelog (`#next` section)](https://deploy-preview-2664--docsydocs.netlify.app/project/about/changelog/#next)
- Bumps the project's Hugo build from 0.163.2 to **0.163.3** (`config.hugo_version` and `hugo-extended`); the theme support floor stays at **0.158.0** (no new syntax adopted, so this is a build-only bump).
- 0.163.3 is a patch release — code-block language escaping (XSS hardening), PostCSS/Babel config-variant resolution (`.mjs`/`.cjs`), and an `uglyURLs` page/section collision fix. None require migration for Docsy: docsy.dev builds clean with zero deprecation notices and no generated-file drift.
- Updates the changelog's project-Hugo-build entry and refreshes the refcache and dev build-ID stamp.

The 0.16.0 release blog posts (release report + Hugo upgrade guide) are bumped to 0.163.3 separately as a release-artifacts follow-up.