### PR TITLE
Get-started: reconcile install docs with 0.16 changes

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -787,6 +787,7 @@ https://mhchem.github.io/MathJax-mhchem/#pu,200,1782498236
 https://mhchem.github.io/MathJax-mhchem/,200,1782498236
 https://mostlydocs.netlify.app/,200,1782498245
 https://netlify.com/,200,1782563367
+https://nodejs.org/,200,1782913422
 https://nodejs.org/en/,200,1782563367
 https://nodejs.org/en/about/releases/,200,1782563368
 https://nodejs.org/en/download/,200,1782563367

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -108,58 +108,38 @@ If no `git` client is installed on your system yet, go to the
 [Git website](https://git-scm.com/), download the installer for your system
 architecture and execute it. Afterwards, check for a successful installation.
 
-## Install PostCSS
+## Install Node.js
 
-To build or update your site's CSS resources, you also need
-[`PostCSS`](https://postcss.org/) to create the final assets. If you need to
-install it, you must have a recent version of [NodeJS](https://nodejs.org/en/)
-installed on your machine so you can use `npm`, the Node package manager. By
-default `npm` installs tools under the directory where you run
-[`npm install`](https://docs.npmjs.com/cli/v10/commands/npm-install#description):
+Docsy sources its Bootstrap and Font Awesome assets from npm, so you need
+[Node.js](https://nodejs.org/) (which provides `npm`, the Node package manager)
+to install them. Install or upgrade to the active [long-term support (LTS)
+release][node-lts], then check your version:
 
 ```bash
-npm install -D autoprefixer
-npm install -D postcss-cli
+node -v
 ```
 
-Starting in
-[version 8 of `postcss-cli`](https://github.com/postcss/postcss-cli/blob/master/CHANGELOG.md),
-you must also separately install `postcss`:
+You install these assets when you create your site, using `hugo mod npm pack`
+followed by `npm install`, as described in the next steps.
+
+## Install PostCSS (optional) {#install-postcss}
+
+Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
+sites don't need it. Install PostCSS only if:
+
+- your site has a **right-to-left (RTL)** language (Docsy uses `rtlcss` to
+  generate RTL styles), or
+- you post-process your own CSS with a project-root
+  `postcss.config.{js,mjs,cjs}` file.
+
+If either applies, install PostCSS from your project root:
 
 ```bash
-npm install -D postcss
+npm install --save-dev autoprefixer postcss postcss-cli
 ```
 
-Note that versions of `PostCSS` later than 5.0.1 will not load `autoprefixer` if
-installed [globally](https://flaviocopes.com/npm-packages-local-global/), you
-must use a local install.
-
-## Install/Upgrade Node.js
-
-To ensure you can properly build your site beyond executing `hugo server`, you
-must have the
-[latest long term support (LTS) Version](https://nodejs.org/en/about/releases/)
-of Node.js. If you do not have the latest LTS version, you may see one of the
-following errors:
-
-```
-Error: Error building site: POSTCSS: failed to transform "scss/main.css" (text/css): Unexpected identifier
-#OR
-/home/user/repos/my-new-site/themes/docsy/node_modules/hugo-extended/postinstall.js:1
-import install from "./lib/install.js";
-       ^^^^^^^
-
-SyntaxError: Unexpected identifier
-    at Module._compile (internal/modules/cjs/loader.js:723:23)
-    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
-    at Module.load (internal/modules/cjs/loader.js:653:32)
-    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
-    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
-    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
-    at startup (internal/bootstrap/node.js:283:19)
-    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
-
-```
+For more about this change, see [PostCSS is opt-in for non-RTL
+sites][blog-postcss] in the 0.16.0 release notes.
 
 ## What's next?
 
@@ -169,4 +149,6 @@ site
 - [Start with a prepopulated site (for beginners)](/docs/get-started/docsy-as-module/example-site-as-template/)
 - [Start site from scratch (for experts)](/docs/get-started/docsy-as-module/start-from-scratch/)
 
+[blog-postcss]: /blog/2026/0.16.0/#postcss
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
+[node-lts]: https://nodejs.org/en/about/releases/

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -119,8 +119,8 @@ release][node-lts], then check your version:
 node -v
 ```
 
-You install these assets when you create your site, using `hugo mod npm pack`
-followed by `npm install`, as described in the next steps.
+You install these assets when you create your site, as described in the next
+steps.
 
 ## Install PostCSS (optional) {#install-postcss}
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -32,27 +32,31 @@ At your command prompt, run the following:
 hugo new site my-new-site
 cd  my-new-site
 hugo mod init github.com/me/my-new-site
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 cat >> hugo.toml <<EOL
 [module]
 proxy = "direct"
 [[module.imports]]
-path = "github.com/google/docsy"
+path = "github.com/google/docsy/theme"
 EOL
+hugo mod npm pack
+npm install
 hugo server
 {{< /tab >}}
 {{< tab header="Windows command line" lang="Batchfile" >}}
 hugo new site my-new-site
 cd  my-new-site
 hugo mod init github.com/me/my-new-site
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 (echo [module]^
 
 proxy = "direct"^
 
 [[module.imports]]^
 
-path = "github.com/google/docsy") >> hugo.toml
+path = "github.com/google/docsy/theme") >> hugo.toml
+hugo mod npm pack
+npm install
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
@@ -103,7 +107,7 @@ which holds the checksums for module verification.
 Next declare the Docsy theme module as a dependency for your site.
 
 ```bash
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 ```
 
 This command adds the `docsy` theme module to your definition file `go.mod`.
@@ -120,12 +124,12 @@ Add the settings in the following snippet at the end of your site's
 [module]
   proxy = "direct"
   # uncomment line below for temporary local development of module
-  # replacements = "github.com/google/docsy -> ../../docsy"
+  # replacements = "github.com/google/docsy/theme -> ../../docsy/theme"
   [module.hugoVersion]
     extended = true
     min = "{{% param "hugoMinVersion" %}}"
   [[module.imports]]
-    path = "github.com/google/docsy"
+    path = "github.com/google/docsy/theme"
     disable = false
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
@@ -135,7 +139,7 @@ module:
     extended: true
     min: {{% param "hugoMinVersion" %}}
   imports:
-    - path: github.com/google/docsy
+    - path: github.com/google/docsy/theme
       disable: false
 {{< /tab >}}
 {{< tab header="hugo.json"  lang="json" >}}
@@ -148,7 +152,7 @@ module:
     },
     "imports": [
       {
-        "path": "github.com/google/docsy",
+        "path": "github.com/google/docsy/theme",
         "disable": false
       }
     ]
@@ -162,6 +166,20 @@ You can find details of what these configuration settings do in the
 [Hugo modules documentation](https://gohugo.io/configuration/module/#top-level-settings).
 Depending on your environment you may need to tweak them slightly, for example
 by adding a proxy to use when downloading remote modules.
+
+### Install theme npm dependencies
+
+Docsy sources its Bootstrap and Font Awesome assets from npm. Consolidate the
+theme's npm dependencies into your project's `package.json` and install them:
+
+```bash
+hugo mod npm pack
+npm install
+```
+
+Re-run `hugo mod npm pack` whenever you [update Docsy](/docs/updating/); Hugo
+warns when the dependency set drifts. For background, see [Bootstrap and Font
+Awesome via npm][blog-npm-deps] in the 0.16.0 release notes.
 
 ### Preview your site
 
@@ -193,5 +211,6 @@ from scratch as it provides defaults for many required configuration parameters.
   [Examples and templates](/examples/).
 - [Publish your site](/docs/deployment/).
 
+[blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [configuration file]:
   https://gohugo.io/configuration/introduction/#configuration-file

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -116,24 +116,22 @@ shown):
 nvm install --lts
 ```
 
-### Install PostCSS
+### Install PostCSS (optional) {#install-postcss}
 
-To build or update your site's CSS resources, you'll also need
-[PostCSS](https://postcss.org/). Install it using the Node package manager,
-`npm`.
+Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
+sites don't need it. Install PostCSS only if your site has a **right-to-left
+(RTL)** language (Docsy uses `rtlcss` to generate RTL styles) or you
+post-process your own CSS with a project-root `postcss.config.{js,mjs,cjs}`
+file.
 
-> [!IMPORTANT] IMPORTANT: Check your Node version
->
-> The PostCSS package installed by some older versions of Node is incompatible
-> with Docsy. Check your version of Node against the **active [LTS release][]**
-> and upgrade, if necessary. For details, see
-> [Node: Get the latest LTS release](#node-get-the-latest-lts-release).
-
-From your project root, run this command:
+If either applies, install PostCSS from your project root:
 
 ```sh
-npm install --save-dev autoprefixer postcss-cli
+npm install --save-dev autoprefixer postcss postcss-cli
 ```
+
+For more about this change, see [PostCSS is opt-in for non-RTL
+sites][blog-postcss] in the 0.16.0 release notes.
 
 ## Option 1: Docsy as a Git submodule
 
@@ -150,9 +148,7 @@ following commands:
     git init
     ```
 
-2.  Install postCSS as [instructed earlier](#install-postcss).
-
-3.  Follow the instructions below for an existing site.
+2.  Follow the instructions below for an existing site.
 
 ### For an existing site
 
@@ -177,7 +173,7 @@ your project's root directory:
 2.  Add Docsy as a theme, for example:
 
     ```sh
-    echo 'theme: docsy' >> hugo.yaml
+    echo 'theme: docsy/theme' >> hugo.yaml
     ```
 
     > [!TIP]
@@ -189,11 +185,8 @@ your project's root directory:
 3.  Get Docsy dependencies:
 
     ```sh
-    (cd themes/docsy && npm install)
+    (cd themes/docsy && npm run postinstall)
     ```
-
-    > [!IMPORTANT] **Important**: read the [Docsy NPM install side-effect][]
-    > note.
 
 4.  (Optional but recommended) To avoid having to repeat the previous step every
     time you update Docsy, consider adding [NPM scripts][] like the following to
@@ -204,7 +197,7 @@ your project's root directory:
       "...": "...",
       "scripts": {
         "get:submodule": "git submodule update --init --depth 1",
-        "_prepare:docsy": "cd themes/docsy && npm install",
+        "_prepare:docsy": "cd themes/docsy && npm run postinstall",
         "prepare": "npm run get:submodule && npm run _prepare:docsy",
         "...": "..."
       },
@@ -236,10 +229,11 @@ the following commands from your project's root directory:
 cd themes
 git clone -b {{% param version %}} https://github.com/google/docsy
 cd docsy
-npm install
+npm run postinstall
 ```
 
-> [!IMPORTANT] **Important**: read the [Docsy NPM install side-effect][] note.
+As with the [submodule option](#option-1-docsy-as-a-git-submodule), set
+`theme: docsy/theme` in your site configuration.
 
 To work from the development version of Docsy (not recommended unless, for
 example, you plan to upstream changes to Docsy), omit the
@@ -260,22 +254,15 @@ You can use Docsy as an NPM module as follows:
     ```sh
     hugo new site --format yaml myproject
     cd myproject
-    echo "theme: docsy\nthemesDir: node_modules" >> hugo.yaml
+    echo "theme: docsy/theme\nthemesDir: node_modules" >> hugo.yaml
     ```
 
-2.  Install Docsy, and postCSS as [instructed earlier](#install-postcss):
+2.  Install Docsy:
 
     ```console
     npm init -y
-    npm install --save-dev autoprefixer postcss-cli
     npm install --save-dev google/docsy#semver:{{% param version %}} --omit=peer
     ```
-
-    > [!WARNING] Hugo-module compatibility
-    >
-    > Installing Docsy using NPM creates an empty `github.com` sibling folder.
-    > For details, see
-    > [Docsy NPM install side-effect](#docsy-npm-install-side-effect).
 
     > [!TIP] Hugo install tip
     >
@@ -292,22 +279,6 @@ You can use Docsy as an NPM module as follows:
     ...
     ```
 
-    > [!WARNING] Error: failed to load modules
-    >
-    > If Hugo reports the following error when building your site ([#2116][]):
-    >
-    > ```text
-    > Error: failed to load modules: module "github.com/FortAwesome/Font-Awesome" not found in ".../myproject/node_modules/github.com/FortAwesome/Font-Awesome" ...
-    > ```
-    >
-    > Then run the following command and try again:
-    >
-    > ```sh
-    > npm rebuild
-    > ```
-    >
-    > [#2116]: https://github.com/google/docsy/issues/2116
-
 As an alternative to specifying a `themesDir`, on some platforms, you can
 instead create a symbolic link to the Docsy theme directory as follows (Linux
 commands shown, executed from the site root folder):
@@ -318,30 +289,6 @@ pushd themes
 ln -s ../node_modules/docsy
 popd
 ```
-
-## Docsy NPM install side-effect
-
-> [!NOTE]
->
-> As of Docsy version [0.8.0][], running `npm install` inside the Docsy theme
-> directory will create a sibling folder named `github.com`, for example:
->
-> ```console
-> $ ls themes
-> docsy                   github.com
-> ```
->
-> This is a workaround necessary to support Docsy's use as a single [Hugo
-> module][hm] ([#1120][]) in the context of projects _not_ using Hugo modules.
-> The `github.com` folder is created via Docsy's `postinstall` script. To
-> disable this behavior, set the environment variable
-> `DOCSY_MKDIR_HUGO_MOD_SKIP=1` before running NPM install.
->
-> [#1120]: https://github.com/google/docsy/issues/1120
-> [0.8.0]: /project/about/changelog/#v0.8.0
-> [hm]: /docs/get-started/docsy-as-module/
-
-[Docsy NPM install side-effect]: #docsy-npm-install-side-effect
 
 ## Preview your site
 
@@ -372,6 +319,7 @@ from scratch as it provides defaults for many required configuration parameters.
   [Examples and templates](/examples/).
 - [Publish your site](/docs/deployment/).
 
+[blog-postcss]: /blog/2026/0.16.0/#postcss
 [lts release]: https://nodejs.org/en/about/releases/
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating

--- a/docsy.dev/content/en/docs/updating/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/updating/convert-site-to-module.md
@@ -14,21 +14,23 @@ Run the following from the command line:
 {{< tab header="Unix shell" lang="Bash" >}}
 cd /path/to/my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 sed -i '/theme = \["docsy"\]/d' config.toml
 mv config.toml hugo.toml
 cat >> hugo.toml <<EOL
 [module]
 proxy = "direct"
 [[module.imports]]
-path = "github.com/google/docsy"
+path = "github.com/google/docsy/theme"
 EOL
+hugo mod npm pack
+npm install
 hugo server
 {{< /tab >}}
 {{< tab header="Windows command line" lang="Batchfile" >}}
 cd  my-existing-site
 hugo mod init github.com/me-at-github/my-existing-site
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 findstr /v /c:"theme = [\"docsy\"]" config.toml > hugo.toml
 (echo [module]^
 
@@ -36,7 +38,9 @@ proxy = "direct"^
 
 [[module.imports]]^
 
-path = "github.com/google/docsy")>>hugo.toml
+path = "github.com/google/docsy/theme")>>hugo.toml
+hugo mod npm pack
+npm install
 hugo server
 {{< /tab >}}
 {{< /tabpane >}}
@@ -63,7 +67,7 @@ This creates two new files, `go.mod` for the module definitions and `go.sum` whi
 Next declare the Docsy theme module as a dependency for your site.
 
 ```bash
-hugo mod get github.com/google/docsy@{{% param "version" %}}
+hugo mod get github.com/google/docsy/theme@{{% param "version" %}}
 ```
 
 This command adds the `docsy` theme module to your definition file `go.mod`.
@@ -90,15 +94,15 @@ Change this line to:
 {{< tabpane >}}
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
-theme = ["github.com/google/docsy"]
+theme = ["github.com/google/docsy/theme"]
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
 theme:
-  - github.com/google/docsy
+  - github.com/google/docsy/theme
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 "theme": [
-  "github.com/google/docsy"
+  "github.com/google/docsy/theme"
 ]
 {{< /tab >}}
 {{< /tabpane >}}
@@ -111,12 +115,12 @@ Alternatively, you can omit this line altogether and replace it with the setting
 [module]
   proxy = "direct"
   # uncomment line below for temporary local development of module
-  # replacements = "github.com/google/docsy -> ../../docsy"
+  # replacements = "github.com/google/docsy/theme -> ../../docsy/theme"
   [module.hugoVersion]
     extended = true
     min = {{% param "hugoMinVersion" %}}
   [[module.imports]]
-    path = "github.com/google/docsy"
+    path = "github.com/google/docsy/theme"
     disable = false
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
@@ -126,9 +130,7 @@ module:
     extended: true
     min: {{% param "hugoMinVersion" %}}
   imports:
-    - path: github.com/google/docsy
-      disable: false
-    - path: github.com/google/docsy/dependencies
+    - path: github.com/google/docsy/theme
       disable: false
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
@@ -141,11 +143,7 @@ module:
     },
     "imports": [
       {
-        "path": "github.com/google/docsy",
-        "disable": false
-      },
-      {
-        "path": "github.com/google/docsy/dependencies",
+        "path": "github.com/google/docsy/theme",
         "disable": false
       }
     ]
@@ -169,6 +167,21 @@ Depending on your environment you may need to tweak them slightly, for example b
 > `[languages]` inside your `hugo.toml` is declared before the section
 > `[module]` with the module imports. Otherwise you will run into trouble!
 
+### Install theme npm dependencies
+
+Docsy sources its Bootstrap and Font Awesome assets from npm. Consolidate the
+theme's npm dependencies into your project's `package.json` and install them:
+
+```bash
+hugo mod npm pack
+npm install
+```
+
+Re-run `hugo mod npm pack` whenever you update Docsy; Hugo warns when the
+dependency set drifts. For background, see
+[Bootstrap and Font Awesome via npm](/blog/2026/0.16.0/#npm-deps) in the 0.16.0
+release notes.
+
 ### Check validity of your configuration settings
 
 To make sure that your configuration settings are correct, run the command `hugo mod graph` which prints a module dependency graph:
@@ -176,12 +189,10 @@ To make sure that your configuration settings are correct, run the command `hugo
 ```bash
 hugo mod graph
 hugo: collected modules in 1092 ms
-github.com/me/my-existing-site github.com/google/docsy@{{% param "version" %}}
-github.com/google/docsy@{{% param "version" %}} github.com/twbs/bootstrap@v5.2.3+incompatible
-github.com/google/docsy@{{% param "version" %}} github.com/FortAwesome/Font-Awesome@ v0.0.0-20230802202706-f0c25837a3fe
+github.com/me/my-existing-site github.com/google/docsy/theme@{{% param "version" %}}
 ```
 
-Make sure that three lines with dependencies `docsy`, `bootstrap` and `Font-Awesome` are listed. If not, please double check your config settings.
+Make sure that the `docsy/theme` dependency is listed. If not, please double check your config settings.
 
 > [!TIP]
 >
@@ -190,9 +201,7 @@ Make sure that three lines with dependencies `docsy`, `bootstrap` and `Font-Awes
 > ```bash
 > hugo mod clean
 > hugo: collected modules in 995 ms
-> hugo: cleaned module cache for "github.com/FortAwesome/Font-Awesome"
-> hugo: cleaned module cache for "github.com/google/docsy"
-> hugo: cleaned module cache for "github.com/twbs/bootstrap"
+> hugo: cleaned module cache for "github.com/google/docsy/theme"
 > ```
 
 ## Clean up your repository

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -670,8 +670,8 @@ For the full list of changes, see the [0.8.0][] release page.
 
 - Docsy is packaged as a **single Hugo module** ([#1120][]). For details, see
   [Use Docsy as a Hugo Module][].
-- **Important**: non-Hugo-module projects should be aware of the [Docsy NPM
-  install side-effect]. Also, for guidance on Hugo-reported "failed to load
+- **Important**: non-Hugo-module projects should be aware of the Docsy NPM
+  install side-effect. Also, for guidance on Hugo-reported "failed to load
   modules" error, see [Docsy as an NPM package][].
 - **Page feedback**, or [User feedback][]:
   - In support of projects configuring analytics outside of Docsy, feedback
@@ -693,8 +693,6 @@ For the full list of changes, see the [0.8.0][] release page.
 [0.8.0]: https://github.com/google/docsy/releases/v0.8.0
 [Docsy as an NPM package]:
   /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
-[Docsy NPM install side-effect]:
-  /docs/get-started/other-options/#docsy-npm-install-side-effect
 [Use Docsy as a Hugo Module]: /docs/get-started/docsy-as-module/
 [User feedback]: /docs/content/feedback/#user-feedback
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -670,9 +670,10 @@ For the full list of changes, see the [0.8.0][] release page.
 
 - Docsy is packaged as a **single Hugo module** ([#1120][]). For details, see
   [Use Docsy as a Hugo Module][].
-- **Important**: non-Hugo-module projects should be aware of the Docsy NPM
-  install side-effect. Also, for guidance on Hugo-reported "failed to load
-  modules" error, see [Docsy as an NPM package][].
+- **Important**: for non-Hugo-module projects, running `npm install` in the
+  Docsy theme directory now creates a `github.com` sibling folder (via Docsy's
+  `postinstall` script). For guidance on the Hugo-reported "failed to load
+  modules" error, see [#2116][].
 - **Page feedback**, or [User feedback][]:
   - In support of projects configuring analytics outside of Docsy, feedback
     functionality is enabled regardless of whether
@@ -690,6 +691,7 @@ For the full list of changes, see the [0.8.0][] release page.
 [#1385]: https://github.com/google/docsy/issues/1385
 [#1726]: https://github.com/google/docsy/pull/1726
 [#1727]: https://github.com/google/docsy/pull/1727
+[#2116]: https://github.com/google/docsy/issues/2116
 [0.8.0]: https://github.com/google/docsy/releases/v0.8.0
 [Docsy as an NPM package]:
   /docs/get-started/other-options/#option-3-docsy-as-an-npm-package


### PR DESCRIPTION
- Contributes to #2668 (the get-started docs reconciliation checkbox); overlaps community PR #2612.
- **Deliberately minimal in scope** — limited to what the get-started and convert-to-module pages need in order to be accurate for 0.16. Known staleness elsewhere (`updating-hugo-module.md`'s pre-0.16 module path, `language.md`'s RTL install command, the deployment pages' PostCSS assumptions, `example-site-as-template.md`'s TL;DR), and a DRYing pass over the install guidance that these pages repeat, are deferred to follow-up work.
- Aligns the get-started and convert-to-module guides with 0.16's theme-folder move and npm-sourced Bootstrap/Font Awesome:
  - Fixes Hugo-module import paths to `github.com/google/docsy/theme` and drops the non-existent `/dependencies` import.
  - Adds the required `hugo mod npm pack` + `npm install` step for Hugo-module sites.
  - Switches clone/submodule installs to `npm run postinstall` and sets `theme: docsy/theme`.
- Makes PostCSS opt-in (RTL, or a project-root `postcss.config.*`), matching the new default.
- Promotes Node.js to a first-class prerequisite, since Bootstrap and Font Awesome now come from npm; command details stay with the setup pages it defers to.
- Removes stale content: the npm install side-effect note, the #2116 and github.com-folder warnings, and outdated `hugo mod graph`/`clean` output samples; retargets the 0.8.0 changelog's pointers accordingly (side-effect link dropped, "failed to load modules" guidance now cites the issue).
- Links the 0.16.0 release notes for "what changed" rather than restating it here.
- **Preview(s)**:
  - [Installation prerequisites](https://deploy-preview-2672--docsydocs.netlify.app/docs/get-started/docsy-as-module/installation-prerequisites/)
  - [Start from scratch](https://deploy-preview-2672--docsydocs.netlify.app/docs/get-started/docsy-as-module/start-from-scratch/)
  - [Other installation options](https://deploy-preview-2672--docsydocs.netlify.app/docs/get-started/other-options/)
  - [Convert an existing site to use Docsy as a module](https://deploy-preview-2672--docsydocs.netlify.app/docs/updating/convert-site-to-module/)

