### PR TITLE
Reconcile remaining docs with the 0.16 npm-dep changes

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -63,6 +63,7 @@ https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-
 https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request,200,1782498226
 https://docs.gitlab.com/user/markdown/#math-equations,200,1782498236
 https://docs.layer5.io/,200,1782498244
+https://docs.netlify.com/build/configure-builds/overview/#definitions,200,1784219324
 https://docs.netlify.com/configure-builds/file-based-configuration/,200,1782563368
 https://docs.npmjs.com/cli/v10/commands/npm-install#description,200,1782563368
 https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish,200,1782563368

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -381,6 +381,7 @@ https://github.com/google/docsy/issues/new?title=Search,200,1782498242
 https://github.com/google/docsy/issues/new?title=Serving%20your%20site%20locally,200,1782498244
 https://github.com/google/docsy/issues/new?title=Style%20guide,200,1782498547
 https://github.com/google/docsy/issues/new?title=Taxonomy%20Support,200,1782498243
+https://github.com/google/docsy/issues/new?title=Troubleshooting%20and%20known%20issues,200,1784211755
 https://github.com/google/docsy/issues/new?title=Update%20Docsy%20without%20Hugo%20Modules,200,1782498243
 https://github.com/google/docsy/issues/new?title=Update%20Docsy,200,1782498244
 https://github.com/google/docsy/issues/new?title=Update%20your%20Docsy%20Hugo%20Module,200,1782498245
@@ -744,6 +745,7 @@ https://main--docsydocs.netlify.app/docs/get-started/docsy-as-module/start-from-
 https://main--docsydocs.netlify.app/docs/get-started/known_issues/,200,1782498243
 https://main--docsydocs.netlify.app/docs/get-started/other-options/,200,1782498243
 https://main--docsydocs.netlify.app/docs/get-started/quickstart-docker/,200,1782498245
+https://main--docsydocs.netlify.app/docs/get-started/troubleshooting/,206,1784212116
 https://main--docsydocs.netlify.app/docs/language/,200,1782498243
 https://main--docsydocs.netlify.app/docs/updating/,200,1782563367
 https://main--docsydocs.netlify.app/docs/updating/convert-site-to-module/,200,1782498243
@@ -890,6 +892,7 @@ https://www.docsy.dev/docs/get-started/docsy-as-module/start-from-scratch/,200,1
 https://www.docsy.dev/docs/get-started/known_issues/,200,1782498243
 https://www.docsy.dev/docs/get-started/other-options/,200,1782498243
 https://www.docsy.dev/docs/get-started/quickstart-docker/,200,1782498243
+https://www.docsy.dev/docs/get-started/troubleshooting/,206,1784212116
 https://www.docsy.dev/docs/language/,200,1782498243
 https://www.docsy.dev/docs/updating/,200,1782563367
 https://www.docsy.dev/docs/updating/convert-site-to-module/,200,1782498243

--- a/docsy.dev/content/en/docs/deployment/local.md
+++ b/docsy.dev/content/en/docs/deployment/local.md
@@ -11,8 +11,7 @@ during development to preview content changes. To serve your site locally:
 
 1. Ensure you have the tools described in [Prerequisites and
    installation][prereq] installed on your local machine, including
-   `postcss-cli` (you'll need it to generate the site resources the first time
-   you run the server).
+   [PostCSS][prereq-postcss] if your site needs it.
 1. Run the `hugo server` command in your site root. By default your site will be
    available at <http://localhost:1313>.
 
@@ -22,3 +21,5 @@ branch, when you switch between git branches the local website reflects the
 files in the current branch.
 
 [prereq]: /docs/get-started/docsy-as-module/installation-prerequisites
+[prereq-postcss]:
+  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss

--- a/docsy.dev/content/en/docs/deployment/netlify.md
+++ b/docsy.dev/content/en/docs/deployment/netlify.md
@@ -29,7 +29,9 @@ provider account. Once you're logged in:
         You need to specify this rather than just `hugo` so that Netlify can use
         the theme's submodules.
       - If you are using Docsy as a [Hugo module][] or NPM package, you can just
-        specify `hugo`.
+        specify `hugo`. Netlify installs dependencies automatically when your
+        site's [base directory][] includes your Node dependency files (such as
+        `package.json` and lock files).
    2. Click **Show advanced**.
    3. In the **Advanced build settings** section, click **New variable**.
    4. Specify `NODE_VERSION` as the **Key** for the new variable, and set its
@@ -57,6 +59,7 @@ clicking **Site settings** > **Build and deploy**.
 
 <!-- prettier-ignore-start -->
 [Build environments and indexing]: /docs/deployment/#build-environments-and-indexing
+[base directory]: https://docs.netlify.com/build/configure-builds/overview/#definitions
 [cd]: https://www.netlify.com/docs/continuous-deployment/
 [Git submodule]: /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
 [go-dl]: https://go.dev/dl/

--- a/docsy.dev/content/en/docs/deployment/netlify.md
+++ b/docsy.dev/content/en/docs/deployment/netlify.md
@@ -53,10 +53,7 @@ You can also put the build command and environment variables in a
 
 If you have an existing deployment you can view and update the relevant
 information by selecting the site from your list of sites in Netlify, then
-clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Focal
-20.04** is selected in the **Build image selection** section - if you're
-creating a new deployment this is used by default. You need to use this image to
-run the extended version of Hugo.
+clicking **Site settings** > **Build and deploy**.
 
 <!-- prettier-ignore-start -->
 [Build environments and indexing]: /docs/deployment/#build-environments-and-indexing
@@ -70,5 +67,5 @@ run the extended version of Hugo.
 [netlify-toml-docs]: https://docs.netlify.com/configure-builds/file-based-configuration/
 [netlify.toml]: <{{% param github_repo %}}/blob/main/docsy.dev/netlify.toml>
 [node-lts]: https://nodejs.org/en/download/
-[Using the theme]: /docs/get-started/docsy-as-module
+[Using the theme]: /docs/get-started/docsy-as-module/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/deployment/netlify.md
+++ b/docsy.dev/content/en/docs/deployment/netlify.md
@@ -4,16 +4,15 @@ linkTitle: Netlify
 description: Deploying your Docsy site on Netlify.
 ---
 
-We recommend using [Netlify](https://www.netlify.com/) as a particularly simple
-way to serve your site from your Git provider (GitHub, GitLab, or BitBucket),
-with [continuous deployment][cd], previews of the generated site when you or
-your users create pull requests against the doc repo, and more. Netlify is free
-to use for Open Source projects, with premium tiers if you require greater
-support.
+We recommend using [Netlify][] as a particularly simple way to serve your site
+from your Git provider (GitHub, GitLab, or BitBucket), with [continuous
+deployment][cd], previews of the generated site when you or your users create
+pull requests against the doc repo, and more. Netlify is free to use for Open
+Source projects, with premium tiers if you require greater support.
 
 Before deploying with Netlify, make sure that you've pushed your site source to
 your chosen GitHub (or other provider) repo, following any setup instructions in
-[Using the theme](/docs/get-started/docsy-as-module).
+[Using the theme][].
 
 Then follow the instructions in [Host on Netlify][] to set up a Netlify account
 (if you don't have one already) and authorize access to your GitHub or other Git
@@ -34,40 +33,23 @@ provider account. Once you're logged in:
    2. Click **Show advanced**.
    3. In the **Advanced build settings** section, click **New variable**.
    4. Specify `NODE_VERSION` as the **Key** for the new variable, and set its
-      **Value** to the [latest LTS version](https://nodejs.org/en/download/) of
-      Node.js.
+      **Value** to the [latest LTS version][node-lts] of Node.js.
    5. In the **Advanced build settings** section, click **New variable**.
    6. Specify `HUGO_VERSION` as the **Key** for the new variable, and set its
-      **Value** to the
-      [latest version](https://github.com/gohugoio/hugo/releases) of Hugo.
+      **Value** to the [latest version][hugo-releases] of Hugo.
    7. In the **Advanced build settings** section, click **New variable** again.
    8. Specify `GO_VERSION` as the **Key** for the new variable, and set its
-      **Value** to the [latest version](https://go.dev/dl/) of Go.
+      **Value** to the [latest version][go-dl] of Go.
 
    If you don't want your site to be indexed by search engines, you can add an
    environment flag to your build command to specify a non-`production`
-   environment, as described in
-   [Build environments and indexing](/docs/deployment/#build-environments-and-indexing).
+   environment, as described in [Build environments and indexing][].
 
 1. Click **Deploy site**.
 
-> [!NOTE]
->
-> Netlify uses your site repo's `package.json` file to install any npm
-> dependencies — including the Docsy theme's — before building your site. If you
-> haven't just copied our example site's version of this file, make sure that
-> you've specified all our [prerequisites][], including
-> [PostCSS][prereq-postcss] if your site needs it.
-
-Alternatively, you can follow the same instructions but specify your **Deploy
-settings** in a [`netlify.toml` file][] in your repo rather than in the **Deploy
-settings** page. For an example, see the [netlify.toml][] for the Docsy website
-(though note that the build command here is a little unusual because the Docsy
-user guide is _inside_ the theme repo).
-
-[`netlify.toml` file]:
-  https://docs.netlify.com/configure-builds/file-based-configuration/
-[netlify.toml]: <{{% param github_repo %}}/blob/main/docsy.dev/netlify.toml>
+You can also put the build command and environment variables in a
+[`netlify.toml`][netlify-toml-docs] instead of the Deploy settings UI. See the
+[Docsy website's `netlify.toml`][netlify.toml] for an example.
 
 If you have an existing deployment you can view and update the relevant
 information by selecting the site from your list of sites in Netlify, then
@@ -76,11 +58,17 @@ clicking **Site settings** - **Build and deploy**. Ensure that **Ubuntu Focal
 creating a new deployment this is used by default. You need to use this image to
 run the extended version of Hugo.
 
+<!-- prettier-ignore-start -->
+[Build environments and indexing]: /docs/deployment/#build-environments-and-indexing
 [cd]: https://www.netlify.com/docs/continuous-deployment/
+[Git submodule]: /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
+[go-dl]: https://go.dev/dl/
 [Host on Netlify]: https://gohugo.io/hosting-and-deployment/hosting-on-netlify/
-[Git submodule]:
-  /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
 [Hugo module]: /docs/get-started/docsy-as-module/
-[prerequisites]: /docs/get-started/docsy-as-module/installation-prerequisites
-[prereq-postcss]:
-  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
+[hugo-releases]: https://github.com/gohugoio/hugo/releases
+[Netlify]: https://www.netlify.com/
+[netlify-toml-docs]: https://docs.netlify.com/configure-builds/file-based-configuration/
+[netlify.toml]: <{{% param github_repo %}}/blob/main/docsy.dev/netlify.toml>
+[node-lts]: https://nodejs.org/en/download/
+[Using the theme]: /docs/get-started/docsy-as-module
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/deployment/netlify.md
+++ b/docsy.dev/content/en/docs/deployment/netlify.md
@@ -53,22 +53,11 @@ provider account. Once you're logged in:
 
 > [!NOTE]
 >
-> Netlify uses your site repo's `package.json` file to install any JavaScript
-> dependencies (like `postcss`) before building your site. If you haven't just
-> copied our example site's version of this file, make sure that you've
-> specified all our [prerequisites][].
->
-> For example, if you want to use a version of `postcss-cli` later than version
-> 8.0.0, you need to ensure that your `package.json` also specifies `postcss`
-> separately:
->
-> ```
->   "devDependencies": {
->     "autoprefixer": "^10.4.19",
->     "postcss-cli": "^11.0.0",
->     "postcss": "^8.4.38"
->   }
-> ```
+> Netlify uses your site repo's `package.json` file to install any npm
+> dependencies — including the Docsy theme's — before building your site. If you
+> haven't just copied our example site's version of this file, make sure that
+> you've specified all our [prerequisites][], including
+> [PostCSS][prereq-postcss] if your site needs it.
 
 Alternatively, you can follow the same instructions but specify your **Deploy
 settings** in a [`netlify.toml` file][] in your repo rather than in the **Deploy
@@ -93,3 +82,5 @@ run the extended version of Hugo.
   /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
 [Hugo module]: /docs/get-started/docsy-as-module/
 [prerequisites]: /docs/get-started/docsy-as-module/installation-prerequisites
+[prereq-postcss]:
+  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -16,8 +16,8 @@ example site automatically pulls in the Docsy theme as a
 [Hugo Module](https://gohugo.io/hugo-modules/), so it's easy to
 [keep up to date](/docs/updating/updating-hugo-module/).
 
-If you prefer to create a site from scratch, follow
-[Start a site from scratch][start-from-scratch].
+If you prefer to create a site from scratch, follow [Start a site from
+scratch][start-from-scratch].
 
 ## TL;DR: Setup for the impatient expert
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -26,8 +26,14 @@ At your Unix shell or Windows command line, run the following command:
 ```bash
 git clone --depth 1 --branch {{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
 cd  my-new-site
+npm install
 hugo server
 ```
+
+The `npm install` is required: it installs the project's npm dependencies, which
+include the theme's npm dependencies as well as the [PostCSS][prereq-postcss]
+toolchain that the example site needs for its right-to-left (RTL) language
+support.
 
 You now can preview your new site in your browser at
 [http://localhost:1313](http://localhost:1313/).
@@ -91,8 +97,8 @@ easy:
 > [!NOTE]
 >
 > Depending on your environment you may need to tweak the
-> [module top level settings](https://github.com/google/docsy-example/blob/f88fca475c28ffba3d72710a50450870230eb3a0/hugo.toml#L222-L227)
-> inside your `hugo.toml` slightly, for example by adding a proxy to use when
+> [module top level settings](https://github.com/google/docsy-example/blob/main/hugo.yaml)
+> inside your `hugo.yaml` slightly, for example by adding a proxy to use when
 > downloading remote modules. You can find details of what these configuration
 > settings do in the
 > [Hugo modules documentation](https://gohugo.io/configuration/module/#top-level-settings).
@@ -102,10 +108,11 @@ Now you can make local edits and test your copied site locally with Hugo.
 ### Preview your site
 
 To build and preview your site locally, switch to the root of your cloned
-project and use hugo's `server` command:
+project, install the project dependencies, and use hugo's `server` command:
 
 ```bash
 cd my-new-site
+npm install
 hugo server
 ```
 
@@ -121,3 +128,6 @@ like. [See the known issues on MacOS](/docs/get-started/known_issues/#macos).
 - [Edit existing content and add more pages](/docs/content/)
 - [Customize your site](/docs/content/lookandfeel/)
 - [Publish your site](/docs/deployment/).
+
+[prereq-postcss]:
+  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -1,6 +1,6 @@
 ---
 title: 'Create a new site: start with a prepopulated site'
-linkTitle: 'Start with a prepopulated site'
+linkTitle: Start with a prepopulated site
 date: 2021-12-08T09:21:54+01:00
 weight: 2
 description: >
@@ -21,22 +21,17 @@ site from scratch.
 
 ## TL;DR: Setup for the impatient expert
 
-At your Unix shell or Windows command line, run the following command:
+From a terminal:
 
 ```bash
 git clone --depth 1 --branch {{% param "version" %}} https://github.com/google/docsy-example.git my-new-site
-cd  my-new-site
+cd my-new-site
 npm install
 hugo server
 ```
 
-The `npm install` is required: it installs the project's npm dependencies, which
-include the theme's npm dependencies as well as the [PostCSS][prereq-postcss]
-toolchain that the example site needs for its right-to-left (RTL) language
-support.
-
-You now can preview your new site in your browser at
-[http://localhost:1313](http://localhost:1313/).
+Preview at <http://localhost:1313/>. If the build fails with a missing Bootstrap
+import, see [Troubleshooting][].
 
 ## Detailed Setup instructions
 
@@ -120,7 +115,7 @@ Preview your site in your browser at:
 [http://localhost:1313](http://localhost:1313/). Thanks to Hugo's live preview,
 you can immediately see the effect of changes that you are making to the source
 files of your local repo. Use `Ctrl + c` to stop the Hugo server whenever you
-like. [See the known issues on MacOS](/docs/get-started/known_issues/#macos).
+like. [See the known issues on MacOS][macos-issues].
 
 ## What's next?
 
@@ -129,5 +124,7 @@ like. [See the known issues on MacOS](/docs/get-started/known_issues/#macos).
 - [Customize your site](/docs/content/lookandfeel/)
 - [Publish your site](/docs/deployment/).
 
-[prereq-postcss]:
-  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
+<!-- prettier-ignore-start -->
+[macos-issues]: /docs/get-started/troubleshooting/#macos
+[Troubleshooting]: /docs/get-started/troubleshooting/#missing-theme-npm-dependencies
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -110,8 +110,7 @@ hugo server
 Preview at <http://localhost:1313/>. Thanks to Hugo's live preview, you can
 immediately see the effect of changes that you are making to the source files of
 your local repo. Use `Ctrl + c` to stop the Hugo server whenever you like. If
-the build fails with a missing Bootstrap import, see [Troubleshooting][]. For
-MacOS limits, see [MacOS issues][macos-issues].
+the build fails with a missing Bootstrap import, see [Troubleshooting][].
 
 ## What's next?
 
@@ -121,7 +120,6 @@ MacOS limits, see [MacOS issues][macos-issues].
 - [Publish your site](/docs/deployment/).
 
 <!-- prettier-ignore-start -->
-[macos-issues]: /docs/get-started/troubleshooting/#macos
 [start-from-scratch]: /docs/get-started/docsy-as-module/start-from-scratch/
 [Troubleshooting]: /docs/get-started/troubleshooting/#missing-theme-npm-dependencies
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -1,11 +1,11 @@
 ---
 title: 'Create a new site: start with a prepopulated site'
 linkTitle: Start with a prepopulated site
-date: 2021-12-08T09:21:54+01:00
-weight: 2
 description: >
   Create a new Hugo site by using a clone of the Docsy example site as your
   starting point.
+weight: 2
+cSpell:ignore: gitea
 ---
 
 The simplest way to create a new Docsy site is to use the source of the
@@ -16,8 +16,8 @@ example site automatically pulls in the Docsy theme as a
 [Hugo Module](https://gohugo.io/hugo-modules/), so it's easy to
 [keep up to date](/docs/updating/updating-hugo-module/).
 
-If you prefer to create a site from scratch, follow the instructions in Start a
-site from scratch.
+If you prefer to create a site from scratch, follow
+[Start a site from scratch][start-from-scratch].
 
 ## TL;DR: Setup for the impatient expert
 
@@ -96,8 +96,6 @@ easy:
 > in your `hugo.yaml` slightly, for example by adding a proxy to use when
 > downloading remote modules.
 
-Now you can make local edits and test your copied site locally with Hugo.
-
 ### Preview your site
 
 To build and preview your site locally, switch to the root of your cloned
@@ -124,5 +122,6 @@ MacOS limits, see [MacOS issues][macos-issues].
 
 <!-- prettier-ignore-start -->
 [macos-issues]: /docs/get-started/troubleshooting/#macos
+[start-from-scratch]: /docs/get-started/docsy-as-module/start-from-scratch/
 [Troubleshooting]: /docs/get-started/troubleshooting/#missing-theme-npm-dependencies
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/example-site-as-template.md
@@ -92,11 +92,9 @@ easy:
 > [!NOTE]
 >
 > Depending on your environment you may need to tweak the
-> [module top level settings](https://github.com/google/docsy-example/blob/main/hugo.yaml)
-> inside your `hugo.yaml` slightly, for example by adding a proxy to use when
-> downloading remote modules. You can find details of what these configuration
-> settings do in the
-> [Hugo modules documentation](https://gohugo.io/configuration/module/#top-level-settings).
+> [module top-level settings](https://gohugo.io/configuration/module/#top-level-settings)
+> in your `hugo.yaml` slightly, for example by adding a proxy to use when
+> downloading remote modules.
 
 Now you can make local edits and test your copied site locally with Hugo.
 
@@ -111,11 +109,11 @@ npm install
 hugo server
 ```
 
-Preview your site in your browser at:
-[http://localhost:1313](http://localhost:1313/). Thanks to Hugo's live preview,
-you can immediately see the effect of changes that you are making to the source
-files of your local repo. Use `Ctrl + c` to stop the Hugo server whenever you
-like. [See the known issues on MacOS][macos-issues].
+Preview at <http://localhost:1313/>. Thanks to Hugo's live preview, you can
+immediately see the effect of changes that you are making to the source files of
+your local repo. Use `Ctrl + c` to stop the Hugo server whenever you like. If
+the build fails with a missing Bootstrap import, see [Troubleshooting][]. For
+MacOS limits, see [MacOS issues][macos-issues].
 
 ## What's next?
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -130,15 +130,14 @@ Hugo-module setups.
 Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
 sites don't need it. Install PostCSS only if:
 
-- your site has a **right-to-left (RTL)** language (Docsy uses `rtlcss` to
-  generate RTL styles — see [Right-to-left languages][rtl]), or
-- you post-process your own CSS with a project-root
+- Your site has a **[right-to-left (RTL)][rtl]** language, or
+- You post-process your own CSS with a project-root
   `postcss.config.{js,mjs,cjs}` file.
 
 If either applies, install PostCSS from your project root:
 
 ```bash
-npm install --save-dev autoprefixer postcss postcss-cli
+npm install --save-dev autoprefixer postcss-cli
 ```
 
 For more about this change, see [PostCSS is opt-in for non-RTL
@@ -149,10 +148,12 @@ sites][blog-postcss] in the 0.16.0 release notes.
 With all prerequisites installed, choose how to start off with your new Hugo
 site
 
-- [Start with a prepopulated site (for beginners)](/docs/get-started/docsy-as-module/example-site-as-template/)
-- [Start site from scratch (for experts)](/docs/get-started/docsy-as-module/start-from-scratch/)
+- [Start with a prepopulated site (for beginners)](example-site-as-template/)
+- [Start site from scratch (for experts)](start-from-scratch/)
 
+<!-- prettier-ignore-start -->
 [blog-postcss]: /blog/2026/0.16.0/#postcss
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
 [node-lts]: https://nodejs.org/en/about/releases/
 [rtl]: /docs/language/#right-to-left-languages
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -124,6 +124,9 @@ steps.
 
 ## Install PostCSS (optional) {#install-postcss}
 
+This section applies to all [installation options](/docs/get-started/), not just
+Hugo-module setups.
+
 Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
 sites don't need it. Install PostCSS only if:
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -140,8 +140,11 @@ If either applies, install PostCSS from your project root:
 npm install --save-dev autoprefixer postcss-cli
 ```
 
-For more about this change, see [PostCSS is opt-in for non-RTL
-sites][blog-postcss] in the 0.16.0 release notes.
+> [!NOTE]
+>
+> npm also installs [postcss][postcss] itself, as a peer dependency of the
+> packages listed above. If you use a package manager that doesn't auto-install
+> peer dependencies, such as Yarn, add `postcss` to the install command.
 
 ## What's next?
 
@@ -152,8 +155,8 @@ site
 - [Start site from scratch (for experts)](start-from-scratch/)
 
 <!-- prettier-ignore-start -->
-[blog-postcss]: /blog/2026/0.16.0/#postcss
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
 [node-lts]: https://nodejs.org/en/about/releases/
+[postcss]: https://www.npmjs.com/package/postcss
 [rtl]: /docs/language/#right-to-left-languages
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -24,10 +24,6 @@ For comprehensive Hugo documentation, see [gohugo.io](https://gohugo.io).
 
 ### On Linux
 
-Be careful using `sudo apt-get install hugo`, as it
-[doesn't get you the `extended` version for all Debian/Ubuntu versions](https://gohugo.io/installation/linux/#debian),
-and may not be up-to-date with the most recent Hugo version.
-
 If you've already installed Hugo, check your version:
 
 ```bash

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -128,7 +128,7 @@ Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
 sites don't need it. Install PostCSS only if:
 
 - your site has a **right-to-left (RTL)** language (Docsy uses `rtlcss` to
-  generate RTL styles), or
+  generate RTL styles — see [Right-to-left languages][rtl]), or
 - you post-process your own CSS with a project-root
   `postcss.config.{js,mjs,cjs}` file.
 
@@ -152,3 +152,4 @@ site
 [blog-postcss]: /blog/2026/0.16.0/#postcss
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
 [node-lts]: https://nodejs.org/en/about/releases/
+[rtl]: /docs/language/#right-to-left-languages

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -191,9 +191,8 @@ hugo server
 ```
 
 By default, your site will be available at
-[http://localhost:1313](http://localhost:1313/). When encountering problems,
-have a look at the [known issues](/docs/get-started/troubleshooting/#macos) on
-MacOS.
+[http://localhost:1313](http://localhost:1313/). For common issues, such as the
+build failing with a missing Bootstrap import, see [Troubleshooting][].
 
 You may get Hugo errors for missing parameters and values when you try to build
 your site. This is usually because you're missing default values for some
@@ -215,3 +214,4 @@ from scratch as it provides defaults for many required configuration parameters.
 [blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [configuration file]:
   https://gohugo.io/configuration/introduction/#configuration-file
+[Troubleshooting]: /docs/get-started/troubleshooting/

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -177,9 +177,10 @@ hugo mod npm pack
 npm install
 ```
 
-Re-run `hugo mod npm pack` whenever you [update Docsy](/docs/updating/); Hugo
-warns when the dependency set drifts. For background, see [Bootstrap and Font
-Awesome via npm][blog-npm-deps] in the 0.16.0 release notes.
+Re-run `hugo mod npm pack` whenever you
+[update Docsy](/docs/updating/updating-hugo-module/); Hugo warns when the
+dependency set drifts. For background, see [Bootstrap and Font Awesome via
+npm][blog-npm-deps] in the 0.16.0 release notes.
 
 ### Preview your site
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -192,7 +192,7 @@ hugo server
 
 By default, your site will be available at
 [http://localhost:1313](http://localhost:1313/). When encountering problems,
-have a look at the [known issues](/docs/get-started/known_issues/#macos) on
+have a look at the [known issues](/docs/get-started/troubleshooting/#macos) on
 MacOS.
 
 You may get Hugo errors for missing parameters and values when you try to build

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -118,20 +118,10 @@ nvm install --lts
 
 ### Install PostCSS (optional) {#install-postcss}
 
-Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
-sites don't need it. Install PostCSS only if your site has a **right-to-left
-(RTL)** language (Docsy uses `rtlcss` to generate RTL styles — see
-[Right-to-left languages][rtl]) or you post-process your own CSS with a
-project-root `postcss.config.{js,mjs,cjs}` file.
-
-If either applies, install PostCSS from your project root:
-
-```sh
-npm install --save-dev autoprefixer postcss postcss-cli
-```
-
-For more about this change, see [PostCSS is opt-in for non-RTL
-sites][blog-postcss] in the 0.16.0 release notes.
+Docsy builds its CSS without PostCSS by default, so most sites don't need it. If
+your site has a right-to-left (RTL) language or post-processes its own CSS, see
+[Install PostCSS][] in the Hugo-module prerequisites — the same guidance applies
+to all installation options.
 
 ## Option 1: Docsy as a Git submodule
 
@@ -319,11 +309,11 @@ from scratch as it provides defaults for many required configuration parameters.
   [Examples and templates](/examples/).
 - [Publish your site](/docs/deployment/).
 
-[blog-postcss]: /blog/2026/0.16.0/#postcss
+[Install PostCSS]:
+  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [lts release]: https://nodejs.org/en/about/releases/
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [npm scripts]: https://docs.npmjs.com/cli/v10/using-npm/scripts
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
-[rtl]: /docs/language/#right-to-left-languages

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -120,9 +120,9 @@ nvm install --lts
 
 Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
 sites don't need it. Install PostCSS only if your site has a **right-to-left
-(RTL)** language (Docsy uses `rtlcss` to generate RTL styles) or you
-post-process your own CSS with a project-root `postcss.config.{js,mjs,cjs}`
-file.
+(RTL)** language (Docsy uses `rtlcss` to generate RTL styles — see
+[Right-to-left languages][rtl]) or you post-process your own CSS with a
+project-root `postcss.config.{js,mjs,cjs}` file.
 
 If either applies, install PostCSS from your project root:
 
@@ -326,3 +326,4 @@ from scratch as it provides defaults for many required configuration parameters.
 [npm scripts]: https://docs.npmjs.com/cli/v10/using-npm/scripts
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
+[rtl]: /docs/language/#right-to-left-languages

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -282,8 +282,8 @@ cd myproject
 hugo server
 ```
 
-By default, your site will be available at <http://localhost:1313>.
-[See the known issues on MacOS](/docs/get-started/troubleshooting/#macos).
+By default, your site will be available at <http://localhost:1313>. For common
+issues, see [Troubleshooting](/docs/get-started/troubleshooting/).
 
 You may get Hugo errors for missing parameters and values when you try to build
 your site. This is usually because you’re missing default values for some

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -118,10 +118,7 @@ nvm install --lts
 
 ### Install PostCSS (optional) {#install-postcss}
 
-Docsy builds its CSS without PostCSS by default, so most sites don't need it. If
-your site has a right-to-left (RTL) language or post-processes its own CSS, see
-[Install PostCSS][] in the Hugo-module prerequisites — the same guidance applies
-to all installation options.
+See [Install PostCSS][].
 
 ## Option 1: Docsy as a Git submodule
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -48,10 +48,6 @@ For comprehensive Hugo documentation, see [gohugo.io](https://gohugo.io/).
 
 #### On Linux
 
-Be careful using `sudo apt-get install hugo`, as it
-[doesn't get you the `extended` version for all Debian/Ubuntu versions](https://gohugo.io/installation/linux/#debian),
-and may not be up-to-date with the most recent Hugo version.
-
 If you've already installed Hugo, check your version:
 
 ```sh

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -300,7 +300,7 @@ hugo server
 ```
 
 By default, your site will be available at <http://localhost:1313>.
-[See the known issues on MacOS](/docs/get-started/known_issues/#macos).
+[See the known issues on MacOS](/docs/get-started/troubleshooting/#macos).
 
 You may get Hugo errors for missing parameters and values when you try to build
 your site. This is usually because you’re missing default values for some

--- a/docsy.dev/content/en/docs/get-started/troubleshooting.md
+++ b/docsy.dev/content/en/docs/get-started/troubleshooting.md
@@ -21,8 +21,8 @@ File to import not found or unreadable: ../../vendor/bootstrap/scss/functions.
 ```
 
 To fix this, install the theme's npm dependencies for your [setup][], then
-rebuild. Hugo module sites: see [Install theme npm
-dependencies][theme-npm-deps].
+rebuild. Example-site-based projects: run `npm install` in your site root. Hugo
+module sites from scratch: see [Install theme npm dependencies][theme-npm-deps].
 
 ## Known issues
 

--- a/docsy.dev/content/en/docs/get-started/troubleshooting.md
+++ b/docsy.dev/content/en/docs/get-started/troubleshooting.md
@@ -1,9 +1,30 @@
 ---
-title: Known issues
-date: 2021-12-08T09:22:27+01:00
-weight: 4
-description: Known issues when installing Docsy theme.
+title: Troubleshooting and known issues
+linkTitle: Troubleshooting
+weight: 60
+description: >
+  Troubleshooting and known issues when installing and using Docsy.
+aliases: [known_issues]
+cSpell:ignore: TOCSS maxfiles maxfilesperproc
 ---
+
+## Troubleshooting
+
+### Missing theme npm dependencies
+
+For any Docsy install mode, if the theme's npm packages aren't available, Hugo
+fails while compiling SCSS with an error like:
+
+```text
+TOCSS: failed to transform "/scss/main.scss" (text/x-scss):
+File to import not found or unreadable: ../../vendor/bootstrap/scss/functions.
+```
+
+To fix this, install the theme's npm dependencies for your [setup][], then
+rebuild. Hugo module sites: see [Install theme npm
+dependencies][theme-npm-deps].
+
+## Known issues
 
 The following issues are known on [MacOS](#macos) and on
 [Windows Subsystem for Linux](#windows-subsystem-for-linux-wsl):
@@ -58,3 +79,8 @@ Note that you might need to set these limits for each new shell.
 
 If you're using WSL, ensure that you're running `hugo` on a Linux mount of the
 filesystem, rather than a Windows one, otherwise you may get unexpected errors.
+
+<!-- prettier-ignore-start -->
+[setup]: /docs/get-started/
+[theme-npm-deps]: /docs/get-started/docsy-as-module/start-from-scratch/#install-theme-npm-dependencies
+<!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/troubleshooting.md
+++ b/docsy.dev/content/en/docs/get-started/troubleshooting.md
@@ -21,8 +21,14 @@ File to import not found or unreadable: ../../vendor/bootstrap/scss/functions.
 ```
 
 To fix this, install the theme's npm dependencies for your [setup][], then
-rebuild. Example-site-based projects: run `npm install` in your site root. Hugo
-module sites from scratch: see [Install theme npm dependencies][theme-npm-deps].
+rebuild:
+
+- Example-site-based projects, and sites using Docsy as an [NPM
+  package][npm-pkg]: run `npm install` from your site root.
+- Hugo module sites built from scratch: see [Install theme npm
+  dependencies][theme-npm-deps].
+- Sites using Docsy as a [Git submodule][submodule] or a cloned theme: run
+  `npm run postinstall` from `themes/docsy`.
 
 ## Known issues
 
@@ -81,6 +87,8 @@ If you're using WSL, ensure that you're running `hugo` on a Linux mount of the
 filesystem, rather than a Windows one, otherwise you may get unexpected errors.
 
 <!-- prettier-ignore-start -->
+[npm-pkg]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 [setup]: /docs/get-started/
+[submodule]: /docs/get-started/other-options/#option-1-docsy-as-a-git-submodule
 [theme-npm-deps]: /docs/get-started/docsy-as-module/start-from-scratch/#install-theme-npm-dependencies
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/language.md
+++ b/docsy.dev/content/en/docs/language.md
@@ -143,7 +143,7 @@ If your multilingual site includes an RTL language (configured with
 your dev dependencies:
 
 ```sh
-npm install --save-dev autoprefixer postcss postcss-cli rtlcss
+npm install --save-dev rtlcss autoprefixer postcss-cli
 ```
 
 For an example of Docsy's RTL support, see the [Persian pages][] of the [Docsy

--- a/docsy.dev/content/en/docs/language.md
+++ b/docsy.dev/content/en/docs/language.md
@@ -143,7 +143,7 @@ If your multilingual site includes an RTL language (configured with
 your dev dependencies:
 
 ```sh
-npm install --save-dev rtlcss autoprefixer postcss-cli
+npm install --save-dev autoprefixer postcss postcss-cli rtlcss
 ```
 
 For an example of Docsy's RTL support, see the [Persian pages][] of the [Docsy

--- a/docsy.dev/content/en/docs/language.md
+++ b/docsy.dev/content/en/docs/language.md
@@ -146,10 +146,15 @@ your dev dependencies:
 npm install --save-dev rtlcss autoprefixer postcss-cli
 ```
 
+npm also installs `postcss` itself as a peer dependency; for details, see
+[Install PostCSS][install-postcss].
+
 For an example of Docsy's RTL support, see the [Persian pages][] of the [Docsy
 example].
 
 [bs-rtl]: https://getbootstrap.com/docs/5.3/getting-started/rtl/
+[install-postcss]:
+  /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [PostCSS]: https://postcss.org/
 [RTLCSS]: https://rtlcss.com/
 [rtlcss-npm]: https://www.npmjs.com/package/rtlcss

--- a/docsy.dev/content/en/docs/updating/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/updating/convert-site-to-module.md
@@ -177,7 +177,8 @@ hugo mod npm pack
 npm install
 ```
 
-Re-run `hugo mod npm pack` whenever you update Docsy; Hugo warns when the
+Re-run `hugo mod npm pack` whenever you
+[update Docsy](/docs/updating/updating-hugo-module/); Hugo warns when the
 dependency set drifts. For background, see
 [Bootstrap and Font Awesome via npm](/blog/2026/0.16.0/#npm-deps) in the 0.16.0
 release notes.

--- a/docsy.dev/content/en/docs/updating/updating-hugo-module.md
+++ b/docsy.dev/content/en/docs/updating/updating-hugo-module.md
@@ -15,11 +15,10 @@ cd /path/to/my-existing-site
 Then invoke hugo's module `get` subcommand with the update flag:
 
 ```bash
-hugo mod get -u github.com/google/docsy
+hugo mod get -u github.com/google/docsy/theme
 ```
 
-Hugo automatically pulls in the latest theme version. That's it, your update is
-done!
+Hugo automatically pulls in the latest theme version.
 
 > [!TIP]
 >
@@ -28,11 +27,25 @@ done!
 > updating your theme, for example:
 >
 > ```bash
-> hugo mod get -u github.com/google/docsy@{{% param "version" %}}
+> hugo mod get -u github.com/google/docsy/theme@{{% param "version" %}}
 > ```
 >
 > Instead of a version tag, you can also specify a commit hash, for example:
 >
 > ```bash
-> hugo mod get -u github.com/google/docsy@6c8a3afe
+> hugo mod get -u github.com/google/docsy/theme@6c8a3afe
 > ```
+
+After updating the theme, refresh the [theme npm dependencies][] that are
+consolidated into your site's `package.json`, and reinstall them:
+
+```bash
+hugo mod npm pack
+npm install
+```
+
+Hugo warns at build time when your `package.json` dependency set has drifted
+from the theme's. That's it, your update is done!
+
+[theme npm dependencies]:
+  /docs/get-started/docsy-as-module/start-from-scratch/#install-theme-npm-dependencies

--- a/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
@@ -66,4 +66,4 @@ Section pages:
 - [Other setup options](/docs/get-started/other-options/): Create a new Docsy site with Docsy using Git or NPM
 - [Deploy Docsy inside a Docker container](/docs/get-started/quickstart-docker/): Instructions on how to set up and run a local Docsy site with Docker.
 - [Basic site configuration](/docs/get-started/basic-configuration/): Basic configuration for new Docsy sites.
-- [Known issues](/docs/get-started/known_issues/): Known issues when installing Docsy theme.
+- [Troubleshooting](/docs/get-started/troubleshooting/): Troubleshooting and known issues when installing and using Docsy.

--- a/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
@@ -66,4 +66,4 @@ Section pages:
 - [Other setup options](/docs/get-started/other-options/): Create a new Docsy site with Docsy using Git or NPM
 - [Deploy Docsy inside a Docker container](/docs/get-started/quickstart-docker/): Instructions on how to set up and run a local Docsy site with Docker.
 - [Basic site configuration](/docs/get-started/basic-configuration/): Basic configuration for new Docsy sites.
-- [Troubleshooting](/docs/get-started/troubleshooting/): Troubleshooting and known issues when installing and using Docsy.
+- [Troubleshooting and known issues](/docs/get-started/troubleshooting/): Troubleshooting and known issues when installing and using Docsy.


### PR DESCRIPTION
- Follow-up to #2672, completing the docs reconciliation with the 0.16 npm-dep changes: fixes the adjacent pages deferred out of that PR's minimal scope.
- **Updating (Hugo module)**: uses the `github.com/google/docsy/theme` module path, and documents the post-update `hugo mod npm pack` + `npm install` refresh — now the canonical home for that fact, which the two setup pages deep-link to.
- **Get started**:
  - Renames `known_issues` to **Troubleshooting** (alias kept) and adds a "Missing theme npm dependencies" entry with fix paths for every setup mode.
  - Makes the prerequisites page the single home for the PostCSS install; the setup pages link to it rather than restating it.
  - Prepopulated site: adds the now-required `npm install` to the TL;DR and preview instructions, and refreshes the stale `hugo.toml` config note (the example site uses `hugo.yaml`).
- **Deployment (local, Netlify)**: drops the "PostCSS required" framing now that PostCSS is opt-in; leans out Netlify's dated instructions, noting npm auto-install and its base-directory caveat.
- **Multi-language (RTL)**: completes the PostCSS install command (`postcss` was missing); the get-started PostCSS sections now link to this canonical RTL section.
- Validated: site builds clean; link check green (all new cross-page anchors verified).
- **Preview(s)**:
  - [Troubleshooting](https://deploy-preview-2675--docsydocs.netlify.app/docs/get-started/troubleshooting/)
  - [Installation prerequisites](https://deploy-preview-2675--docsydocs.netlify.app/docs/get-started/docsy-as-module/installation-prerequisites/)
  - [Start with a prepopulated site](https://deploy-preview-2675--docsydocs.netlify.app/docs/get-started/docsy-as-module/example-site-as-template/)
  - [Update your Docsy Hugo Module](https://deploy-preview-2675--docsydocs.netlify.app/docs/updating/updating-hugo-module/)
  - [Multi-language support (RTL)](https://deploy-preview-2675--docsydocs.netlify.app/docs/language/#right-to-left-languages)
  - [Serving your site locally](https://deploy-preview-2675--docsydocs.netlify.app/docs/deployment/local/)
  - [Deployment on Netlify](https://deploy-preview-2675--docsydocs.netlify.app/docs/deployment/netlify/)