### PR TITLE
Add update:goldens scripts for golden-test refresh

### DIFF
--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -88,10 +88,15 @@ From the repo root:
 | `test:fixture-site` | Fast, offline checks over minimal monolingual fixture sites — paths docsy.dev can't cover |
 | `test:smoke`        | Slow, network-bound; builds a site from GitHub three ways (NPM, Hugo module, clone)       |
 | `test:tooling`      | Unit tests for repo scripts                                                               |
-| `test:website`      | Full docsy.dev checks: format, links, hugo-build, alt-site, and md-output golden tests    |
+| `test:website`      | Full docsy.dev checks: format, links, hugo-build, alt-site, md-output, and favicon tests  |
 
 All but `test:smoke` run in CI; smoke tests are run manually for PR-branch
 validation (they auto-target the current branch's GitHub upstream).
+
+The md-output and favicon tests compare built output against committed golden
+files. When a golden test reports intended drift, run `npm run update:goldens`
+to rebuild the site and refresh both suites' goldens, then review the diff and
+commit it.
 
 ## Link checking and the refcache
 

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -15,6 +15,7 @@
     "_postbuild": "npm run _check:links--warn",
     "_serve": "npm run _hugo-dev -- serve --disableFastRender --renderToMemory",
     "_test:base": "npm run check:format && npm run _check:links",
+    "_update:goldens": "npm run update:md-goldens && npm run update:favicon-goldens",
     "build:preview": "cross-env npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-http://localhost}\"",
     "build:production": "npm run _hugo -- --minify",
     "build": "cross-env npm run _build -- --baseURL \"${BASE_URL:-http://localhost}\"",
@@ -32,6 +33,7 @@
     "postinstall": "npm run --prefix .. install:theme-deps",
     "precheck:links:internal": "npm run build",
     "precheck:links": "npm run build",
+    "preupdate:goldens": "npm run build",
     "refcache": "npx refcache",
     "seq": "bash -c 'for cmd in \"$@\"; do npm run $cmd || exit 1; done' - ",
     "serve": "npm run _serve -- --minify",
@@ -44,6 +46,7 @@
     "test": "npm run seq -- test:base test:extra",
     "update:dep": "npm run -s update:hugo",
     "update:favicon-goldens": "node tests/favicons/update-goldens.mjs",
+    "update:goldens": "npm run _update:goldens",
     "update:hugo": "npm install --save-exact -D hugo-extended@latest",
     "update:md-goldens": "node tests/md-output/update-goldens.mjs",
     "update:packages": "npx npm-check-updates -u"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test:website": "npm run -C docsy.dev test",
     "test": "npm run fix-and-test",
     "update:dep": "npm install --save-exact @fortawesome/fontawesome-free@latest bootstrap@latest",
+    "update:goldens": "npm run -C docsy.dev update:goldens",
     "update:packages:all": "npm run update:packages --workspaces --include-workspace-root",
     "update:packages:not-hugo": "npm run update:packages -- -x hugo-extended",
     "update:packages": "npx npm-check-updates -u",


### PR DESCRIPTION
- Adds an `update:goldens` script family so golden-test drift has a one-command refresh, mirroring the test flow at the repo root:
  - Root `update:goldens` delegates to docsy.dev, where `preupdate:goldens` rebuilds the site and `_update:goldens` then refreshes both the md-output and favicon golden suites.
  - Keeps the refresh in the `update:*` family (deliberate baseline advance, diff reviewed at commit time) rather than `fix:*`, whose aggregates run inside `fix-and-test` — auto-refreshing goldens there would make the golden tests tautologically green.
- Documents the refresh flow in the maintainer notes and mentions the favicon tests in the `test:website` script-table row.
- **Preview**: [Maintainer notes](https://deploy-preview-2678--docsydocs.netlify.app/project/about/maintainer-notes/)