### PR TITLE
Upgrade project Hugo build to 0.164.0

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -163,6 +163,7 @@ https://github.com/gohugoio/hugo/releases/tag/v0.157.0,200,1782498231
 https://github.com/gohugoio/hugo/releases/tag/v0.158.0,200,1782563370
 https://github.com/gohugoio/hugo/releases/tag/v0.163.2,200,1782498231
 https://github.com/gohugoio/hugo/releases/tag/v0.163.3,200,1782563370
+https://github.com/gohugoio/hugo/releases/tag/v0.164.0,200,1784242277
 https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md,200,1782563368
 https://github.com/google/docsy,200,1782563367
 https://github.com/google/docsy-example,200,1782563368

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 028-over-main-93948e65
+  buildId: &tdBuildId 036-over-main-7c9a0608
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 028-over-main-93948e65
+  buildId: &tdBuildId 036-over-main-7c9a0608
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 028-over-main-93948e65
+  buildId: &tdBuildId 036-over-main-7c9a0608
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -166,7 +166,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 - Migrated the theme and docs off deprecated Hugo language APIs. Thanks
   [@deining][] for the groundwork in [#2594][] and [#2578][]!
-- Upgraded the project's Hugo build to [0.163.3][hugo-0.163.3]. The theme's
+- Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
   minimum supported Hugo version remains 0.158.0. See [Hugo 0.158+ upgrade
   guide][] ([#2581][], [#2648][], [#2649][], [#2658][]).
 - Reorganized the repository package boundary: `theme/package.json` owns theme
@@ -217,7 +217,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
 [hugo-0.158.0]: https://github.com/gohugoio/hugo/releases/tag/v0.158.0
-[hugo-0.163.3]: https://github.com/gohugoio/hugo/releases/tag/v0.163.3
+[hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
 <!-- prettier-ignore-end -->
 
 ## v0.15.0 {#v0.15.0}

--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "afdocs": "^0.9.2",
     "cross-env": "^10.1.0",
-    "hugo-extended": "0.163.3",
+    "hugo-extended": "0.164.0",
     "link-cache": "github:chalin/link-cache#semver:^0.2.0",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+028-over-main-93948e65",
+  "version": "0.15.1-dev+036-over-main-7c9a0608",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",
@@ -90,7 +90,7 @@
     "prettier": "^3.9.3"
   },
   "config": {
-    "hugo_version": "0.163.3"
+    "hugo_version": "0.164.0"
   },
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
- Bumps the project's Hugo build from 0.163.3 to **0.164.0** (`config.hugo_version` and `hugo-extended`); the theme support floor stays at **0.158.0** (no new syntax adopted, so this is a build-only bump).
- 0.164.0 deprecates `resources.PostProcess` (unused in Docsy), makes `.Render` fail the build on missing views (all Docsy views resolve), bundles Chroma dark/light style-pair support (no drift in the generated Chroma SCSS), and fixes the 0.128.0+ template-rendering slowdown on large sites. docsy.dev builds clean with zero deprecation notices and zero golden churn.
- Updates the changelog's project-Hugo-build entry and refreshes the refcache and dev build-ID stamp.
- **Preview(s)**:
  - [Changelog `#next` section](https://deploy-preview-2679--docsydocs.netlify.app/project/about/changelog/#next)
