### PR TITLE
Refresh 0.16.0 release artifacts through 4e954dc1

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -491,6 +491,7 @@ https://github.com/google/docsy/pull/2656,200,1782563370
 https://github.com/google/docsy/pull/2658,200,1782563371
 https://github.com/google/docsy/pull/2660,200,1782498231
 https://github.com/google/docsy/pull/2662,200,1782498231
+https://github.com/google/docsy/pull/2664,200,1784236427
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368
@@ -559,6 +560,7 @@ https://github.com/kubernetes/website/issues/44002,200,1782498236
 https://github.com/kubernetes/website/issues/48807,200,1782498237
 https://github.com/kubernetes/website/pull/48721,200,1782498237
 https://github.com/layer5io/docs,200,1782498548
+https://github.com/lycheeverse/lychee,200,1784236427
 https://github.com/marketplace/actions/hugo-setup,200,1782563368
 https://github.com/navidrome/website,200,1782498548
 https://github.com/nvm-sh/nvm,200,1782498235

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -161,6 +161,7 @@ https://github.com/gohugoio/hugo/releases/tag/v0.154.4,200,1782498234
 https://github.com/gohugoio/hugo/releases/tag/v0.155.3,200,1782498232
 https://github.com/gohugoio/hugo/releases/tag/v0.157.0,200,1782498231
 https://github.com/gohugoio/hugo/releases/tag/v0.158.0,200,1782563370
+https://github.com/gohugoio/hugo/releases/tag/v0.160.1,200,1784287569
 https://github.com/gohugoio/hugo/releases/tag/v0.163.2,200,1782498231
 https://github.com/gohugoio/hugo/releases/tag/v0.163.3,200,1782563370
 https://github.com/gohugoio/hugo/releases/tag/v0.164.0,200,1784242277

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -495,6 +495,7 @@ https://github.com/google/docsy/pull/2658,200,1782563371
 https://github.com/google/docsy/pull/2660,200,1782498231
 https://github.com/google/docsy/pull/2662,200,1782498231
 https://github.com/google/docsy/pull/2664,200,1784236427
+https://github.com/google/docsy/pull/2677,200,1784292830
 https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -41,6 +41,7 @@ https://developers.google.com/style/tense,200,1782498230
 https://diagrams.net/,200,1782498237
 https://discourse.gohugo.io/t/can-hugo-include-shortcode-headings-in-toc/51940,200,1782498235
 https://discourse.gohugo.io/t/config-is-services-googleanalytics-id-an-alias-for-googleanalytics/39469,200,1782498235
+https://discourse.gohugo.io/t/hugo-building-slowly-from-release-0-128-0/57314/21,200,1784289856
 https://discourse.gohugo.io/t/hugo-v0-112-0-new-template-functions/44512,200,1782498231
 https://discourse.gohugo.io/t/markdown-attributes/41783,200,1782498238
 https://discourse.gohugo.io/t/tableofcontents-doesnt-render-headings-correctly-that-contains-shortcode/55399,200,1782498235
@@ -356,6 +357,7 @@ https://github.com/google/docsy/issues/new?title=Git%20repo%20info%20and%20branc
 https://github.com/google/docsy/issues/new?title=Hello%20Docsy!,200,1782498546
 https://github.com/google/docsy/issues/new?title=Hugo%200.152.0-0.155.x%20upgrade%20guide,200,1782498546
 https://github.com/google/docsy/issues/new?title=Hugo%200.158.0-0.163.x%20upgrade%20guide,200,1782498546
+https://github.com/google/docsy/issues/new?title=Hugo%200.158.0-0.164.x%20upgrade%20guide,200,1784289856
 https://github.com/google/docsy/issues/new?title=Hugo%20Content%20Tips,200,1782498244
 https://github.com/google/docsy/issues/new?title=Implementation,200,1782498547
 https://github.com/google/docsy/issues/new?title=Known%20issues,200,1782498245

--- a/docsy.dev/config/_default/hugo.yaml
+++ b/docsy.dev/config/_default/hugo.yaml
@@ -49,7 +49,7 @@ markup:
 
 params:
   # Officially supported Hugo version. Can be >= the Docsy min Hugo version.
-  hugoMinVersion: &hugoMinVersion 0.158.0
+  hugoMinVersion: &hugoMinVersion 0.160.1
   productionURL: &productionURL https://www.docsy.dev
   mainBranchPreviewURL: https://main--docsydocs.netlify.app/
   copyright:

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -21,17 +21,9 @@ cSpell:ignore: CatmullRom favicons TOF
 
 {{% card header="Highlights" %}}
 
