### PR TITLE
Fix Lychee bin entry point so npx/PATH invocations run

### DIFF
--- a/scripts/lychee/README.md
+++ b/scripts/lychee/README.md
@@ -21,7 +21,13 @@ a self-contained, cached link-checking setup.
 ## Usage
 
 For a site that installs Docsy as an npm package, the bins are on your project's
-`PATH`:
+`PATH`. Until Docsy is published to the npm registry, install it from GitHub:
+
+```sh
+npm install --save-dev github:google/docsy
+```
+
+Then run the bins with `npx`:
 
 ```sh
 npx lychee-norm-cache    # check links, then sort/normalize the cache
@@ -33,16 +39,17 @@ any extra arguments to lychee. Run either tool with `--help` for its full
 options, and `lychee --help` for the link-checking flags `lychee-norm-cache`
 forwards (e.g. `--offline`, `--max-cache-age 0`).
 
-For a Hugo module or Git submodule install, run the tools directly:
+For a Git submodule install, run the tools directly — the submodule includes
+this `scripts/` directory:
 
 ```sh
-node DOCSY_DIR/scripts/lychee/check/index.mjs
-node DOCSY_DIR/scripts/lychee/refcache/index.mjs --summary
+node themes/docsy/scripts/lychee/check/index.mjs
+node themes/docsy/scripts/lychee/refcache/index.mjs --summary
 ```
 
-Here `DOCSY_DIR` is your Docsy install directory: `themes/docsy` for a Git
-submodule, or the path printed by
-`go list -m -f '{{.Dir}}' github.com/google/docsy` for a Hugo module.
+A Hugo-module install doesn't expose these scripts (they live outside the
+theme's Hugo module), so use the npm-package approach above: add Docsy as a
+devDependency, then run the `npx` commands.
 
 <!-- prettier-ignore-start -->
 [Lychee]: https://github.com/lycheeverse/lychee

--- a/scripts/lychee/check/index.mjs
+++ b/scripts/lychee/check/index.mjs
@@ -9,6 +9,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const INSTALL_HINT = 'https://github.com/lycheeverse/lychee#installation';
 
@@ -95,6 +96,16 @@ function main(argv) {
   return status;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Real-path compare, not `file://${argv[1]}`: npm links bins as symlinks, so
+// argv[1] is the symlink while import.meta.url is the real path.
+function isEntryPoint() {
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint()) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/lychee/check/index.test.mjs
+++ b/scripts/lychee/check/index.test.mjs
@@ -7,6 +7,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { resolveToken, sortCacheText } from './index.mjs';
@@ -87,3 +90,29 @@ test('--help prints usage and exits 0 without needing lychee', () => {
   assert.equal(r.status, 0, 'help exits 0');
   assert.match(r.stdout, /Usage: lychee-norm-cache/, 'help prints usage');
 });
+
+test(
+  'runs when invoked through a bin symlink (npx)',
+  { skip: process.platform === 'win32' ? 'POSIX symlink bins only' : false },
+  () => {
+    // A naive `file://${argv[1]}` guard misses the symlink and silently skips
+    // main(), so `npx lychee-norm-cache` would do nothing.
+    const script = fileURLToPath(new URL('./index.mjs', import.meta.url));
+    const dir = mkdtempSync(join(tmpdir(), 'lnc-'));
+    const link = join(dir, 'lychee-norm-cache');
+    symlinkSync(script, link);
+    try {
+      const r = spawnSync(process.execPath, [link, '--help'], {
+        encoding: 'utf8',
+      });
+      assert.equal(r.status, 0, 'help exits 0');
+      assert.match(
+        r.stdout,
+        /Usage: lychee-norm-cache/,
+        'main ran via the symlink',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);

--- a/scripts/lychee/refcache/index.mjs
+++ b/scripts/lychee/refcache/index.mjs
@@ -6,7 +6,8 @@
 // it contains a comma, so STATUS and TIMESTAMP are read from the final two
 // fields.
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const DAY = 86400;
 const BUCKET_COUNT = 5;
@@ -316,6 +317,16 @@ function main(argv) {
   if (writeLines) writeFileSync(args.path, writeLines.join('\n'));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Real-path compare, not `file://${argv[1]}`: npm links bins as symlinks, so
+// argv[1] is the symlink while import.meta.url is the real path.
+function isEntryPoint() {
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+}
+
+if (isEntryPoint()) {
   main(process.argv.slice(2));
 }

--- a/scripts/lychee/refcache/index.test.mjs
+++ b/scripts/lychee/refcache/index.test.mjs
@@ -4,6 +4,11 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   parseArgs,
@@ -240,3 +245,27 @@ test('runOps without a prune does not rewrite the file', () => {
   assert.equal(pruned, 0, 'nothing pruned');
   assert.equal(writeLines, null, 'no write when nothing changed');
 });
+
+// --- CLI entry point ---
+
+test(
+  'runs when invoked through a bin symlink (npx)',
+  { skip: process.platform === 'win32' ? 'POSIX symlink bins only' : false },
+  () => {
+    // A naive `file://${argv[1]}` guard misses the symlink and silently skips
+    // main(), so `npx refcache` would do nothing.
+    const script = fileURLToPath(new URL('./index.mjs', import.meta.url));
+    const dir = mkdtempSync(join(tmpdir(), 'refcache-'));
+    const link = join(dir, 'refcache');
+    symlinkSync(script, link);
+    try {
+      const r = spawnSync(process.execPath, [link, '--help'], {
+        encoding: 'utf8',
+      });
+      assert.equal(r.status, 0, 'help exits 0');
+      assert.match(r.stdout, /Usage: refcache/, 'main ran via the symlink');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
- Fixes the entry-point guard in the `lychee-norm-cache` and `refcache` bins: ``import.meta.url === `file://${process.argv[1]}` `` never matches for symlinked bins (npm links bins as symlinks), so `npx lychee-norm-cache` silently skipped `main()` and exited 0 — the bins ran only via a direct `node path/to/index.mjs`, which is how `docsy.dev` and the unit tests invoke them, so it went unnoticed.
  - Compares real paths instead (`realpathSync(argv[1])` vs `fileURLToPath(import.meta.url)`), so the bins work as the `npx` / PATH commands npm consumers invoke.
  - Adds a symlink regression test to each bin, skipped on Windows where bin shims are `.cmd` wrappers rather than symlinks.
- Corrects `scripts/lychee/README.md`: the Hugo-module instruction pointed at a `go list` path with no `scripts/`; documents adding Docsy as a devDependency (from GitHub until it ships to npm) and running the bins with `npx`, and fixes the Git-submodule path.