### PR TITLE
Refresh 0.16.0 release artifacts through 494f3da6

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -204,6 +204,10 @@ directly to 0.164.0 unless your project has a reason to pin a lower version. For
 the detailed Hugo changes between 0.158.0 and 0.164.0, see the companion [Hugo
 0.158+ upgrade guide][hugo-upgrade].
 
+This distinction — the **minimum** Hugo version versus the **officially
+supported** version that the project pins and tests — is now documented as part
+of Docsy's [official support policy][].
+
 ### Actions {#hugo-actions}
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
@@ -460,5 +464,6 @@ About this release:
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
 [Lychee]: https://github.com/lycheeverse/lychee
 [Multi-language support]: /docs/language/
+[official support policy]: /project/about/changelog/#official-support
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/
 <!-- prettier-ignore-end -->

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -66,7 +66,7 @@ first-parent spine and the raw range are identical; every subject carries its
 | `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home |
 | `7c9a0608` [#2678][] | —         | Add `update:goldens` golden-refresh scripts     | tool  | N/A  | N/A  | N/A  | N/A  | Test tooling; root `fix:goldens` alias    |
 | `4e954dc1` [#2679][] | —         | Project Hugo build 0.164.0                      | maint | N/A  | done | done | done | 0.128.0+ perf fix; Chroma/sitemap churn   |
-| `6d9367e2` [#2677][] | [#2668][] | Raise theme Hugo floor to 0.160.1               | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
+| `6d9367e2` [#2677][] | [#2668][] | Artifact refresh; theme Hugo floor → 0.160.1    | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
 | `494f3da6` [#2680][] | —         | Clarify minimum vs officially supported Hugo    | docs  | done | done | done | N/A  | User-visible: support policy surfaced     |
 
 ## Notes on bundled changes

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,18 +1,18 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-07-17
+lastmod: 2026-07-18
 range: v0.15.0..main
-last-main-commit: 4e954dc1
+last-main-commit: 494f3da6
 cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[4e954dc1][], mapped to where each is covered. This is the objective "is
+[494f3da6][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 36 commits in range are squash-merged PRs (one commit per PR), so the
+All 38 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -67,7 +67,7 @@ first-parent spine and the raw range are identical; every subject carries its
 | `7c9a0608` [#2678][] | —         | Add `update:goldens` golden-refresh scripts     | tool  | N/A  | N/A  | N/A  | N/A  | Test tooling; root `fix:goldens` alias    |
 | `4e954dc1` [#2679][] | —         | Project Hugo build 0.164.0                      | maint | N/A  | done | done | done | 0.128.0+ perf fix; Chroma/sitemap churn   |
 | `6d9367e2` [#2677][] | [#2668][] | Raise theme Hugo floor to 0.160.1               | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
-| [#2680][]            | —         | Clarify minimum vs officially supported Hugo    | docs  | done | done | todo | N/A  | User-visible: support policy surfaced     |
+| `494f3da6` [#2680][] | —         | Clarify minimum vs officially supported Hugo    | docs  | done | done | done | N/A  | User-visible: support policy surfaced     |
 
 ## Notes on bundled changes
 
@@ -114,7 +114,9 @@ first-parent spine and the raw range are identical; every subject carries its
   **officially supported** version (the docsy.dev pin) — sync-guards them
   (`test:hugo-versions`, minimum-Hugo smoke lane), and surfaces the
   official-support policy in the changelog and install prerequisites.
-  User-visible improvement: worth a release-blog mention (Blog: todo above).
+  User-visible improvement: the release post's Hugo section links the policy
+  (routed 2026-07-18); the changelog coverage **is** the rewritten §Official
+  support section itself.
 
 ## Linked issues
 
@@ -198,6 +200,6 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2678]: https://github.com/google/docsy/pull/2678
 [#2679]: https://github.com/google/docsy/pull/2679
 [#2680]: https://github.com/google/docsy/pull/2680
-[4e954dc1]: https://github.com/google/docsy/commit/4e954dc1
+[494f3da6]: https://github.com/google/docsy/commit/494f3da6
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-07-17
+lastmod: 2026-07-18
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: 4e954dc1
+last-main-commit: 494f3da6
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,9 +1,9 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-07-17
+lastmod: 2026-07-18
 range: v0.15.0..main
-last-main-commit: 4e954dc1
+last-main-commit: 494f3da6
 cSpell:ignore: favicons retokenization thoughtry
 ---
 
@@ -11,7 +11,7 @@ Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [4e954dc1][].
+> Prepared for commits in [v0.15.0...main][] through [494f3da6][].
 
 ## Themes (with evidence and client impact)
 
@@ -31,7 +31,8 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   (`languageName`/`languageDirection`) still work but should become
   `label`/`direction`. Node 22+ required for Hugo-managed Node tools from
   0.161.x (Docsy recommends Node LTS 24). Per-version mechanics live in the
-  [Hugo upgrade guide][].
+  [Hugo upgrade guide][]. The **minimum** vs **officially supported** version
+  distinction is now named, documented, and sync-guarded ([#2680][]).
 - **Favicons** — [#2653][], [#2654][], [#2656][]; [#2595][] closed, [#2357][]
   continues (26Q3). Default favicon artwork removed; the default partial
   discovers and links conventional `static/` files (`favicon.ico`,
@@ -151,6 +152,12 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   implemented but unreferenced).
 - Omitted [#2650][] (double-`v` docs fix) from the changelog — too minor; the
   changelog tracks breaking changes and highlights only.
+- **Clarified Hugo-version semantics** ([#2680][], 2026-07-18): Docsy names and
+  sync-guards its two Hugo versions — the theme **minimum** (requirement
+  statements, `test:hugo-versions`, minimum-Hugo smoke lane) and the
+  **officially supported** version (the docsy.dev pin). Policy home is the
+  changelog §Official support; the release post's Hugo section and the install
+  prerequisites link to it rather than restating (one home per fact).
 - Defer remaining monorepo ([#2617][]) and favicon ([#2357][]) work to post-0.16
   trackers; neither blocks the tag.
 
@@ -265,7 +272,8 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2675]: https://github.com/google/docsy/pull/2675
 [#2678]: https://github.com/google/docsy/pull/2678
 [#2679]: https://github.com/google/docsy/pull/2679
-[4e954dc1]: https://github.com/google/docsy/commit/4e954dc1
+[#2680]: https://github.com/google/docsy/pull/2680
+[494f3da6]: https://github.com/google/docsy/commit/494f3da6
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main


### PR DESCRIPTION
- Contributes to #2615
- Routine coverage-ledger refresh after #2680 landed (the only new commit since the last refresh, #2677):
  - Fills the #2680 ledger row (hash, Blog cell done) and updates the ledger notes.
  - Release post's Hugo section now links the official support policy — the one artifact gap; the policy's canonical home stays the changelog §Official support.
  - Wrapup: Hugo-support theme cites #2680; Decisions records the routing.
  - Workspace coordinates bumped to `494f3da6`.
- **Preview**:
  - [0.16.0 release post § Hugo 0.160.1+ support](https://deploy-preview-2681--docsydocs.netlify.app/blog/2026/0.16.0/#hugo)