### PR TITLE
Adopt renamed link-cache package (was lychee-cache)

### DIFF
--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -53,7 +53,7 @@
     "afdocs": "^0.9.2",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.163.3",
-    "lychee-cache": "github:chalin/lychee-cache#semver:^0.1.0",
+    "link-cache": "github:chalin/link-cache#semver:^0.2.0",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "rtlcss": "^4.3.0"


### PR DESCRIPTION
- The `chalin/lychee-cache` helper package is now [`chalin/link-cache`](https://github.com/chalin/link-cache), renamed ahead of generalizing it beyond Lychee (an enhanced link cache from which the Lychee cache is derived); this repoints docsy.dev's devDep to the renamed repo at v0.2.0.
- Bin names (`lychee-norm-cache`, `refcache`) are unchanged, so scripts and CI are unaffected.