-- {{% _param FAS_LG folder-tree primary %}}
-  <span>**[Theme folder move](#theme-folder)**: the theme now lives in `theme/`,
-  cleanly separated from repository and website tooling — one config-line update
-  for each install mode</span>
-- {{% _param FAS_LG code success %}} <span>**[Hugo 0.158+](#hugo)**: theme
-  templates track Hugo's current APIs; the minimum supported Hugo version is now
-  0.158.0, and the project build is validated with Hugo 0.163.3</span>
 - {{% _param FAS_LG cubes primary %}}
-  <span>**[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies
-  now come from Hugo's first-class npm-module support, replacing the Hugo-module
-  import workarounds and the `rfs` vendoring hack</span>
+  <span>**[Packaging modernization](#theme-folder)**: the theme now lives in
+  `theme/`, and [its dependencies now come from npm](#npm-deps)</span>
 - {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
   their icons — drop conventionally named files into `static/` and Docsy
   discovers and links them; one less thing to hand-maintain</span>

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -2,12 +2,13 @@
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
 date: 2026-06-15
-lastmod: 2026-06-15
+lastmod: 2026-07-16
 draft: true
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the theme folder
-  move, Hugo 0.158+ support, favicon handling, an experimental shared chrome
-  build mode, and repository packaging cleanup.
+  move, Hugo 0.158+ support, npm-sourced Bootstrap and Font Awesome, favicon
+  handling, an experimental shared chrome build mode, and repository packaging
+  cleanup.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -21,18 +22,23 @@ cSpell:ignore: CatmullRom favicons TOF
 {{% card header="Highlights" %}}
 
 - {{% _param FAS_LG folder-tree primary %}}
-  <span>**[Theme folder move](#theme-folder)**: the Docsy theme now lives in
-  `theme/`, with one config-line update for each supported install mode</span>
-- {{% _param FAS_LG code success %}} <span>**[Hugo 0.158+](#hugo)**: Docsy's
-  minimum supported Hugo version is now 0.158.0, and the project build is
-  validated with Hugo 0.163.2</span>
-- {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites supply
-  their own icons; Docsy discovers conventionally named files in
-  `static/`</span>
+  <span>**[Theme folder move](#theme-folder)**: the theme now lives in `theme/`,
+  cleanly separated from repository and website tooling — one config-line update
+  for each install mode</span>
+- {{% _param FAS_LG code success %}} <span>**[Hugo 0.158+](#hugo)**: theme
+  templates track Hugo's current APIs; the minimum supported Hugo version is now
+  0.158.0, and the project build is validated with Hugo 0.163.3</span>
+- {{% _param FAS_LG cubes primary %}}
+  <span>**[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies
+  now come from Hugo's first-class npm-module support, replacing the Hugo-module
+  import workarounds and the `rfs` vendoring hack</span>
+- {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
+  their icons — drop conventionally named files into `static/` and Docsy
+  discovers and links them; one less thing to hand-maintain</span>
 - {{% _param FAS_LG bolt warning %}} <span>**[Shared chrome](#shared-chrome)**
   (experimental): an opt-in build mode that emits repeated chrome once per
-  language for faster link-checking and previews; `full` stays the
-  default</span>
+  language and restores it in the browser, for considerably faster link-checking
+  of large sites; `full` stays the default</span>
 
 {{% /card %}}
 
@@ -43,9 +49,16 @@ cSpell:ignore: CatmullRom favicons TOF
   website tooling ([#2641][], [#2645][]).
 - **[Hugo support](#hugo)**:
   - The theme minimum moved from Hugo 0.146.0 to **0.158.0**.
-  - The Docsy project build was upgraded to **Hugo 0.163.2**.
+  - The Docsy project build was upgraded to **Hugo 0.163.3**.
   - Theme templates and docs moved off deprecated Hugo language APIs ([#2647][],
-    [#2648][], [#2649][]).
+    [#2648][], [#2649][], [#2664][]).
+- **[Bootstrap and Font Awesome via npm](#npm-deps)**:
+  - The theme sources Bootstrap and Font Awesome from npm through
+    [`hugo mod npm pack`][hugo-npm-pack], rather than importing their GitHub
+    repositories as Hugo modules.
+  - Hugo-module sites pull the dependencies with `hugo mod npm pack` and
+    `npm install`; other install modes are unaffected.
+  - PostCSS is now [opt-in for non-RTL sites](#postcss) ([#2668][]).
 - **[Favicons](#favicons)**:
   - The theme no longer ships default favicon artwork.
   - The default partial discovers and links common favicon filenames from a
@@ -71,7 +84,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Default favicons removed](#favicons)
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
-  not already building cleanly with Hugo 0.163.2.
+  not already building cleanly with Hugo 0.163.3.
 - Optionally skim:
   - {{% _param NEW %}} New favicon discovery behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
@@ -186,16 +199,16 @@ Theme templates now use Hugo's newer language APIs, introduced in 0.158.0, so
 sites building with Hugo 0.157.x or earlier must upgrade Hugo before or while
 upgrading Docsy ([#2581][], [#2593][]).
 
-The Docsy project build is validated with **Hugo 0.163.2**. We recommend moving
-directly to 0.163.2 unless your project has a reason to pin a lower version. For
-the detailed Hugo changes between 0.158.0 and 0.163.2, see the companion [Hugo
+The Docsy project build is validated with **Hugo 0.163.3**. We recommend moving
+directly to 0.163.3 unless your project has a reason to pin a lower version. For
+the detailed Hugo changes between 0.158.0 and 0.163.3, see the companion [Hugo
 0.158+ upgrade guide][hugo-upgrade].
 
 ### Actions {#hugo-actions}
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.158.0 or later. Prefer Hugo 0.163.2.
+- Upgrade to Hugo 0.158.0 or later. Prefer Hugo 0.163.3.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.158.0`.
 - If your multilingual site config still uses Hugo's older language keys,
   consider updating them:
@@ -349,7 +362,9 @@ path change covered in [Theme folder move](#theme-folder).
 
 Docsy's own test suite now includes guards for Hugo deprecation output and small
 fixture-site regression tests. These checks helped validate the Hugo 0.158.0 to
-0.163.2 upgrade range and the new theme folder install matrix.
+0.163.3 upgrade range and the new theme folder install matrix. The project's
+link checking also moved from the unmaintained htmltest to [Lychee][], with a
+committed link cache for fast, reproducible checks.
 
 ## {{% _param FAS rocket primary %}} Upgrade to 0.16.0 {#upgrade}
 
@@ -359,7 +374,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0. For this release, use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
-- **Hugo**: [0.157.0][] -> [0.163.2][] (theme minimum: [0.158.0][])
+- **Hugo**: [0.157.0][] -> [0.163.3][] (theme minimum: [0.158.0][])
 - **Node**: LTS 24 (unchanged)
 
 [^vers-note]:
@@ -379,7 +394,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 ### {{% _param FAS square-check primary %}} Sanity checks
 
 - [ ] **Build your site** locally with Hugo 0.158.0 or later, preferably
-      0.163.2.
+      0.163.3.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
 - [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
@@ -440,12 +455,13 @@ About this release:
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2660]: https://github.com/google/docsy/pull/2660
 [#2662]: https://github.com/google/docsy/pull/2662
+[#2664]: https://github.com/google/docsy/pull/2664
 [#2668]: https://github.com/google/docsy/issues/2668
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [0.158.0]: https://github.com/gohugoio/hugo/releases/tag/v0.158.0
-[0.163.2]: https://github.com/gohugoio/hugo/releases/tag/v0.163.2
+[0.163.3]: https://github.com/gohugoio/hugo/releases/tag/v0.163.3
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [browserslist-defaults]: https://github.com/browserslist/browserslist
 [chrome]: /docs/deployment/chrome/
@@ -454,6 +470,7 @@ About this release:
 [experimental]: /project/about/changelog/#experimental
 [hugo-upgrade]: hugo-0.158.0+/
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
+[Lychee]: https://github.com/lycheeverse/lychee
 [Multi-language support]: /docs/language/
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -2,11 +2,11 @@
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
 date: 2026-06-15
-lastmod: 2026-07-16
+lastmod: 2026-07-17
 draft: true
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the theme folder
-  move, Hugo 0.158+ support, npm-sourced Bootstrap and Font Awesome, favicon
+  move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, favicon
   handling, an experimental shared chrome build mode, and repository packaging
   cleanup.
 author: >-
@@ -40,7 +40,7 @@ cSpell:ignore: CatmullRom favicons TOF
   `theme/`, separating the consumer-facing theme tree from repository and
   website tooling.
 - **[Hugo support](#hugo)**:
-  - The theme minimum moved from Hugo 0.146.0 to **0.158.0**.
+  - The theme minimum moved from Hugo 0.146.0 to **0.160.1**.
   - The Docsy project build was upgraded to **Hugo 0.163.3**.
   - Theme templates and docs moved off deprecated Hugo language APIs.
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**:
@@ -181,12 +181,14 @@ cd ..
 For a Git submodule install, keep your existing submodule update workflow, then
 run the same `docsy` postinstall step after updating the submodule.
 
-## {{% _param BREAKING %}} Hugo 0.158+ support {#hugo}
+## {{% _param BREAKING %}} Hugo 0.160.1+ support {#hugo}
 
-Docsy 0.16.0 raises the theme's minimum supported Hugo version to **0.158.0**.
-Theme templates now use Hugo's newer language APIs, introduced in 0.158.0, so
-sites building with Hugo 0.157.x or earlier must upgrade Hugo before or while
-upgrading Docsy.
+Docsy 0.16.0 raises the theme's minimum supported Hugo version to **0.160.1**.
+Theme templates use Hugo's newer language APIs, introduced in 0.158.0, and the
+theme's [npm-sourced dependencies](#npm-deps) rely on `hugo mod npm pack`
+support introduced in 0.159.0; the 0.160.1 minimum also excludes known
+regressions in the 0.159.2 to 0.160.0 range. Sites building with an older Hugo
+version must upgrade Hugo before or while upgrading Docsy.
 
 The Docsy project build is validated with **Hugo 0.163.3**. We recommend moving
 directly to 0.163.3 unless your project has a reason to pin a lower version. For
@@ -197,8 +199,8 @@ the detailed Hugo changes between 0.158.0 and 0.163.3, see the companion [Hugo
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.158.0 or later. Prefer Hugo 0.163.3.
-- If your site declares `module.hugoVersion.min`, set it to at least `0.158.0`.
+- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.163.3.
+- If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
 - If your multilingual site config still uses Hugo's older language keys,
   consider updating them:
   - `languageName` -> `label`
@@ -363,7 +365,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0. For this release, use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
-- **Hugo**: [0.157.0][] -> [0.163.3][] (theme minimum: [0.158.0][])
+- **Hugo**: [0.157.0][] -> [0.163.3][] (theme minimum: [0.160.1][])
 - **Node**: LTS 24 (unchanged)
 
 [^vers-note]:
@@ -382,7 +384,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 
 ### {{% _param FAS square-check primary %}} Sanity checks
 
-- [ ] **Build your site** locally with Hugo 0.158.0 or later, preferably
+- [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
       0.163.3.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
@@ -437,7 +439,7 @@ About this release:
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
-[0.158.0]: https://github.com/gohugoio/hugo/releases/tag/v0.158.0
+[0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [0.163.3]: https://github.com/gohugoio/hugo/releases/tag/v0.163.3
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [browserslist-defaults]: https://github.com/browserslist/browserslist

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -38,30 +38,27 @@ cSpell:ignore: CatmullRom favicons TOF
 
 - **[Theme folder move](#theme-folder)**: the canonical theme files moved under
   `theme/`, separating the consumer-facing theme tree from repository and
-  website tooling ([#2641][], [#2645][]).
+  website tooling.
 - **[Hugo support](#hugo)**:
   - The theme minimum moved from Hugo 0.146.0 to **0.158.0**.
   - The Docsy project build was upgraded to **Hugo 0.163.3**.
-  - Theme templates and docs moved off deprecated Hugo language APIs ([#2647][],
-    [#2648][], [#2649][], [#2664][]).
+  - Theme templates and docs moved off deprecated Hugo language APIs.
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**:
   - The theme sources Bootstrap and Font Awesome from npm through
     [`hugo mod npm pack`][hugo-npm-pack], rather than importing their GitHub
     repositories as Hugo modules.
   - Hugo-module sites pull the dependencies with `hugo mod npm pack` and
     `npm install`; other install modes are unaffected.
-  - PostCSS is now [opt-in for non-RTL sites](#postcss) ([#2668][]).
+  - PostCSS is now [opt-in for non-RTL sites](#postcss).
 - **[Favicons](#favicons)**:
   - The theme no longer ships default favicon artwork.
   - The default partial discovers and links common favicon filenames from a
     site's `static/` directory.
-  - A `gen-favicons` helper can generate raster icons from a source SVG
-    ([#2357][], [#2595][], [#2653][], [#2654][], [#2656][]).
+  - A `gen-favicons` helper can generate raster icons from a source SVG.
 - **[Shared chrome build mode](#shared-chrome)** (experimental): a new opt-in
   `td.chrome = shared` mode that emits the repeated chrome (navbar, footer,
   left-nav) once per language and restores it in the browser, so one build
-  serves both readers and link checkers; the default `full` mode is unchanged
-  ([#2659][], [#2660][], [#2662][]).
+  serves both readers and link checkers; the default `full` mode is unchanged.
 - **Other notable changes**:
   - Theme runtime dependencies now live in `theme/package.json`.
   - The repository uses npm workspaces for `docsy.dev` and `theme`.
@@ -189,7 +186,7 @@ run the same `docsy` postinstall step after updating the submodule.
 Docsy 0.16.0 raises the theme's minimum supported Hugo version to **0.158.0**.
 Theme templates now use Hugo's newer language APIs, introduced in 0.158.0, so
 sites building with Hugo 0.157.x or earlier must upgrade Hugo before or while
-upgrading Docsy ([#2581][], [#2593][]).
+upgrading Docsy.
 
 The Docsy project build is validated with **Hugo 0.163.3**. We recommend moving
 directly to 0.163.3 unless your project has a reason to pin a lower version. For
@@ -227,7 +224,7 @@ since neither project publishes a Go module. Hugo's first-class npm-module
 support makes them unnecessary: `theme/package.json` declares Bootstrap and Font
 Awesome, and [`hugo mod npm pack`][hugo-npm-pack] delivers them to your project.
 This also retires the theme's generated Go-module requires, a module-sync
-script, and a Bootstrap `rfs` vendor workaround ([#2668][]).
+script, and a Bootstrap `rfs` vendor workaround.
 
 ### Actions {#npm-deps-actions}
 
@@ -405,7 +402,10 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 
 The 0.16.0 release closes the main user-facing pieces of the theme-folder move.
 Follow-up repository cleanup and future packaging work continue under [Finalize
-monorepo setup - 26Q2 (#2617)][#2617].
+monorepo setup - 26Q2 (#2617)][#2617]. The experimental
+[shared chrome build mode](#shared-chrome) evolves under [#2659][], and further
+favicon improvements, such as light- and dark-mode variants, are tracked in
+[#2357][].
 
 <!-- prettier-ignore -->
 > [!INFO]- Your opinion counts!
@@ -431,24 +431,9 @@ About this release:
 
 <!-- prettier-ignore-start -->
 [#2357]: https://github.com/google/docsy/issues/2357
-[#2581]: https://github.com/google/docsy/issues/2581
-[#2593]: https://github.com/google/docsy/issues/2593
-[#2595]: https://github.com/google/docsy/issues/2595
 [#2615]: https://github.com/google/docsy/issues/2615
 [#2617]: https://github.com/google/docsy/issues/2617
-[#2641]: https://github.com/google/docsy/pull/2641
-[#2645]: https://github.com/google/docsy/pull/2645
-[#2647]: https://github.com/google/docsy/pull/2647
-[#2648]: https://github.com/google/docsy/pull/2648
-[#2649]: https://github.com/google/docsy/pull/2649
-[#2653]: https://github.com/google/docsy/pull/2653
-[#2654]: https://github.com/google/docsy/pull/2654
-[#2656]: https://github.com/google/docsy/pull/2656
 [#2659]: https://github.com/google/docsy/issues/2659
-[#2660]: https://github.com/google/docsy/pull/2660
-[#2662]: https://github.com/google/docsy/pull/2662
-[#2664]: https://github.com/google/docsy/pull/2664
-[#2668]: https://github.com/google/docsy/issues/2668
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -41,7 +41,7 @@ cSpell:ignore: CatmullRom favicons TOF
   website tooling.
 - **[Hugo support](#hugo)**:
   - The theme minimum moved from Hugo 0.146.0 to **0.160.1**.
-  - The Docsy project build was upgraded to **Hugo 0.163.3**.
+  - The Docsy project build was upgraded to **Hugo 0.164.0**.
   - Theme templates and docs moved off deprecated Hugo language APIs.
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**:
   - The theme sources Bootstrap and Font Awesome from npm through
@@ -73,7 +73,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Default favicons removed](#favicons)
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
-  not already building cleanly with Hugo 0.163.3.
+  not already building cleanly with Hugo 0.164.0.
 - Optionally skim:
   - {{% _param NEW %}} New favicon discovery behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
@@ -190,16 +190,16 @@ support introduced in 0.159.0; the 0.160.1 minimum also excludes known
 regressions in the 0.159.2 to 0.160.0 range. Sites building with an older Hugo
 version must upgrade Hugo before or while upgrading Docsy.
 
-The Docsy project build is validated with **Hugo 0.163.3**. We recommend moving
-directly to 0.163.3 unless your project has a reason to pin a lower version. For
-the detailed Hugo changes between 0.158.0 and 0.163.3, see the companion [Hugo
+The Docsy project build is validated with **Hugo 0.164.0**. We recommend moving
+directly to 0.164.0 unless your project has a reason to pin a lower version. For
+the detailed Hugo changes between 0.158.0 and 0.164.0, see the companion [Hugo
 0.158+ upgrade guide][hugo-upgrade].
 
 ### Actions {#hugo-actions}
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.163.3.
+- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.164.0.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
 - If your multilingual site config still uses Hugo's older language keys,
   consider updating them:
@@ -353,7 +353,7 @@ path change covered in [Theme folder move](#theme-folder).
 
 Docsy's own test suite now includes guards for Hugo deprecation output and small
 fixture-site regression tests. These checks helped validate the Hugo 0.158.0 to
-0.163.3 upgrade range and the new theme folder install matrix. The project's
+0.164.0 upgrade range and the new theme folder install matrix. The project's
 link checking also moved from the unmaintained htmltest to [Lychee][], with a
 committed link cache for fast, reproducible checks.
 
@@ -365,7 +365,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0. For this release, use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
-- **Hugo**: [0.157.0][] -> [0.163.3][] (theme minimum: [0.160.1][])
+- **Hugo**: [0.157.0][] -> [0.164.0][] (theme minimum: [0.160.1][])
 - **Node**: LTS 24 (unchanged)
 
 [^vers-note]:
@@ -385,7 +385,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 ### {{% _param FAS square-check primary %}} Sanity checks
 
 - [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
-      0.163.3.
+      0.164.0.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
 - [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
@@ -440,7 +440,7 @@ About this release:
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
-[0.163.3]: https://github.com/gohugoio/hugo/releases/tag/v0.163.3
+[0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [browserslist-defaults]: https://github.com/browserslist/browserslist
 [chrome]: /docs/deployment/chrome/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -183,12 +183,21 @@ run the same `docsy` postinstall step after updating the submodule.
 
 ## {{% _param BREAKING %}} Hugo 0.160.1+ support {#hugo}
 
-Docsy 0.16.0 raises the theme's minimum supported Hugo version to **0.160.1**.
-Theme templates use Hugo's newer language APIs, introduced in 0.158.0, and the
-theme's [npm-sourced dependencies](#npm-deps) rely on `hugo mod npm pack`
-support introduced in 0.159.0; the 0.160.1 minimum also excludes known
-regressions in the 0.159.2 to 0.160.0 range. Sites building with an older Hugo
-version must upgrade Hugo before or while upgrading Docsy.
+Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
+**0.160.1**. The minimum reflects three changes in this range:
+
+- Theme templates use Hugo language APIs introduced in **0.158.0**; older Hugo
+  versions fail with template errors.
+- The theme's [npm-sourced dependencies](#npm-deps) rely on `hugo mod npm pack`
+  support introduced in **0.159.0**. On older Hugo versions the pack step exits
+  successfully but writes empty dependency lists, so the failure surfaces only
+  later, as a hard-to-trace SCSS import error — Hugo's minimum-version warning
+  is the only early signal.
+- **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
+  such as Markdown-link escaping, and passthrough and shortcode rendering.
+
+Sites building with an older Hugo version must upgrade Hugo before or while
+upgrading Docsy.
 
 The Docsy project build is validated with **Hugo 0.164.0**. We recommend moving
 directly to 0.164.0 unless your project has a reason to pin a lower version. For

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -2,6 +2,7 @@
 title: Hugo 0.158.0-0.163.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-06-15
+lastmod: 2026-07-16
 draft: true
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
@@ -13,11 +14,11 @@ cSpell:ignore: amp AVIF CatmullRom goldmark Netlify Pandoc partialCached passthr
 ---
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
-0.163.2 that are relevant to Docsy users. It is a companion post to the Docsy
+0.163.3 that are relevant to Docsy users. It is a companion post to the Docsy
 [0.16.0](0.16.0/) release and upgrade guide.
 
 Docsy 0.16.0 requires Hugo 0.158.0 or later. The Docsy project build is tested
-with Hugo 0.163.2, which is the recommended target for this upgrade range.
+with Hugo 0.163.3, which is the recommended target for this upgrade range.
 
 ## Upgrade summary
 
@@ -40,7 +41,7 @@ Docsy site to 0.16.0.
   - [Image URL churn](#image-url-churn)
   - [Template and module cleanup](#template-module-cleanup)
   - [Notable changes](#notable-changes)
-- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.163.2](#upgrade)
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.163.3](#upgrade)
   once you're ready.
 
 ## {{% _param BREAKING %}} Hugo version for Docsy 0.16.0 {#hugo-version}
@@ -50,7 +51,7 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 so older Hugo versions will fail with template errors.
 
 The theme minimum remains 0.158.0 through the 0.163.x range. However, we
-recommend upgrading directly to **Hugo 0.163.2** because the later releases
+recommend upgrading directly to **Hugo 0.163.3** because the later releases
 include security fixes, avoid a short-lived 0.159.x link-escaping regression,
 and are the versions validated across Docsy, the Docsy example site, and at
 least one large downstream Docsy site.
@@ -59,19 +60,19 @@ least one large downstream Docsy site.
 
 {{% _param BREAKING %}} **Applies to all sites upgrading to Docsy 0.16.0.**
 
-- Upgrade Hugo to 0.158.0 or later. Prefer 0.163.2.
+- Upgrade Hugo to 0.158.0 or later. Prefer 0.163.3.
 - If your project declares `module.hugoVersion.min`, set it to at least
   `0.158.0`.
 - If you use `hugo-extended`, pin a compatible version in your site:
 
   ```sh
-  npm install hugo-extended@0.163.2 --save-dev
+  npm install hugo-extended@0.163.3 --save-dev
   ```
 
 - If you use [hvm][], select the latest compatible Hugo release:
 
   ```sh
-  hvm use 0.163.2
+  hvm use 0.163.3
   ```
 
 ## Language API deprecations (0.158.0) {#language-apis}
@@ -174,8 +175,10 @@ breaking change even when the Docsy theme itself has not changed.
 
 Hugo 0.163.2 fixes an `ERR_ACCESS_DENIED` regression in this permission model
 that could abort builds when `node_modules` lives outside the project tree, such
-as in a CI provider's shared cache (for example, Netlify). It is another reason
-to prefer 0.163.2 for PostCSS pipelines.
+as in a CI provider's shared cache (for example, Netlify). Hugo 0.163.3 extends
+the same work so that config-file resolution also finds `.mjs` and `.cjs`
+variants of PostCSS and Babel configs. Both are reasons to prefer 0.163.3 for
+PostCSS pipelines.
 
 ### Actions {#node-tools-actions}
 
@@ -186,7 +189,9 @@ runs PostCSS, Babel, Tailwind, or similar Node tools during the Hugo build.
 - Build locally and check for Node permission errors.
 - If your CI keeps `node_modules` outside the project tree (for example,
   Netlify's shared cache) and the build fails with `ERR_ACCESS_DENIED`, upgrade
-  to Hugo 0.163.2.
+  to Hugo 0.163.2 or later.
+- If your PostCSS or Babel config uses an `.mjs` or `.cjs` variant (for example,
+  `postcss.config.mjs`), use Hugo 0.163.3, which resolves those variants.
 - If your project uses Tailwind, install Tailwind as an npm package. Hugo no
   longer supports the standalone Tailwind binary in this path.
 
@@ -274,6 +279,9 @@ JavaScript tooling config:
   output. Hugo 0.162.0 fixed GitInfo handling for modules whose `go.mod` lives
   in a repository subdirectory.
 - If you use `--renderSegments`, prefer Hugo 0.163.1 for its segment-merge fix.
+- If your site sets `uglyURLs: true` and has a page and a section sharing a name
+  (for example, `download.htm` beside `download/`), use Hugo 0.163.3, which
+  fixes a rendering collision introduced earlier in the 0.163.x range.
 - If your site renders Pandoc or reStructuredText content through external
   converters, Hugo 0.163.2 now **fails the build** when the converter binary is
   missing (matching AsciiDoc) instead of silently publishing raw content; ensure
@@ -282,8 +290,11 @@ JavaScript tooling config:
 ### Security fixes {#security-fixes}
 
 This range includes multiple security-related updates, including Go
-`html/template` fixes and stricter URL/content handling. This is a strong reason
-to prefer 0.163.2 over stopping at the minimum 0.158.0.
+`html/template` fixes and stricter URL/content handling. Hugo 0.163.3 also
+hardens the default code-block render hook: the language token (info string) of
+fenced code blocks is now escaped, which matters most for sites that render
+untrusted Markdown. This is a strong reason to prefer 0.163.3 over stopping at
+the minimum 0.158.0.
 
 ### New features worth knowing about {#new-features}
 
@@ -293,21 +304,21 @@ to prefer 0.163.2 over stopping at the minimum 0.158.0.
 - `strings.ReplacePairs` is available for template authors on Hugo 0.158.0 or
   later.
 
-## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.163.2 {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.163.3 {#upgrade}
 
 After addressing applicable breaking changes and deprecations, upgrade to Hugo
-0.163.2.
+0.163.3.
 
 If you use the [hugo-extended][] npm package:
 
 ```sh
-npm install hugo-extended@0.163.2 --save-dev
+npm install hugo-extended@0.163.3 --save-dev
 ```
 
 If you use [hvm][]:
 
 ```sh
-hvm use 0.163.2
+hvm use 0.163.3
 ```
 
 <section class="td-checkbox-list-wrapper">
@@ -353,7 +364,7 @@ module:
     min: 0.158.0
 ```
 
-For local builds, deployments, and new upgrades, we recommend Hugo 0.163.2.
+For local builds, deployments, and new upgrades, we recommend Hugo 0.163.3.
 
 <!-- prettier-ignore-start -->
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -48,17 +48,8 @@ Docsy site to 0.16.0.
 ## {{% _param BREAKING %}} Hugo version for Docsy 0.16.0 {#hugo-version}
 
 Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
-**0.160.1**. The minimum reflects three changes in this range:
-
-- Theme templates use Hugo language APIs introduced in **0.158.0**; older Hugo
-  versions fail with template errors.
-- The theme's npm-sourced Bootstrap and Font Awesome rely on `hugo mod npm pack`
-  support introduced in **0.159.0**. On older Hugo versions the pack step exits
-  successfully but writes empty dependency lists, so the failure surfaces only
-  later, as a hard-to-trace SCSS import error — Hugo's minimum-version warning
-  is the only early signal.
-- **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
-  such as Markdown-link escaping, and passthrough and shortcode rendering.
+**0.160.1**. For the rationale behind that floor, see
+[Hugo 0.160.1+ support](0.16.0/#hugo) in the release post.
 
 We recommend upgrading directly to **Hugo 0.164.0**: the later releases include
 security fixes, 0.164.0

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -119,7 +119,7 @@ Review custom template code for these replacements:
 
 For current Docsy examples, see [Multi-language support][].
 
-## Markdown-link escaping (0.159.2 to 0.160.1) {#amp-escaping}
+## Markdown-link escaping (0.159.2, fixed in 0.160.0) {#amp-escaping}
 
 Hugo 0.159.2 included a security fix for dangerous URLs in Markdown links and
 images. It also introduced a regression that could double-escape `&` in rendered

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,5 +1,5 @@
 ---
-title: Hugo 0.158.0-0.163.x upgrade guide
+title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-06-15
 lastmod: 2026-07-17
@@ -10,15 +10,15 @@ author: >-
 body_class: release-highlights
 tags: [hugo, upgrade]
 # prettier-ignore
-cSpell:ignore: amp AVIF CatmullRom goldmark Netlify Pandoc partialCached passthrough renderSegments reStructuredText useEmbedded userinfo
+cSpell:ignore: amp AVIF CatmullRom chromastyles goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
 ---
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
-0.163.3 that are relevant to Docsy users. It is a companion post to the Docsy
+0.164.0 that are relevant to Docsy users. It is a companion post to the Docsy
 [0.16.0](0.16.0/) release and upgrade guide.
 
 Docsy 0.16.0 requires Hugo 0.160.1 or later. The Docsy project build is tested
-with Hugo 0.163.3, which is the recommended target for this upgrade range.
+with Hugo 0.164.0, which is the recommended target for this upgrade range.
 
 ## Upgrade summary
 
@@ -40,8 +40,9 @@ Docsy site to 0.16.0.
   - [Markdown-link escaping](#amp-escaping)
   - [Image URL churn](#image-url-churn)
   - [Template and module cleanup](#template-module-cleanup)
+  - [Faster builds and stricter templates](#hugo-0-164-0)
   - [Notable changes](#notable-changes)
-- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.163.3](#upgrade)
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.164.0](#upgrade)
   once you're ready.
 
 ## {{% _param BREAKING %}} Hugo version for Docsy 0.16.0 {#hugo-version}
@@ -59,27 +60,29 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 - **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
   such as Markdown-link escaping, and passthrough and shortcode rendering.
 
-We recommend upgrading directly to **Hugo 0.163.3** because the later releases
-include security fixes and are the versions validated across Docsy, the Docsy
-example site, and at least one large downstream Docsy site.
+We recommend upgrading directly to **Hugo 0.164.0**: the later releases include
+security fixes, 0.164.0
+[fixes a long-standing template-rendering slowdown](#hugo-0-164-0), and these
+are the versions validated across Docsy, the Docsy example site, and at least
+one large downstream Docsy site.
 
 ### Actions {#hugo-version-actions}
 
 {{% _param BREAKING %}} **Applies to all sites upgrading to Docsy 0.16.0.**
 
-- Upgrade Hugo to 0.160.1 or later. Prefer 0.163.3.
+- Upgrade Hugo to 0.160.1 or later. Prefer 0.164.0.
 - If your project declares `module.hugoVersion.min`, set it to at least
   `0.160.1`.
 - If you use `hugo-extended`, pin a compatible version in your site:
 
   ```sh
-  npm install hugo-extended@0.163.3 --save-dev
+  npm install hugo-extended@0.164.0 --save-dev
   ```
 
 - If you use [hvm][], select the latest compatible Hugo release:
 
   ```sh
-  hvm use 0.163.3
+  hvm use 0.164.0
   ```
 
 ## Language API deprecations (0.158.0) {#language-apis}
@@ -185,8 +188,8 @@ Hugo 0.163.2 fixes an `ERR_ACCESS_DENIED` regression in this permission model
 that could abort builds when `node_modules` lives outside the project tree, such
 as in a CI provider's shared cache (for example, Netlify). Hugo 0.163.3 extends
 the same work so that config-file resolution also finds `.mjs` and `.cjs`
-variants of PostCSS and Babel configs. Both are reasons to prefer 0.163.3 for
-PostCSS pipelines.
+variants of PostCSS and Babel configs. Both are reasons to prefer 0.163.3 or
+later for PostCSS pipelines.
 
 ### Actions {#node-tools-actions}
 
@@ -274,6 +277,37 @@ Hugo 0.161.x-0.163.x can change resized-image filenames that contain
 this as expected cache-key churn. It can create noisy diffs and cache misses,
 but it is not usually a content regression.
 
+## Faster builds and stricter templates (0.164.0) {#hugo-0-164-0}
+
+Hugo 0.164.0 fixes a template-rendering slowdown that affected Hugo 0.128.0
+through 0.163.x. Large sites benefit the most: on a reported ~8,500-page Docsy
+site, the fix cut full-build time from 608 to 117 seconds ([performance
+discussion][hugo-164-perf]).
+
+The same release tightens template handling and refreshes syntax highlighting:
+
+- `resources.PostProcess` is deprecated; use `templates.Defer` instead. Docsy's
+  templates don't use `resources.PostProcess`.
+- `.Render` now fails the build when the named view template is missing, instead
+  of silently rendering nothing; nested view names work again.
+- The bundled Chroma highlighter retokenizes some languages, such as protobuf,
+  YAML, and Markdown: syntax-highlighting classes change, text content does not.
+- In multilingual sitemaps, each URL's `xhtml:link` alternates now list the
+  entry's own language first.
+
+### Actions {#hugo-0-164-0-actions}
+
+**Applies if** your site is large, overrides or adds templates, or commits
+generated output.
+
+- Benchmark a clean production build; template-heavy sites may see large
+  build-time wins.
+- Replace `resources.PostProcess` with `templates.Defer` in custom templates.
+- Fix any `.Render` calls that name a missing view template; they now fail the
+  build.
+- Treat syntax-highlighting class changes and sitemap alternate-link reordering
+  as expected output churn.
+
 ## Other deprecations and notable changes {#notable-changes}
 
 ### Template and config deprecations {#other-deprecations}
@@ -301,8 +335,8 @@ This range includes multiple security-related updates, including Go
 `html/template` fixes and stricter URL/content handling. Hugo 0.163.3 also
 hardens the default code-block render hook: the language token (info string) of
 fenced code blocks is now escaped, which matters most for sites that render
-untrusted Markdown. This is a strong reason to prefer 0.163.3 over stopping at
-the minimum 0.158.0.
+untrusted Markdown. This is a strong reason to prefer 0.163.3 or later over
+stopping at the minimum 0.160.1.
 
 ### New features worth knowing about {#new-features}
 
@@ -311,22 +345,24 @@ the minimum 0.158.0.
 - AVIF image processing was added and then tuned in the 0.162.x-0.163.x range.
 - `strings.ReplacePairs` is available for template authors on Hugo 0.158.0 or
   later.
+- On Hugo 0.164.0, `hugo gen chromastyles` gains `--mode` and `--modeSelector`
+  flags for generating combined light/dark syntax-highlighting stylesheets.
 
-## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.163.3 {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.164.0 {#upgrade}
 
 After addressing applicable breaking changes and deprecations, upgrade to Hugo
-0.163.3.
+0.164.0.
 
 If you use the [hugo-extended][] npm package:
 
 ```sh
-npm install hugo-extended@0.163.3 --save-dev
+npm install hugo-extended@0.164.0 --save-dev
 ```
 
 If you use [hvm][]:
 
 ```sh
-hvm use 0.163.3
+hvm use 0.164.0
 ```
 
 <section class="td-checkbox-list-wrapper">
@@ -343,6 +379,8 @@ hvm use 0.163.3
       0.159.2.
 - [ ] **Images**: expect `_hu_` resized-image filename churn and verify the
       rendered images, not just filenames.
+- [ ] **Generated output**: on 0.164.0, expect syntax-highlighting class and
+      sitemap alternate-link churn in committed output.
 - [ ] **Security policy**: test remote resources, symlinked inputs, and any
       `.html` content files.
 
@@ -359,23 +397,25 @@ hvm use 0.163.3
 - [ ] [Language API actions](#language-api-actions)
 - [ ] [Imaging actions](#imaging-actions)
 - [ ] [Markdown-link escaping actions](#amp-escaping-actions)
+- [ ] [Hugo 0.164.0 actions](#hugo-0-164-0-actions)
 
 </section>
 
 ## Recommended minimum Hugo version {#min-hugo-version}
 
-Docsy 0.16.0 requires Hugo 0.158.0 or later:
+Docsy 0.16.0 requires Hugo 0.160.1 or later:
 
 ```yaml
 module:
   hugoVersion:
-    min: 0.158.0
+    min: 0.160.1
 ```
 
-For local builds, deployments, and new upgrades, we recommend Hugo 0.163.3.
+For local builds, deployments, and new upgrades, we recommend Hugo 0.164.0.
 
 <!-- prettier-ignore-start -->
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
+[hugo-164-perf]: https://discourse.gohugo.io/t/hugo-building-slowly-from-release-0-128-0/57314/21
 [hvm]: https://github.com/jmooring/hvm
 [Multi-language support]: /docs/language/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -2,7 +2,7 @@
 title: Hugo 0.158.0-0.163.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-06-15
-lastmod: 2026-07-16
+lastmod: 2026-07-17
 draft: true
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
@@ -17,7 +17,7 @@ This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
 0.163.3 that are relevant to Docsy users. It is a companion post to the Docsy
 [0.16.0](0.16.0/) release and upgrade guide.
 
-Docsy 0.16.0 requires Hugo 0.158.0 or later. The Docsy project build is tested
+Docsy 0.16.0 requires Hugo 0.160.1 or later. The Docsy project build is tested
 with Hugo 0.163.3, which is the recommended target for this upgrade range.
 
 ## Upgrade summary
@@ -28,7 +28,7 @@ Docsy site to 0.16.0.
 - Review {{% _param BADGE BREAKING warning %}} changes:
   <a id="breaking-changes"></a>
   - {{% _param BREAKING %}}
-    [Docsy now requires Hugo 0.158.0 or later](#hugo-version)
+    [Docsy now requires Hugo 0.160.1 or later](#hugo-version)
   - {{% _param BREAKING %}}
     [Node 22+ is required for Hugo-managed Node tools](#node-tools)
   - {{% _param BREAKING %}}
@@ -47,22 +47,29 @@ Docsy site to 0.16.0.
 ## {{% _param BREAKING %}} Hugo version for Docsy 0.16.0 {#hugo-version}
 
 Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
-**0.158.0**. Theme templates now use Hugo language APIs introduced in 0.158.0,
-so older Hugo versions will fail with template errors.
+**0.160.1**. The minimum reflects three changes in this range:
 
-The theme minimum remains 0.158.0 through the 0.163.x range. However, we
-recommend upgrading directly to **Hugo 0.163.3** because the later releases
-include security fixes, avoid a short-lived 0.159.x link-escaping regression,
-and are the versions validated across Docsy, the Docsy example site, and at
-least one large downstream Docsy site.
+- Theme templates use Hugo language APIs introduced in **0.158.0**; older Hugo
+  versions fail with template errors.
+- The theme's npm-sourced Bootstrap and Font Awesome rely on `hugo mod npm pack`
+  support introduced in **0.159.0**. On older Hugo versions the pack step exits
+  successfully but writes empty dependency lists, so the failure surfaces only
+  later, as a hard-to-trace SCSS import error — Hugo's minimum-version warning
+  is the only early signal.
+- **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
+  such as Markdown-link escaping, and passthrough and shortcode rendering.
+
+We recommend upgrading directly to **Hugo 0.163.3** because the later releases
+include security fixes and are the versions validated across Docsy, the Docsy
+example site, and at least one large downstream Docsy site.
 
 ### Actions {#hugo-version-actions}
 
 {{% _param BREAKING %}} **Applies to all sites upgrading to Docsy 0.16.0.**
 
-- Upgrade Hugo to 0.158.0 or later. Prefer 0.163.3.
+- Upgrade Hugo to 0.160.1 or later. Prefer 0.163.3.
 - If your project declares `module.hugoVersion.min`, set it to at least
-  `0.158.0`.
+  `0.160.1`.
 - If you use `hugo-extended`, pin a compatible version in your site:
 
   ```sh
@@ -81,8 +88,8 @@ Hugo 0.158.0 renamed several language configuration keys and template methods.
 The old names log deprecation notices first, then move toward warnings and
 eventual errors on Hugo's deprecation timeline.
 
-Docsy's own templates and docs now use the new names, which is why Docsy 0.16.0
-requires Hugo 0.158.0 or later.
+Docsy's own templates and docs now use the new names — one of the changes behind
+0.16.0's [raised Hugo minimum](#hugo-version).
 
 ### Actions {#language-api-actions}
 
@@ -125,7 +132,8 @@ images. It also introduced a regression that could double-escape `&` in rendered
 Markdown link URLs, producing `&amp;amp;` in HTML output.
 
 Hugo 0.160.0 fixed that regression, and Hugo 0.160.1 is the safer 0.160.x patch
-release. If you are moving through this range, do not stop at 0.159.2.
+release. If you are moving through this range, do not stop at 0.159.2. Docsy
+0.16.0's minimum Hugo version, 0.160.1, already excludes this window.
 
 ### Actions {#amp-escaping-actions}
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -137,7 +137,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   `static/` and the theme discovers and links them -- no favicons partial
   required. A new `gen-favicons` helper generates raster icons from a source
   SVG. See [0.16.0 release report][0.16.0-blog-favicons] and [Add your
-  favicons][favicons] ([#2357][], [#2654][], [#2656][]).
+  favicons][favicons] ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
@@ -145,17 +145,17 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   Conventional `static/` filenames are discovered and linked automatically (see
   **Favicon discovery** under **New** above), so a custom partial is only needed
   for non-default filenames or extra links. See [0.16.0 release
-  report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2653][]).
+  report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
   **[0.158.0][hugo-0.158.0]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
   Theme templates now use the language APIs introduced in Hugo 0.158.0. Note:
   the language config keys deprecated by Hugo 0.158.0 (`languageName`,
   `languageDirection`) still work in your site config, but consider renaming
   them to `label` and `direction`. See [Hugo 0.158+ upgrade guide][] and
-  [Multi-language support](/docs/language/) ([#2647][]).
+  [Multi-language support](/docs/language/) ([#2593][]).
 - **Theme folder move**: the canonical theme now lives in `theme/`; consuming
   sites need a one-line install-path update for their install mode. See [0.16.0
-  release report][0.16.0-blog-theme-folder] ([#2641][], [#2645][]).
+  release report][0.16.0-blog-theme-folder] ([#2617][]).
 - **Bootstrap and Font Awesome via npm**: the theme declares them as npm
   dependencies instead of importing them as Hugo modules. **Applies to
   Hugo-module installs**, which run `hugo mod npm pack` and `npm install` to
@@ -168,10 +168,10 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
 - Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
   minimum supported Hugo version remains 0.158.0. See [Hugo 0.158+ upgrade
-  guide][] ([#2581][], [#2648][], [#2649][], [#2658][]).
+  guide][] ([#2581][]).
 - Reorganized the repository package boundary: `theme/package.json` owns theme
   runtime dependencies, and the root package orchestrates the `docsy.dev` and
-  `theme` workspaces ([#2645][]).
+  `theme` workspaces ([#2617][]).
 - **PostCSS is opt-in for non-RTL sites**: Docsy runs `postCSS` only for sites
   with RTL languages or that provide a project-root
   `postcss.config.{js,mjs,cjs}`, so other sites no longer need
@@ -194,16 +194,10 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [#2357]: https://github.com/google/docsy/issues/2357
 [#2578]: https://github.com/google/docsy/pull/2578
 [#2581]: https://github.com/google/docsy/issues/2581
+[#2593]: https://github.com/google/docsy/issues/2593
 [#2594]: https://github.com/google/docsy/pull/2594
-[#2641]: https://github.com/google/docsy/pull/2641
-[#2645]: https://github.com/google/docsy/pull/2645
-[#2647]: https://github.com/google/docsy/pull/2647
-[#2648]: https://github.com/google/docsy/pull/2648
-[#2649]: https://github.com/google/docsy/pull/2649
-[#2653]: https://github.com/google/docsy/pull/2653
-[#2654]: https://github.com/google/docsy/pull/2654
-[#2656]: https://github.com/google/docsy/pull/2656
-[#2658]: https://github.com/google/docsy/pull/2658
+[#2595]: https://github.com/google/docsy/issues/2595
+[#2617]: https://github.com/google/docsy/issues/2617
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2668]: https://github.com/google/docsy/issues/2668
 [0.16.0 release report]: /blog/2026/0.16.0/

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -148,11 +148,10 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
   **[0.160.1][hugo-0.160.1]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
-  For the rationale, see [0.16.0 release report][0.16.0-blog-hugo]. Note: the
-  language config keys deprecated by Hugo 0.158.0 (`languageName`,
-  `languageDirection`) still work in your site config, but consider renaming
-  them to `label` and `direction`. See [Hugo 0.158+ upgrade guide][] and
-  [Multi-language support](/docs/language/) ([#2593][]).
+  For the rationale, see [0.16.0 release report][0.16.0-blog-hugo] ([#2668][],
+  [#2677][]). Note: the language config keys deprecated by Hugo 0.158.0 still
+  work in your site config, but consider renaming them; see [Hugo 0.158+ upgrade
+  guide][] ([#2593][]).
 - **Theme folder move**: the canonical theme now lives in `theme/`; consuming
   sites need a one-line install-path update for their install mode. See [0.16.0
   release report][0.16.0-blog-theme-folder] ([#2617][]).
@@ -200,6 +199,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [#2617]: https://github.com/google/docsy/issues/2617
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2668]: https://github.com/google/docsy/issues/2668
+[#2677]: https://github.com/google/docsy/pull/2677
 [0.16.0 release report]: /blog/2026/0.16.0/
 [0.16.0-blog-favicons]: /blog/2026/0.16.0/#favicons
 [0.16.0-blog-hugo]: /blog/2026/0.16.0/#hugo

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -147,9 +147,11 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   for non-default filenames or extra links. See [0.16.0 release
   report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
-  **[0.158.0][hugo-0.158.0]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
-  Theme templates now use the language APIs introduced in Hugo 0.158.0. Note:
-  the language config keys deprecated by Hugo 0.158.0 (`languageName`,
+  **[0.160.1][hugo-0.160.1]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
+  Theme templates use the language APIs introduced in Hugo 0.158.0, the theme's
+  npm-dependency install relies on `hugo mod npm pack` support from Hugo
+  0.159.0, and 0.160.1 excludes known 0.159.2–0.160.0 regressions. Note: the
+  language config keys deprecated by Hugo 0.158.0 (`languageName`,
   `languageDirection`) still work in your site config, but consider renaming
   them to `label` and `direction`. See [Hugo 0.158+ upgrade guide][] and
   [Multi-language support](/docs/language/) ([#2593][]).
@@ -167,7 +169,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
 - Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
-  minimum supported Hugo version remains 0.158.0. See [Hugo 0.158+ upgrade
+  minimum supported Hugo version remains 0.160.1. See [Hugo 0.158+ upgrade
   guide][] ([#2581][]).
 - Reorganized the repository package boundary: `theme/package.json` owns theme
   runtime dependencies, and the root package orchestrates the `docsy.dev` and
@@ -210,7 +212,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [favicons]: /docs/content/iconsimages/#add-your-favicons
 [git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
-[hugo-0.158.0]: https://github.com/gohugoio/hugo/releases/tag/v0.158.0
+[hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
 <!-- prettier-ignore-end -->
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -148,9 +148,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
   **[0.160.1][hugo-0.160.1]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
-  Theme templates use the language APIs introduced in Hugo 0.158.0, the theme's
-  npm-dependency install relies on `hugo mod npm pack` support from Hugo
-  0.159.0, and 0.160.1 excludes known 0.159.2–0.160.0 regressions. Note: the
+  For the rationale, see [0.16.0 release report][0.16.0-blog-hugo]. Note: the
   language config keys deprecated by Hugo 0.158.0 (`languageName`,
   `languageDirection`) still work in your site config, but consider renaming
   them to `label` and `direction`. See [Hugo 0.158+ upgrade guide][] and
@@ -204,6 +202,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [#2668]: https://github.com/google/docsy/issues/2668
 [0.16.0 release report]: /blog/2026/0.16.0/
 [0.16.0-blog-favicons]: /blog/2026/0.16.0/#favicons
+[0.16.0-blog-hugo]: /blog/2026/0.16.0/#hugo
 [0.16.0-blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [0.16.0-blog-postcss]: /blog/2026/0.16.0/#postcss
 [0.16.0-blog-theme-folder]: /blog/2026/0.16.0/#theme-folder

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -11,14 +11,23 @@ more, see [Contributing][]. This page is for **maintainers only**.
 ## Content placement
 
 Keep project content DRY by writing each fact in the artifact whose purpose and
-audience it serves:
+audience it serves. Each artifact links to the more detailed ones rather than
+restating them:
 
 - **[Changelog][]**: a lean record of _what changed_, for devs who want a quick
-  overview. No upgrade advice, implementation detail, or background.
+  overview. No upgrade advice, implementation detail, or background. Entries
+  link to the release report for details and cite a change's key issues — PRs
+  only when there is no key issue, such as for contributor credit.
 - **Release and upgrade blog posts**: what's new, what to watch out for, and
-  actionable upgrade guidance — the historical narrative.
+  actionable upgrade guidance — the historical narrative. Link to the site docs
+  for current behavior and reference detail. Don't enumerate PRs and issues;
+  link an open tracker only where it adds follow-up context.
 - **Site docs** (`docs/`): Docsy _as it is now_. Minimal historical references
   or links to issues and PRs.
+- **[Release notes][] and [milestones][]**: the exhaustive record — generated
+  release notes list every PR, PRs link their motivating issues, and the release
+  milestone gathers the issues resolved. Authored artifacts link to these rather
+  than reproducing the enumeration.
 - **Test and code comments**: implementation rationale and regression
   background.
 
@@ -555,7 +564,9 @@ before any further changes are merged into the `main` branch:
 [github.com/google/docsy/theme]: <{{% param github_repo %}}/blob/main/theme/>
 [go.mod]: <{{% param github_repo %}}/blob/main/theme/go.mod>
 [install-hugo.sh]: <{{% param github_repo %}}/blob/main/docsy.dev/scripts/install-hugo.sh>
+[milestones]: <{{% param github_repo %}}/milestones>
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
+[Release notes]: <{{% param github_repo %}}/releases>
 [theme/hugo.yaml]: <{{% param github_repo %}}/blob/main/theme/hugo.yaml>
 [theme/theme.toml]: <{{% param github_repo %}}/blob/main/theme/theme.toml>
 [public]: /project/about/changelog/#public

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -81,6 +81,13 @@ The script deliberately does **not** touch the _theme_ support floor,
 users; do it only as an explicit decision, with a changelog breaking-change
 entry and upgrade notes.
 
+The converse risk: features landed during a release can quietly require newer
+Hugo than the declared floor — 0.16.0's npm-dependency install needed 0.159.0
+while the floor said 0.158.0, and the sub-0.159 failure was silent. Before
+tagging, **validate the floor**: build a consumer site (for example, a fixture
+site) with Hugo pinned to exactly `min_version`, and raise the floor if the
+build fails.
+
 Note that `params.hugoMinVersion` feeds **user-facing docs** (via
 `{{%/* param hugoMinVersion */%}}`) as the _site-recommended_ Hugo version. For
 a **build-only bump** — raising the project's own Hugo without changing what we

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -7,7 +7,7 @@ LLMS index: [llms.txt](/llms.txt)
 Section pages:
 
 - [Hugo 0.158.0-0.163.x upgrade guide](/blog/2026/hugo-0.158.0+/)
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.158+ support, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.158+ support, npm-sourced Bootstrap and Font Awesome, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.
 - [Hugo 0.152.0-0.155.x upgrade guide](/blog/2026/hugo-0.152.0+/)

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -7,7 +7,7 @@ LLMS index: [llms.txt](/llms.txt)
 Section pages:
 
 - [Hugo 0.158.0-0.163.x upgrade guide](/blog/2026/hugo-0.158.0+/)
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.158+ support, npm-sourced Bootstrap and Font Awesome, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.
 - [Hugo 0.152.0-0.155.x upgrade guide](/blog/2026/hugo-0.152.0+/)

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Hugo 0.158.0-0.163.x upgrade guide](/blog/2026/hugo-0.158.0+/)
+- [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/)
 - [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,18 +1,18 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-06-25
+lastmod: 2026-07-16
 range: v0.15.0..main
-last-main-commit: b3ce9274
-cSpell:ignore: favicons gohugoio
+last-main-commit: a7c58f5d
+cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[b3ce9274][], mapped to where each is covered. This is the objective "is
+[a7c58f5d][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 23 commits in range are squash-merged PRs (one commit per PR), so the
+All 34 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -53,6 +53,17 @@ first-parent spine and the raw range are identical; every subject carries its
 | `487050c2` [#2660][] | [#2659][] | Lean-render mode: drop repeated chrome          | feat  | done | done | done | N/A  | Chrome v1; folded into `shared` [#2662][] |
 | `3bcd6e7d` [#2661][] | [#2659][] | full-vs-shared link-check matrix (docsy.dev)    | tool  | N/A  | N/A  | N/A  | N/A  | Internal CI tooling for chrome            |
 | `b3ce9274` [#2662][] | [#2659][] | Experimental `shared` chrome build mode         | feat  | done | done | done | N/A  | One feature w/ [#2660][]; off by default  |
+| `5998cf5e` [#2663][] | [#2615][] | Draft 0.16.0 release report + Hugo guide        | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts + this workspace    |
+| `5758c063` [#2664][] | —         | Project Hugo build 0.163.3 (patch over 0.163.2) | maint | N/A  | done | done | done | Blog/Hugo-post bumps landed this refresh  |
+| `09443ba8` [#2665][] | —         | Link checking: htmltest → Lychee (docsy.dev)    | tool  | N/A  | N/A  | done | N/A  | One-line mention in build/test guards     |
+| `93948e65` [#2666][] | —         | Fix rotted externals; skip-marker migration     | docs  | done | N/A  | N/A  | N/A  | Site content fixes                        |
+| `56c2cf0e` [#2667][] | —         | Packaged root-level Lychee tooling              | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]; prettier ^3.9.3  |
+| `394e86f4` [#2669][] | —         | Fix Lychee bin entry point (npx/PATH)           | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]                   |
+| `56c5ab12` [#2670][] | [#2668][] | Bootstrap and Font Awesome from npm             | break | done | done | done | N/A  | Hugo-module installs: `hugo mod npm pack` |
+| `1aa519e7` [#2671][] | [#2668][] | Link-check CLIs → external link-cache pkg       | tool  | N/A  | N/A  | N/A  | N/A  | `docsy` pkg ships only `gen-favicons` bin |
+| `1e2d57ea` [#2672][] | [#2668][] | Get-started install docs reconciled for 0.16    | docs  | done | N/A  | N/A  | N/A  | Module paths, npm-pack step, PostCSS      |
+| `15d2f98c` [#2674][] | —         | Adopt renamed link-cache pkg (was lychee-cache) | tool  | N/A  | N/A  | N/A  | N/A  | devDependency switch only                 |
+| `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home |
 
 ## Notes on bundled changes
 
@@ -75,6 +86,22 @@ first-parent spine and the raw range are identical; every subject carries its
   it as client-restored `shared` chrome; [#2661][] is the internal
   full-vs-shared link-check matrix. Tracker [#2659][]; the default `full` mode
   is unchanged.
+- **npm-dep modernization** ([#2670][]; docs [#2672][] + [#2675][]): [#2670][]
+  is **breaking** for Hugo-module installs (they now run `hugo mod npm pack` +
+  `npm install`); npm-package and clone/submodule installs are unaffected
+  (`postinstall`). The same arc made **PostCSS opt-in** for non-RTL sites
+  (direction change recorded in [#2668][]). [#2672][] reconciles the
+  get-started/convert-to-module docs; [#2675][] completes the adjacent pages
+  (updating, troubleshooting, deployment, RTL).
+- **Link-check tooling** ([#2665][], [#2666][], [#2667][], [#2669][], [#2671][],
+  [#2674][]): docsy.dev link checking moved from the unmaintained htmltest to
+  Lychee with a committed `.lycheecache`. The cache CLIs were first packaged
+  in-repo ([#2667][], entry-point fix [#2669][]), then split out to the external
+  [link-cache][] package ([#2671][], rename [#2674][]), so the published `docsy`
+  package ships only the `gen-favicons` bin. [#2666][] fixed rotted externals
+  and migrated the skip marker to `?link-check=no`. Maintainer-facing; one-line
+  blog mention under build and test guards. [#2667][] also raised the prettier
+  floor to `^3.9.3` (3.9.0–3.9.2 corrupt multi-line Hugo shortcodes).
 
 ## Linked issues
 
@@ -84,6 +111,8 @@ first-parent spine and the raw range are identical; every subject carries its
   experimental).
 - [#2581][]: Upgrade Hugo from 0.157.0 to latest — closed.
 - [#2593][]: Deprecation warnings with Hugo 0.158.0 — closed.
+- [#2668][]: npm-dep modernization (Bootstrap/Font Awesome via npm) — closed
+  (completed 2026-07-15).
 - [#2578][], [#2594][]: contributor language-API PRs ([@deining][]), superseded
   by [#2647][].
 - [#2590][]: community Russian-locale sync — PR only (no separate issue).
@@ -140,5 +169,18 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2660]: https://github.com/google/docsy/pull/2660
 [#2661]: https://github.com/google/docsy/pull/2661
 [#2662]: https://github.com/google/docsy/pull/2662
-[b3ce9274]: https://github.com/google/docsy/commit/b3ce9274
+[#2663]: https://github.com/google/docsy/pull/2663
+[#2664]: https://github.com/google/docsy/pull/2664
+[#2665]: https://github.com/google/docsy/pull/2665
+[#2666]: https://github.com/google/docsy/pull/2666
+[#2667]: https://github.com/google/docsy/pull/2667
+[#2668]: https://github.com/google/docsy/issues/2668
+[#2669]: https://github.com/google/docsy/pull/2669
+[#2670]: https://github.com/google/docsy/pull/2670
+[#2671]: https://github.com/google/docsy/pull/2671
+[#2672]: https://github.com/google/docsy/pull/2672
+[#2674]: https://github.com/google/docsy/pull/2674
+[#2675]: https://github.com/google/docsy/pull/2675
+[a7c58f5d]: https://github.com/google/docsy/commit/a7c58f5d
+[link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -32,7 +32,7 @@ first-parent spine and the raw range are identical; every subject carries its
 | -------------------- | --------- | ----------------------------------------------- | ----- | ---- | ---- | ---- | ---- | ----------------------------------------- |
 | `843c5345` [#2641][] | [#2617][] | Move theme into `theme/` (TOF phases 0–4b)      | break | done | done | done | N/A  | Install-path change; pairs w/ [#2645][]   |
 | `94f94145` [#2645][] | [#2617][] | npm workspaces; simplify theme-deps install     | maint | done | done | done | N/A  | Packaging cleanup; pairs w/ [#2641][]     |
-| `5c5733de` [#2647][] | [#2593][] | Hugo 0.158.0; raise theme min; language APIs    | break | done | done | done | done | Min-Hugo bump 0.146→0.158                 |
+| `5c5733de` [#2647][] | [#2593][] | Hugo 0.158.0; raise theme min; language APIs    | break | done | done | done | done | Floor 0.146→0.158; now 0.160.1 [#2677][]  |
 | `3e76f1f2` [#2648][] | [#2581][] | Upgrade to Hugo 0.160.1                         | maint | done | done | done | done | Combined 0.159.x + 0.160.x                |
 | `f22a352d` [#2649][] | [#2581][] | Project Hugo build 0.163.1; imaging migration   | maint | done | done | done | done | `imaging.quality` config migration        |
 | `acf3453b` [#2653][] | [#2595][] | Remove default favicons; modernize docsy.dev    | break | done | done | done | N/A  | ~18 bundled icons removed                 |

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -3,16 +3,16 @@ title: 0.16 coverage ledger
 date: 2026-06-15
 lastmod: 2026-07-17
 range: v0.15.0..main
-last-main-commit: a7c58f5d
+last-main-commit: 4e954dc1
 cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[a7c58f5d][], mapped to where each is covered. This is the objective "is
+[4e954dc1][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 34 commits in range are squash-merged PRs (one commit per PR), so the
+All 36 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -64,6 +64,8 @@ first-parent spine and the raw range are identical; every subject carries its
 | `1e2d57ea` [#2672][] | [#2668][] | Get-started install docs reconciled for 0.16    | docs  | done | N/A  | N/A  | N/A  | Module paths, npm-pack step, PostCSS      |
 | `15d2f98c` [#2674][] | —         | Adopt renamed link-cache pkg (was lychee-cache) | tool  | N/A  | N/A  | N/A  | N/A  | devDependency switch only                 |
 | `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home |
+| `7c9a0608` [#2678][] | —         | Add `update:goldens` golden-refresh scripts     | tool  | N/A  | N/A  | N/A  | N/A  | Test tooling; root `fix:goldens` alias    |
+| `4e954dc1` [#2679][] | —         | Project Hugo build 0.164.0                      | maint | N/A  | done | done | done | 0.128.0+ perf fix; Chroma/sitemap churn   |
 | — [#2677][]          | [#2668][] | Raise theme Hugo floor to 0.160.1               | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
 
 ## Notes on bundled changes
@@ -186,6 +188,8 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2672]: https://github.com/google/docsy/pull/2672
 [#2674]: https://github.com/google/docsy/pull/2674
 [#2675]: https://github.com/google/docsy/pull/2675
-[a7c58f5d]: https://github.com/google/docsy/commit/a7c58f5d
+[#2678]: https://github.com/google/docsy/pull/2678
+[#2679]: https://github.com/google/docsy/pull/2679
+[4e954dc1]: https://github.com/google/docsy/commit/4e954dc1
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-07-16
+lastmod: 2026-07-17
 range: v0.15.0..main
 last-main-commit: a7c58f5d
 cSpell:ignore: favicons gohugoio lycheecache
@@ -64,6 +64,7 @@ first-parent spine and the raw range are identical; every subject carries its
 | `1e2d57ea` [#2672][] | [#2668][] | Get-started install docs reconciled for 0.16    | docs  | done | N/A  | N/A  | N/A  | Module paths, npm-pack step, PostCSS      |
 | `15d2f98c` [#2674][] | —         | Adopt renamed link-cache pkg (was lychee-cache) | tool  | N/A  | N/A  | N/A  | N/A  | devDependency switch only                 |
 | `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home |
+| — [#2677][]          | [#2668][] | Raise theme Hugo floor to 0.160.1               | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
 
 ## Notes on bundled changes
 
@@ -92,7 +93,10 @@ first-parent spine and the raw range are identical; every subject carries its
   (`postinstall`). The same arc made **PostCSS opt-in** for non-RTL sites
   (direction change recorded in [#2668][]). [#2672][] reconciles the
   get-started/convert-to-module docs; [#2675][] completes the adjacent pages
-  (updating, troubleshooting, deployment, RTL).
+  (updating, troubleshooting, deployment, RTL). The npm-dep install flow also
+  drove the theme's Hugo floor to **0.160.1** ([#2677][]): `hugo mod npm pack`
+  silently writes empty dependency lists before 0.159.0, and 0.160.1 excludes
+  the 0.159.2–0.160.0 regression window.
 - **Link-check tooling** ([#2665][], [#2666][], [#2667][], [#2669][], [#2671][],
   [#2674][]): docsy.dev link checking moved from the unmaintained htmltest to
   Lychee with a committed `.lycheecache`. The cache CLIs were first packaged
@@ -175,6 +179,7 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2666]: https://github.com/google/docsy/pull/2666
 [#2667]: https://github.com/google/docsy/pull/2667
 [#2668]: https://github.com/google/docsy/issues/2668
+[#2677]: https://github.com/google/docsy/pull/2677
 [#2669]: https://github.com/google/docsy/pull/2669
 [#2670]: https://github.com/google/docsy/pull/2670
 [#2671]: https://github.com/google/docsy/pull/2671

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-06-25
+lastmod: 2026-07-16
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: b3ce9274
+last-main-commit: a7c58f5d
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-07-16
+lastmod: 2026-07-17
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: a7c58f5d
+last-main-commit: 4e954dc1
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,10 +1,10 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-07-16
+lastmod: 2026-07-17
 range: v0.15.0..main
 last-main-commit: a7c58f5d
-cSpell:ignore: favicons
+cSpell:ignore: favicons thoughtry
 ---
 
 Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
@@ -24,12 +24,13 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   module tag.
 - **Hugo 0.158+ support** — [#2647][], [#2648][], [#2649][], [#2658][],
   [#2664][]; trackers [#2581][], [#2593][] (closed); goldens [#726][]. Theme
-  minimum raised to 0.158.0; project build validated on 0.163.3; templates/docs
-  moved off deprecated language APIs (zero deprecation notices). **Breaking**
-  minimum-Hugo bump. Old keys (`languageName`/`languageDirection`) still work
-  but should become `label`/`direction`. Node 22+ required for Hugo-managed Node
-  tools from 0.161.x (Docsy recommends Node LTS 24). Per-version mechanics live
-  in the [Hugo upgrade guide][].
+  minimum raised to 0.160.1 (language APIs 0.158.0; npm-dep install 0.159.0;
+  0.159.2–0.160.0 regressions excluded); project build validated on 0.163.3;
+  templates/docs moved off deprecated language APIs (zero deprecation notices).
+  **Breaking** minimum-Hugo bump. Old keys (`languageName`/`languageDirection`)
+  still work but should become `label`/`direction`. Node 22+ required for
+  Hugo-managed Node tools from 0.161.x (Docsy recommends Node LTS 24).
+  Per-version mechanics live in the [Hugo upgrade guide][].
 - **Favicons** — [#2653][], [#2654][], [#2656][]; [#2595][] closed, [#2357][]
   continues (26Q3). Default favicon artwork removed; the default partial
   discovers and links conventional `static/` files (`favicon.ico`,
@@ -69,7 +70,7 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 1. **Theme folder move** — update the install path for your mode (Hugo module
    `…/docsy/theme`; npm/clone `theme: docsy/theme`). See [release report][]
    (Theme folder move).
-2. **Minimum Hugo 0.158.0** — upgrade Hugo (prefer 0.163.3); optionally rename
+2. **Minimum Hugo 0.160.1** — upgrade Hugo (prefer 0.163.3); optionally rename
    `languageName`/`languageDirection` to `label`/`direction`; use Node LTS 24.
    See [Hugo upgrade guide][].
 3. **Default favicons removed** — supply your own files under `static/`; the
@@ -121,7 +122,16 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 - Moved the project Hugo build to 0.163.2 ([#2658][]) for the PostCSS/Netlify
   `ERR_ACCESS_DENIED` fix, then to 0.163.3 ([#2664][]) — a build-only patch bump
   (code-block escaping, PostCSS/Babel config variants, `uglyURLs` fix); the
-  theme minimum stays 0.158.0. Both blog posts recommend 0.163.3.
+  theme minimum stayed 0.158.0 at that point. Both blog posts recommend 0.163.3.
+- **Raised the theme's Hugo floor to 0.160.1** (2026-07-17): a fixture-matrix
+  test showed the npm-dep install flow (`hugo mod npm pack` → `npm install` →
+  `hugo`) silently fails on 0.158.x — pack exits 0 but writes empty dependency
+  lists, surfacing only later as an SCSS import error — and works from 0.159.0.
+  With a silent sub-0.159 failure mode, Hugo's minimum-version warning is the
+  only consumer guardrail, so the floor must be accurate. 0.160.1 (not bare
+  0.159.0) also excludes the 0.159.2–0.160.0 regression window. Security
+  currency stays the recommendation's job (0.163.3). Analysis and methodology:
+  thoughtry `projects/docsy/tasks/v0.16.0/index.md` (2026-07-17).
 - Routed the link-check tooling arc ([#2665][]–[#2674][]) as
   internal/maintainer-facing: no changelog entry; a one-line mention under the
   report's build-and-test-guards section. The cache CLIs live in the external

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -200,6 +200,8 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
       procedure** — new this release).
 - [ ] Milestone hygiene: close or move all milestone-24 issues except [#2615][].
 - [ ] Post-release: refresh `docsy-example` and the examples page for 0.16.0.
+      (Its Hugo floor is already 0.160.1: [docsy-example#478] landed early since
+      the site tracks Docsy main, where npm-dep installs already require it.)
 
 ## Post-release / deferred
 
@@ -263,5 +265,6 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2678]: https://github.com/google/docsy/pull/2678
 [#2679]: https://github.com/google/docsy/pull/2679
 [4e954dc1]: https://github.com/google/docsy/commit/4e954dc1
+[docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -93,6 +93,12 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
 ## Decisions
 
+- The highlights card is capped at **three items** (2026-07-16): a merged
+  **Packaging modernization** entry (theme folder move + npm-sourced deps, title
+  linking `#theme-folder` with an inline link to `#npm-deps`), favicons, and
+  shared chrome. The minimum-Hugo bump is deliberately not in the card: it is
+  routine (0.15 did the same), has its own section plus the companion Hugo
+  guide, and Ready-to-Upgrade lists every breaking change anyway.
 - The four breaking changes for 0.16 are the theme folder move, the minimum-Hugo
   bump, default-favicon removal, and npm-sourced Bootstrap/Font Awesome
   ([#2670][], added in the 2026-07-16 refresh). The headline **new** feature is

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -93,6 +93,13 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
 ## Decisions
 
+- Applied the enumeration-home rule (2026-07-16, now canonical in maintainer
+  notes → Content placement): the GitHub release notes + milestone own the
+  exhaustive PR/issue record; the blog post carries no PR/issue enumeration
+  (open trackers only where they add follow-up context: [#2617][], [#2659][],
+  [#2357][] in What's next); the changelog cites key issues, keeping PR links
+  only for contributor credit ([#2594][], [#2578][]). The ledger remains the
+  internal full-coverage record.
 - The highlights card is capped at **three items** (2026-07-16): a merged
   **Packaging modernization** entry (theme folder move + npm-sourced deps, title
   linking `#theme-folder` with an inline link to `#npm-deps`), favicons, and

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -200,8 +200,8 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
       procedure** — new this release).
 - [ ] Milestone hygiene: close or move all milestone-24 issues except [#2615][].
 - [ ] Post-release: refresh `docsy-example` and the examples page for 0.16.0.
-      (Its Hugo floor is already 0.160.1: [docsy-example#478] landed early since
-      the site tracks Docsy main, where npm-dep installs already require it.)
+      (Its Hugo floor is handled early by [docsy-example#478][], since the site
+      tracks Docsy main, where npm-dep installs already require 0.160.1.)
 
 ## Post-release / deferred
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -3,15 +3,15 @@ title: 0.16 release-prep wrapup
 date: 2026-06-15
 lastmod: 2026-07-17
 range: v0.15.0..main
-last-main-commit: a7c58f5d
-cSpell:ignore: favicons thoughtry
+last-main-commit: 4e954dc1
+cSpell:ignore: favicons retokenization thoughtry
 ---
 
 Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [a7c58f5d][].
+> Prepared for commits in [v0.15.0...main][] through [4e954dc1][].
 
 ## Themes (with evidence and client impact)
 
@@ -23,14 +23,15 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   `theme: docsy/theme`), and the release must publish the nested `theme/vX.Y.Z`
   module tag.
 - **Hugo 0.158+ support** — [#2647][], [#2648][], [#2649][], [#2658][],
-  [#2664][]; trackers [#2581][], [#2593][] (closed); goldens [#726][]. Theme
-  minimum raised to 0.160.1 (language APIs 0.158.0; npm-dep install 0.159.0;
-  0.159.2–0.160.0 regressions excluded); project build validated on 0.163.3;
-  templates/docs moved off deprecated language APIs (zero deprecation notices).
-  **Breaking** minimum-Hugo bump. Old keys (`languageName`/`languageDirection`)
-  still work but should become `label`/`direction`. Node 22+ required for
-  Hugo-managed Node tools from 0.161.x (Docsy recommends Node LTS 24).
-  Per-version mechanics live in the [Hugo upgrade guide][].
+  [#2664][], [#2679][]; trackers [#2581][], [#2593][] (closed); goldens
+  [#726][]. Theme minimum raised to 0.160.1 (language APIs 0.158.0; npm-dep
+  install 0.159.0; 0.159.2–0.160.0 regressions excluded); project build
+  validated on 0.164.0; templates/docs moved off deprecated language APIs (zero
+  deprecation notices). **Breaking** minimum-Hugo bump. Old keys
+  (`languageName`/`languageDirection`) still work but should become
+  `label`/`direction`. Node 22+ required for Hugo-managed Node tools from
+  0.161.x (Docsy recommends Node LTS 24). Per-version mechanics live in the
+  [Hugo upgrade guide][].
 - **Favicons** — [#2653][], [#2654][], [#2656][]; [#2595][] closed, [#2357][]
   continues (26Q3). Default favicon artwork removed; the default partial
   discovers and links conventional `static/` files (`favicon.ico`,
@@ -59,18 +60,19 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   every page. User guide: [Chrome build modes][chrome].
 - **Packaging, docs, and tooling cleanup** — npm workspaces, maintainer-notes
   and examples-page refreshes, a Netlify-badge URL fix, a version-doc `vv` fix,
-  and test guards (Hugo deprecation probe, fixture-site tests). docsy.dev link
-  checking moved from the unmaintained htmltest to Lychee ([#2665][]), with the
-  cache CLIs extracted to the external [link-cache][] package ([#2671][],
-  [#2674][]) so the published `docsy` package ships only the `gen-favicons` bin.
-  Mostly internal/maintainer-facing.
+  and test guards (Hugo deprecation probe, fixture-site tests), plus
+  golden-refresh scripts ([#2678][]). docsy.dev link checking moved from the
+  unmaintained htmltest to Lychee ([#2665][]), with the cache CLIs extracted to
+  the external [link-cache][] package ([#2671][], [#2674][]) so the published
+  `docsy` package ships only the `gen-favicons` bin. Mostly
+  internal/maintainer-facing.
 
 ## Breaking changes and required actions
 
 1. **Theme folder move** — update the install path for your mode (Hugo module
    `…/docsy/theme`; npm/clone `theme: docsy/theme`). See [release report][]
    (Theme folder move).
-2. **Minimum Hugo 0.160.1** — upgrade Hugo (prefer 0.163.3); optionally rename
+2. **Minimum Hugo 0.160.1** — upgrade Hugo (prefer 0.164.0); optionally rename
    `languageName`/`languageDirection` to `label`/`direction`; use Node LTS 24.
    See [Hugo upgrade guide][].
 3. **Default favicons removed** — supply your own files under `static/`; the
@@ -88,7 +90,7 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   mode, each with Actions, an upgrade section, and sanity checks. Highlights
   refreshed in the 2026-07-16 pass (value-first phrasing; npm-dep item added).
 - [Hugo upgrade guide][] (`blog/2026/hugo-0.158.0+.md`): complete draft
-  (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.163.3 (DRY).
+  (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.164.0 (DRY).
 - Changelog `v0.16.0 - UNRELEASED` section: complete; reconciled with the
   ledger.
 
@@ -122,7 +124,8 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 - Moved the project Hugo build to 0.163.2 ([#2658][]) for the PostCSS/Netlify
   `ERR_ACCESS_DENIED` fix, then to 0.163.3 ([#2664][]) — a build-only patch bump
   (code-block escaping, PostCSS/Babel config variants, `uglyURLs` fix); the
-  theme minimum stayed 0.158.0 at that point. Both blog posts recommend 0.163.3.
+  theme minimum stayed 0.158.0 at that point. Both blog posts recommended
+  0.163.3 until the 0.164.0 bump (below).
 - **Raised the theme's Hugo floor to 0.160.1** (2026-07-17): a fixture-matrix
   test showed the npm-dep install flow (`hugo mod npm pack` → `npm install` →
   `hugo`) silently fails on 0.158.x — pack exits 0 but writes empty dependency
@@ -130,8 +133,14 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   With a silent sub-0.159 failure mode, Hugo's minimum-version warning is the
   only consumer guardrail, so the floor must be accurate. 0.160.1 (not bare
   0.159.0) also excludes the 0.159.2–0.160.0 regression window. Security
-  currency stays the recommendation's job (0.163.3). Analysis and methodology:
-  thoughtry `projects/docsy/tasks/v0.16.0/index.md` (2026-07-17).
+  currency stays the recommendation's job (now 0.164.0). Analysis and
+  methodology: thoughtry `projects/docsy/tasks/v0.16.0/index.md` (2026-07-17).
+- Moved the recommended Hugo to **0.164.0** (2026-07-17) after [#2679][] landed
+  the project build bump and docsy-example followed: 0.164.0 fixes the 0.128.0+
+  template-rendering slowdown (a reported ~8,500-page Docsy site went from 608
+  to 117 seconds), with only benign output churn (Chroma retokenization, sitemap
+  alternate order). The Hugo post gained a 0.164.0 section and now covers
+  0.158.0–0.164.x; the theme floor stays 0.160.1.
 - Routed the link-check tooling arc ([#2665][]–[#2674][]) as
   internal/maintainer-facing: no changelog entry; a one-line mention under the
   report's build-and-test-guards section. The cache CLIs live in the external
@@ -249,6 +258,8 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2672]: https://github.com/google/docsy/pull/2672
 [#2674]: https://github.com/google/docsy/pull/2674
 [#2675]: https://github.com/google/docsy/pull/2675
-[a7c58f5d]: https://github.com/google/docsy/commit/a7c58f5d
+[#2678]: https://github.com/google/docsy/pull/2678
+[#2679]: https://github.com/google/docsy/pull/2679
+[4e954dc1]: https://github.com/google/docsy/commit/4e954dc1
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -204,8 +204,10 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2403]: https://github.com/google/docsy/issues/2403
 [#2431]: https://github.com/google/docsy/issues/2431
 [#2554]: https://github.com/google/docsy/issues/2554
+[#2578]: https://github.com/google/docsy/pull/2578
 [#2581]: https://github.com/google/docsy/issues/2581
 [#2593]: https://github.com/google/docsy/issues/2593
+[#2594]: https://github.com/google/docsy/pull/2594
 [#2595]: https://github.com/google/docsy/issues/2595
 [#2598]: https://github.com/google/docsy/issues/2598
 [#2614]: https://github.com/google/docsy/issues/2614

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -176,6 +176,9 @@ The canonical procedure is maintainer notes, [Publishing a release][pub-rel];
 this tracks 0.16-specific status and deltas, not the full mechanics.
 
 - [ ] Flip `draft: true` → `false` on both blog posts and set their final dates.
+- [x] Validate the theme floor per maintainer notes (Hugo version pins): done
+      2026-07-17 via a fixture-matrix build on 0.158.0/0.159.0; floor raised to
+      0.160.1 — see Decisions.
 - [ ] Replace placeholders that resolve only after tagging: the
       `releases/tag/v0.16.0` links and the changelog `UNRELEASED`
       heading/banner.

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,9 +1,9 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-06-25
+lastmod: 2026-07-16
 range: v0.15.0..main
-last-main-commit: b3ce9274
+last-main-commit: a7c58f5d
 cSpell:ignore: favicons
 ---
 
@@ -11,7 +11,7 @@ Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [b3ce9274][].
+> Prepared for commits in [v0.15.0...main][] through [a7c58f5d][].
 
 ## Themes (with evidence and client impact)
 
@@ -22,14 +22,14 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   a one-line path update (Hugo module `…/docsy/theme`; npm/clone
   `theme: docsy/theme`), and the release must publish the nested `theme/vX.Y.Z`
   module tag.
-- **Hugo 0.158+ support** — [#2647][], [#2648][], [#2649][], [#2658][]; trackers
-  [#2581][], [#2593][] (closed); goldens [#726][]. Theme minimum raised to
-  0.158.0; project build validated on 0.163.2; templates/docs moved off
-  deprecated language APIs (zero deprecation notices). **Breaking** minimum-Hugo
-  bump. Old keys (`languageName`/`languageDirection`) still work but should
-  become `label`/`direction`. Node 22+ required for Hugo-managed Node tools from
-  0.161.x (Docsy recommends Node LTS 24). Per-version mechanics live in the
-  [Hugo upgrade guide][].
+- **Hugo 0.158+ support** — [#2647][], [#2648][], [#2649][], [#2658][],
+  [#2664][]; trackers [#2581][], [#2593][] (closed); goldens [#726][]. Theme
+  minimum raised to 0.158.0; project build validated on 0.163.3; templates/docs
+  moved off deprecated language APIs (zero deprecation notices). **Breaking**
+  minimum-Hugo bump. Old keys (`languageName`/`languageDirection`) still work
+  but should become `label`/`direction`. Node 22+ required for Hugo-managed Node
+  tools from 0.161.x (Docsy recommends Node LTS 24). Per-version mechanics live
+  in the [Hugo upgrade guide][].
 - **Favicons** — [#2653][], [#2654][], [#2656][]; [#2595][] closed, [#2357][]
   continues (26Q3). Default favicon artwork removed; the default partial
   discovers and links conventional `static/` files (`favicon.ico`,
@@ -37,6 +37,16 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   `apple-touch-icon-NxN.png` variants); a `gen-favicons` CLI generates raster
   icons from a source SVG. **Breaking** (defaults removed) and **new**
   (zero-config discovery). User guide: [Add your favicons][].
+- **npm-dep modernization** — [#2670][]; docs [#2672][], [#2675][]; tracker
+  [#2668][] (closed). Bootstrap and Font Awesome now come from npm via Hugo's
+  first-class npm-module support (`hugo mod npm pack`), with
+  `theme/package.json` as the single source of truth — retiring the Hugo-module
+  imports of both GitHub repos, the generated `go.mod` requires, the module-sync
+  script, and the Bootstrap `rfs` vendor hack. **Breaking** for Hugo-module
+  installs (run `hugo mod npm pack` + `npm install`); npm-package and
+  clone/submodule installs unaffected (`postinstall`). The same arc made
+  **PostCSS opt-in** for non-RTL sites. [#2672][] + [#2675][] reconcile the
+  get-started, updating, deployment, and RTL docs.
 - **Shared chrome build mode (experimental)** — [#2660][], [#2662][]; tooling
   [#2661][]; tracker [#2659][] (open). New opt-in `td.chrome = shared` build
   mode: Docsy emits the repeated chrome (navbar, footer, left-nav) on one donor
@@ -48,36 +58,45 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   every page. User guide: [Chrome build modes][chrome].
 - **Packaging, docs, and tooling cleanup** — npm workspaces, maintainer-notes
   and examples-page refreshes, a Netlify-badge URL fix, a version-doc `vv` fix,
-  and test guards (Hugo deprecation probe, fixture-site tests). Mostly
-  internal/maintainer-facing.
+  and test guards (Hugo deprecation probe, fixture-site tests). docsy.dev link
+  checking moved from the unmaintained htmltest to Lychee ([#2665][]), with the
+  cache CLIs extracted to the external [link-cache][] package ([#2671][],
+  [#2674][]) so the published `docsy` package ships only the `gen-favicons` bin.
+  Mostly internal/maintainer-facing.
 
 ## Breaking changes and required actions
 
 1. **Theme folder move** — update the install path for your mode (Hugo module
    `…/docsy/theme`; npm/clone `theme: docsy/theme`). See [release report][]
    (Theme folder move).
-2. **Minimum Hugo 0.158.0** — upgrade Hugo (prefer 0.163.2); optionally rename
+2. **Minimum Hugo 0.158.0** — upgrade Hugo (prefer 0.163.3); optionally rename
    `languageName`/`languageDirection` to `label`/`direction`; use Node LTS 24.
    See [Hugo upgrade guide][].
 3. **Default favicons removed** — supply your own files under `static/`; the
    default partial links conventional filenames. See [release report][]
    (Favicons).
+4. **Bootstrap and Font Awesome via npm** — Hugo-module installs run
+   `hugo mod npm pack` + `npm install` after updating Docsy; npm-package and
+   clone/submodule installs are unaffected. See [release report][] (Bootstrap
+   and Font Awesome via npm).
 
 ## Release content status
 
 - [release report][] (`blog/2026/0.16.0.md`): complete draft (`draft: true`).
-  Covers the three breaking changes plus the experimental shared chrome build
-  mode, each with Actions, an upgrade section, and sanity checks.
+  Covers the four breaking changes plus the experimental shared chrome build
+  mode, each with Actions, an upgrade section, and sanity checks. Highlights
+  refreshed in the 2026-07-16 pass (value-first phrasing; npm-dep item added).
 - [Hugo upgrade guide][] (`blog/2026/hugo-0.158.0+.md`): complete draft
-  (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.163.2 (DRY).
+  (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.163.3 (DRY).
 - Changelog `v0.16.0 - UNRELEASED` section: complete; reconciled with the
   ledger.
 
 ## Decisions
 
-- The three breaking changes for 0.16 are the theme folder move, the
-  minimum-Hugo bump, and default-favicon removal. The headline **new** feature
-  is the experimental `shared` chrome build mode; everything else is cleanup or
+- The four breaking changes for 0.16 are the theme folder move, the minimum-Hugo
+  bump, default-favicon removal, and npm-sourced Bootstrap/Font Awesome
+  ([#2670][], added in the 2026-07-16 refresh). The headline **new** feature is
+  the experimental `shared` chrome build mode; everything else is cleanup or
   internal.
 - Ship the `shared` chrome build mode as **experimental and opt-in** (off by
   default, `td.chrome = full`); it is a contributor/CI feature that doesn't
@@ -87,7 +106,13 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 - Keep Hugo mechanics in the [Hugo upgrade guide][] and link to it from the
   report and changelog (DRY).
 - Moved the project Hugo build to 0.163.2 ([#2658][]) for the PostCSS/Netlify
-  `ERR_ACCESS_DENIED` fix; the theme minimum stays 0.158.0.
+  `ERR_ACCESS_DENIED` fix, then to 0.163.3 ([#2664][]) — a build-only patch bump
+  (code-block escaping, PostCSS/Babel config variants, `uglyURLs` fix); the
+  theme minimum stays 0.158.0. Both blog posts recommend 0.163.3.
+- Routed the link-check tooling arc ([#2665][]–[#2674][]) as
+  internal/maintainer-facing: no changelog entry; a one-line mention under the
+  report's build-and-test-guards section. The cache CLIs live in the external
+  [link-cache][] package, keeping `gen-favicons` the only shipped bin.
 - Referenced [#2656][] from the favicon report/changelog entries (was
   implemented but unreferenced).
 - Omitted [#2650][] (double-`v` docs fix) from the changelog — too minor; the
@@ -98,11 +123,13 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 ## Milestone 24 hygiene
 
 Hygiene review of [milestone #24][milestone] ahead of tagging (issues only). As
-of this pass: **6 open**, **5 closed**.
+of this pass (2026-07-16): **7 open**, **7 closed**.
 
 Closed (shipped in 0.16): [#2595][] (favicons), [#2593][] (Hugo deprecations),
 [#2581][] (Hugo upgrade), [#2598][] (Netlify badge), [#2431][] (predecessor of
-[#2581][]).
+[#2581][]), [#2668][] (npm-dep modernization). Closed as not planned: [#2657][]
+(page-meta URL marker; Lychee's URL-pattern excludes cover those links without a
+marker).
 
 Open — disposition before/at release:
 
@@ -110,6 +137,7 @@ Open — disposition before/at release:
 | ----------------------------------------------------- | ----------- | ------------- | --------------------------------------- |
 | [#2615][]: Release 0.16.0 preparation                 | tracker     | n/a           | Keep; close when 0.16.0 is tagged.      |
 | [#2617][]: Finalize monorepo setup — 26Q2             | tracker     | partial (TOF) | Keep open; remaining cleanup post-0.16. |
+| [#2659][]: Experimental `shared` chrome build mode    | tracker     | yes (exp.)    | Keep open; feature continues post-0.16. |
 | [#2614][]: AI-agent doc consumption                   | tracker     | no (phase 2+) | Move off the 0.16 milestone.            |
 | [#2554][]: Use 'note' role instead of 'alert'         | enhancement | no            | Reassign to a later milestone.          |
 | [#2403][]: View-page URL should use `blob` not `tree` | bug         | no            | Reassign to a later milestone.          |
@@ -179,10 +207,20 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2653]: https://github.com/google/docsy/pull/2653
 [#2654]: https://github.com/google/docsy/pull/2654
 [#2656]: https://github.com/google/docsy/pull/2656
+[#2657]: https://github.com/google/docsy/issues/2657
 [#2658]: https://github.com/google/docsy/pull/2658
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2660]: https://github.com/google/docsy/pull/2660
 [#2661]: https://github.com/google/docsy/pull/2661
 [#2662]: https://github.com/google/docsy/pull/2662
-[b3ce9274]: https://github.com/google/docsy/commit/b3ce9274
+[#2664]: https://github.com/google/docsy/pull/2664
+[#2665]: https://github.com/google/docsy/pull/2665
+[#2668]: https://github.com/google/docsy/issues/2668
+[#2670]: https://github.com/google/docsy/pull/2670
+[#2671]: https://github.com/google/docsy/pull/2671
+[#2672]: https://github.com/google/docsy/pull/2672
+[#2674]: https://github.com/google/docsy/pull/2674
+[#2675]: https://github.com/google/docsy/pull/2675
+[a7c58f5d]: https://github.com/google/docsy/commit/a7c58f5d
+[link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -120,7 +120,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   blog NEW section spanning [#2660][] and [#2662][]; [#2661][] (the
   full-vs-shared link-check matrix) is internal tooling (`N/A`).
 - Keep Hugo mechanics in the [Hugo upgrade guide][] and link to it from the
-  report and changelog (DRY).
+  report and changelog; conversely, the **floor rationale** lives in the release
+  report's Hugo section, with the Hugo post and changelog linking to it rather
+  than restating (DRY, one home per fact; 2026-07-17).
 - Moved the project Hugo build to 0.163.2 ([#2658][]) for the PostCSS/Netlify
   `ERR_ACCESS_DENIED` fix, then to 0.163.3 ([#2664][]) — a build-only patch bump
   (code-block escaping, PostCSS/Babel config variants, `uglyURLs` fix); the

--- a/theme/hugo.yaml
+++ b/theme/hugo.yaml
@@ -33,7 +33,7 @@ mediaTypes:
 module:
   hugoVersion:
     extended: true
-    min: 0.158.0
+    min: 0.160.1
   mounts:
     - source: assets
       target: assets

--- a/theme/theme.toml
+++ b/theme/theme.toml
@@ -7,7 +7,7 @@ homepage = "https://docsy.dev"
 demosite = "https://example.docsy.dev/"
 tags = ["documentation", "multilingual", "customizable", "responsive", "docs"]
 features = []
-min_version = "0.158.0"
+min_version = "0.160.1"
 
 [author]
   name = "The Docsy Authors"


### PR DESCRIPTION
- Contributes to #2615
- Refreshes the 0.16.0 release artifacts to cover the 13 PRs merged since drafting (#2663–#2679):
  - Release post: leads the highlights with user value; adds the npm-dep modernization (#2670); recommends Hugo 0.164.0 and now owns the Hugo-floor rationale.
  - Hugo upgrade post: extends coverage to 0.164.x with a new 0.164.0 section; covers the 0.163.x patches.
  - Changelog: updates the minimum-Hugo breaking entry.
  - Release-prep workspace: extends the ledger and decisions through 4e954dc1 (36 commits).
- Raises the theme's minimum Hugo version from 0.158.0 to 0.160.1: the npm-dep install flow silently fails before Hugo 0.159.0, and 0.160.1 excludes the 0.159.2–0.160.0 regressions; verified with a fixture-site Hugo matrix.
- **Preview(s)**:
  - [0.16.0 release post](https://deploy-preview-2677--docsydocs.netlify.app/blog/2026/0.16.0/)
  - [Hugo upgrade post](https://deploy-preview-2677--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/)