### PR TITLE
Lean and DRY pass over the 0.16.0 release artifacts

### DIFF
--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -36,34 +36,20 @@ cSpell:ignore: CatmullRom favicons TOF
 
 ## Release summary
 
-- **[Theme folder move](#theme-folder)**: the canonical theme files moved under
-  `theme/`, separating the consumer-facing theme tree from repository and
-  website tooling.
-- **[Hugo support](#hugo)**:
-  - The theme minimum moved from Hugo 0.146.0 to **0.160.1**.
-  - The Docsy project build was upgraded to **Hugo 0.164.0**.
-  - Theme templates and docs moved off deprecated Hugo language APIs.
-- **[Bootstrap and Font Awesome via npm](#npm-deps)**:
-  - The theme sources Bootstrap and Font Awesome from npm through
-    [`hugo mod npm pack`][hugo-npm-pack], rather than importing their GitHub
-    repositories as Hugo modules.
-  - Hugo-module sites pull the dependencies with `hugo mod npm pack` and
-    `npm install`; other install modes are unaffected.
-  - PostCSS is now [opt-in for non-RTL sites](#postcss).
-- **[Favicons](#favicons)**:
-  - The theme no longer ships default favicon artwork.
-  - The default partial discovers and links common favicon filenames from a
-    site's `static/` directory.
-  - A `gen-favicons` helper can generate raster icons from a source SVG.
-- **[Shared chrome build mode](#shared-chrome)** (experimental): a new opt-in
-  `td.chrome = shared` mode that emits the repeated chrome (navbar, footer,
-  left-nav) once per language and restores it in the browser, so one build
-  serves both readers and link checkers; the default `full` mode is unchanged.
-- **Other notable changes**:
-  - Theme runtime dependencies now live in `theme/package.json`.
-  - The repository uses npm workspaces for `docsy.dev` and `theme`.
-  - Test coverage now includes Hugo deprecation checks and small fixture-site
-    regression tests.
+- **[Theme folder move](#theme-folder)**: the canonical theme now lives under
+  `theme/`; each install mode needs a one-line path update
+- **[Hugo 0.160.1+ support](#hugo)**: the theme minimum was raised from 0.146.0;
+  the project build now runs Hugo 0.164.0
+- **[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies now
+  come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
+  [PostCSS is opt-in](#postcss) for non-RTL sites
+- **[Favicons](#favicons)**: no more default artwork -- sites supply their own
+  icons, discovered from `static/` by filename convention
+- **[Shared chrome build mode](#shared-chrome)** (experimental): emits the
+  repeated chrome once per language and restores it in the browser, so one build
+  serves both readers and link checkers
+- **[Other notable changes](#other-notable-changes)**: repository package
+  layout, and build and test guards
 
 ## Ready to Upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
 
@@ -75,9 +61,9 @@ cSpell:ignore: CatmullRom favicons TOF
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
   not already building cleanly with Hugo 0.164.0.
 - Optionally skim:
-  - {{% _param NEW %}} New favicon discovery behavior
+  - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
-  - {{% _param CLEANUP %}} Repository packaging cleanup
+  - {{% _param CLEANUP %}} [Repository packaging cleanup](#package-layout)
   - {{% _param CLEANUP %}} [PostCSS is opt-in for non-RTL sites](#postcss)
   - [Other notable changes](#other-notable-changes)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.16.0](#upgrade) once
@@ -93,8 +79,7 @@ looks for the theme. The exact edit depends on how your site installs Docsy.
 
 This change lets the project keep the installable theme surface lean while
 moving repository-only tooling, website tooling, tests, and release automation
-out of the theme's way. It also makes `theme/package.json` the owner of theme
-runtime dependencies such as Bootstrap and Font Awesome.
+out of the theme's way.
 
 ### Actions {#theme-folder-actions}
 
@@ -127,9 +112,9 @@ hugo mod get github.com/google/docsy/theme@VERSION
 hugo mod tidy
 ```
 
-Users still request `@v0.16.0` in the command above. The release process creates
-the matching nested Hugo module tag, `theme/v0.16.0`, at the same commit as the
-repository release tag.
+You still request the plain release version, as in the command above; each
+release also creates the matching nested Hugo module tag, such as
+`theme/v0.16.0`.
 
 #### GitHub NPM package sites {#npm-sites}
 
@@ -308,21 +293,18 @@ The motivation is the contributor and CI experience, not a change to your
 published site. Because the chrome's many repeated links appear on one page
 instead of on every page, a `shared` build is dramatically cheaper to
 link-check, output-diff, and preview -- the outer loop of working on a site --
-while readers still get the full page once JavaScript runs. The default `full`
-mode stays the default, and a normal production build is unchanged.
+while readers still get the full page once JavaScript runs.
 
-The existing large-site navigation optimization is intact and generalized, not
-lost. A `full` build on a site above `sidebar_cache_limit` still renders the
-left-nav once as a shared cached menu; 0.16.0 only moved that activation from
-per-page inline jQuery into the shipped `chrome-nav.js`. As a result,
-`chrome-nav.js` now loads on every page regardless of build mode -- worth a note
-for JS-audit-conscious sites, and harmless for everyone else.
+The existing large-site navigation optimization is intact: a `full` build on a
+site above `sidebar_cache_limit` still renders the left-nav once as a shared
+cached menu -- 0.16.0 only moved that activation from per-page inline jQuery
+into the shipped `chrome-nav.js`, which now loads on every page regardless of
+build mode.
 
-Think of `shared` mode as a small, experimental first step toward a more
-component-oriented Docsy, where shared page regions are authored and shipped
-once. For configuration, the kept-or-restored contract, and current limitations,
-see [Chrome build modes][chrome]. This feature is [experimental][] and may
-change.
+The `shared` mode is a small first step toward a more component-oriented Docsy,
+where shared page regions are authored and shipped once. For configuration, the
+kept-or-restored contract, and current limitations, see [Chrome build
+modes][chrome]. The feature is [experimental][] and may change.
 
 ### Actions {#shared-chrome-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -245,11 +245,6 @@ sites no longer need a PostCSS toolchain at all and can drop `autoprefixer`,
 `postcss`, and `postcss-cli` from their dependencies. For the current install
 guidance, see [Install PostCSS][].
 
-Docsy's CSS targets the [Browserslist `defaults`][browserslist-defaults]
-browsers. To keep Autoprefixer (or other PostCSS plugins) for a non-RTL site,
-add a project-root `postcss.config.js` and install your own PostCSS
-dependencies.
-
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Favicons {#favicons}
 
 Docsy no longer ships default favicon artwork. Sites now own their favicon
@@ -334,7 +329,7 @@ or previews -- especially for a large or multilingual site.
 The Docsy repository now has a clearer package boundary:
 
 - `theme/` contains the theme files that consuming sites need.
-- `theme/package.json` owns Bootstrap and Font Awesome runtime dependencies.
+- `theme/package.json` owns the theme's runtime npm dependencies.
 - `docsy.dev/` owns the website build and site-specific tooling.
 - The repository root owns workspace orchestration, release tooling, and tests.
 
@@ -437,7 +432,6 @@ About this release:
 [hugo-supported-version]:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
-[browserslist-defaults]: https://github.com/browserslist/browserslist
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#next
 [compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -169,17 +169,14 @@ theme: docsy
 theme: docsy/theme
 ```
 
-For a fresh clone install, use this setup shape:
+Then update your clone or submodule to _`VERSION`_ using your existing update
+workflow, and re-run the theme's install step from inside `themes/docsy/`:
 
 ```sh
-cd themes
-git clone -b VERSION https://github.com/google/docsy
-(cd docsy && npm run postinstall)
-cd ..
+npm run postinstall
 ```
 
-For a Git submodule install, keep your existing submodule update workflow, then
-run the same `docsy` postinstall step after updating the submodule.
+For a fresh clone or submodule setup, see [Other installation options][].
 
 ## {{% _param BREAKING %}} Hugo 0.160.1+ support {#hugo}
 
@@ -214,17 +211,8 @@ of Docsy's [official support policy][].
 
 - Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.164.0.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
-- If your multilingual site config still uses Hugo's older language keys,
-  consider updating them:
-  - `languageName` -> `label`
-  - `languageDirection` -> `direction`
-- If your site overrides Docsy templates or language-related partials, check for
-  deprecated Hugo language API names such as `.Language.Lang`, `.LanguageName`,
-  and `.LanguageDirection`.
-
-The old language config keys still work in site configuration, but updating them
-keeps builds quiet as Hugo moves deprecations from info messages toward warnings
-and, later, errors. For current Docsy examples, see [Multi-language support][].
+- If your site is multilingual or overrides language-related templates, follow
+  the [language-API renames][hugo-language-apis] in the Hugo guide.
 
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Bootstrap and Font Awesome via npm {#npm-deps}
 
@@ -261,7 +249,8 @@ dependency set drifts.
 Docsy now runs `postCSS` only for sites with RTL languages (which need it for
 `rtlcss`) or that provide a project-root `postcss.config.{js,mjs,cjs}`. Other
 sites no longer need a PostCSS toolchain at all and can drop `autoprefixer`,
-`postcss`, and `postcss-cli` from their dependencies.
+`postcss`, and `postcss-cli` from their dependencies. For the current install
+guidance, see [Install PostCSS][].
 
 Docsy's CSS targets the [Browserslist `defaults`][browserslist-defaults]
 browsers. To keep Autoprefixer (or other PostCSS plugins) for a non-RTL site,
@@ -383,8 +372,8 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 
 [^vers-note]:
     Matches `docsy.dev`'s tested Hugo pin and the theme's declared minimum Hugo
-    version. Later Hugo or Node versions may work but are not officially
-    supported until validated by Docsy.
+    version. Later Hugo or Node versions may work; see the [official support
+    policy][].
 
 > [!NOTE]
 >
@@ -460,10 +449,12 @@ About this release:
 [CL@0.16.0]: /project/about/changelog/#next
 [compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [experimental]: /project/about/changelog/#experimental
+[hugo-language-apis]: hugo-0.158.0+/#language-apis
 [hugo-upgrade]: hugo-0.158.0+/
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
+[Install PostCSS]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [Lychee]: https://github.com/lycheeverse/lychee
-[Multi-language support]: /docs/language/
 [official support policy]: /project/about/changelog/#official-support
+[Other installation options]: /docs/get-started/other-options/
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -15,7 +15,6 @@ author: >-
 body_class: release-highlights
 tags: [release, upgrade]
 params:
-  # Frozen at publish time; see maintainer notes, "Hugo versions".
   hugoSupportedVersion: 0.164.0
 cSpell:ignore: CatmullRom favicons TOF
 ---

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -14,6 +14,9 @@ author: >-
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 body_class: release-highlights
 tags: [release, upgrade]
+params:
+  # Frozen at publish time; see maintainer notes, "Hugo versions".
+  hugoTarget: 0.164.0
 cSpell:ignore: CatmullRom favicons TOF
 ---
 
@@ -39,7 +42,7 @@ cSpell:ignore: CatmullRom favicons TOF
 - **[Theme folder move](#theme-folder)**: the canonical theme now lives under
   `theme/`; each install mode needs a one-line path update
 - **[Hugo 0.160.1+ support](#hugo)**: the theme minimum was raised from 0.146.0;
-  the project build now runs Hugo 0.164.0
+  the project build now runs Hugo {{% param hugoTarget %}}
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies now
   come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
   [PostCSS is opt-in](#postcss) for non-RTL sites
@@ -59,7 +62,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Default favicons removed](#favicons)
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
-  not already building cleanly with Hugo 0.164.0.
+  not already building cleanly with Hugo {{% param hugoTarget %}}.
 - Optionally skim:
   - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
@@ -181,11 +184,12 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 Sites building with an older Hugo version must upgrade Hugo before or while
 upgrading Docsy.
 
-The Docsy project build is validated with **Hugo 0.164.0**, as are the Docsy
-example site and at least one large downstream Docsy site. We recommend moving
-directly to 0.164.0 unless your project has a reason to pin a lower version. For
-the detailed Hugo changes between 0.158.0 and 0.164.0, see the companion [Hugo
-0.158+ upgrade guide][hugo-upgrade].
+The Docsy project build is validated with **Hugo {{% param hugoTarget %}}**, as
+are the Docsy example site and at least one large downstream Docsy site. We
+recommend moving directly to {{% param hugoTarget %}} unless your project has a
+reason to pin a lower version. For the detailed Hugo changes between 0.158.0 and
+{{% param hugoTarget %}}, see the companion [Hugo 0.158+ upgrade
+guide][hugo-upgrade].
 
 This distinction — the **minimum** Hugo version versus the **officially
 supported** version that the project pins and tests — is now documented as part
@@ -195,8 +199,9 @@ of Docsy's [official support policy][].
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.164.0; for install commands,
-  see the Hugo guide's [Upgrade to Hugo 0.164.0][hugo-upgrade-install] section.
+- Upgrade to Hugo 0.160.1 or later. Prefer Hugo {{% param hugoTarget %}}; for
+  install commands, see the Hugo guide's [Upgrade to Hugo
+  {{% param hugoTarget %}}][hugo-upgrade-install] section.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
 - If your site is multilingual or overrides language-related templates, follow
   the [language-API renames][hugo-language-apis] in the Hugo guide.
@@ -351,7 +356,8 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0. For this release, use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
-- **Hugo**: [0.157.0][] -> [0.164.0][] (theme minimum: [0.160.1][])
+- **Hugo**: [0.157.0][] -> [{{% param hugoTarget %}}][hugo-target] (theme
+  minimum: [0.160.1][])
 - **Node**: LTS 24 (unchanged)
 
 [^vers-note]:
@@ -371,7 +377,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 ### {{% _param FAS square-check primary %}} Sanity checks
 
 - [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
-      0.164.0.
+      {{% param hugoTarget %}}.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
 - [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
@@ -426,7 +432,8 @@ About this release:
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
-[0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
+[hugo-target]:
+  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoTarget %}}>
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [browserslist-defaults]: https://github.com/browserslist/browserslist
 [chrome]: /docs/deployment/chrome/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -16,7 +16,7 @@ body_class: release-highlights
 tags: [release, upgrade]
 params:
   # Frozen at publish time; see maintainer notes, "Hugo versions".
-  hugoTarget: 0.164.0
+  hugoSupportedVersion: 0.164.0
 cSpell:ignore: CatmullRom favicons TOF
 ---
 
@@ -42,7 +42,7 @@ cSpell:ignore: CatmullRom favicons TOF
 - **[Theme folder move](#theme-folder)**: the canonical theme now lives under
   `theme/`; each install mode needs a one-line path update
 - **[Hugo 0.160.1+ support](#hugo)**: the theme minimum was raised from 0.146.0;
-  the project build now runs Hugo {{% param hugoTarget %}}
+  the project build now runs Hugo {{% param hugoSupportedVersion %}}
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies now
   come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
   [PostCSS is opt-in](#postcss) for non-RTL sites
@@ -62,7 +62,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Default favicons removed](#favicons)
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
-  not already building cleanly with Hugo {{% param hugoTarget %}}.
+  not already building cleanly with Hugo {{% param hugoSupportedVersion %}}.
 - Optionally skim:
   - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
@@ -184,11 +184,12 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 Sites building with an older Hugo version must upgrade Hugo before or while
 upgrading Docsy.
 
-The Docsy project build is validated with **Hugo {{% param hugoTarget %}}**, as
-are the Docsy example site and at least one large downstream Docsy site. We
-recommend moving directly to {{% param hugoTarget %}} unless your project has a
-reason to pin a lower version. For the detailed Hugo changes between 0.158.0 and
-{{% param hugoTarget %}}, see the companion [Hugo 0.158+ upgrade
+The Docsy project build is validated with **Hugo
+{{% param hugoSupportedVersion %}}**, as are the Docsy example site and at least
+one large downstream Docsy site. We recommend moving directly to
+{{% param hugoSupportedVersion %}} unless your project has a reason to pin a
+lower version. For the detailed Hugo changes between 0.158.0 and
+{{% param hugoSupportedVersion %}}, see the companion [Hugo 0.158+ upgrade
 guide][hugo-upgrade].
 
 This distinction — the **minimum** Hugo version versus the **officially
@@ -199,9 +200,10 @@ of Docsy's [official support policy][].
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.160.1 or later. Prefer Hugo {{% param hugoTarget %}}; for
-  install commands, see the Hugo guide's [Upgrade to Hugo
-  {{% param hugoTarget %}}][hugo-upgrade-install] section.
+- Upgrade to Hugo 0.160.1 or later. Prefer Hugo
+  {{% param hugoSupportedVersion %}}; for install commands, see the Hugo guide's
+  [Upgrade to Hugo {{% param hugoSupportedVersion %}}][hugo-upgrade-install]
+  section.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
 - If your site is multilingual or overrides language-related templates, follow
   the [language-API renames][hugo-language-apis] in the Hugo guide.
@@ -356,8 +358,9 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0. For this release, use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
-- **Hugo**: [0.157.0][] -> [{{% param hugoTarget %}}][hugo-target] (theme
-  minimum: [0.160.1][])
+- **Hugo**: [0.157.0][] ->
+  [{{% param hugoSupportedVersion %}}][hugo-supported-version] (theme minimum:
+  [0.160.1][])
 - **Node**: LTS 24 (unchanged)
 
 [^vers-note]:
@@ -377,7 +380,7 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 ### {{% _param FAS square-check primary %}} Sanity checks
 
 - [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
-      {{% param hugoTarget %}}.
+      {{% param hugoSupportedVersion %}}.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
 - [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
@@ -432,8 +435,8 @@ About this release:
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
-[hugo-target]:
-  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoTarget %}}>
+[hugo-supported-version]:
+  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [browserslist-defaults]: https://github.com/browserslist/browserslist
 [chrome]: /docs/deployment/chrome/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -181,7 +181,8 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 Sites building with an older Hugo version must upgrade Hugo before or while
 upgrading Docsy.
 
-The Docsy project build is validated with **Hugo 0.164.0**. We recommend moving
+The Docsy project build is validated with **Hugo 0.164.0**, as are the Docsy
+example site and at least one large downstream Docsy site. We recommend moving
 directly to 0.164.0 unless your project has a reason to pin a lower version. For
 the detailed Hugo changes between 0.158.0 and 0.164.0, see the companion [Hugo
 0.158+ upgrade guide][hugo-upgrade].
@@ -194,7 +195,8 @@ of Docsy's [official support policy][].
 
 {{% _param BREAKING %}} **Applies to all projects upgrading to Docsy 0.16.0.**
 
-- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.164.0.
+- Upgrade to Hugo 0.160.1 or later. Prefer Hugo 0.164.0; for install commands,
+  see the Hugo guide's [Upgrade to Hugo 0.164.0][hugo-upgrade-install] section.
 - If your site declares `module.hugoVersion.min`, set it to at least `0.160.1`.
 - If your site is multilingual or overrides language-related templates, follow
   the [language-API renames][hugo-language-apis] in the Hugo guide.
@@ -433,6 +435,7 @@ About this release:
 [experimental]: /project/about/changelog/#experimental
 [hugo-language-apis]: hugo-0.158.0+/#language-apis
 [hugo-upgrade]: hugo-0.158.0+/
+[hugo-upgrade-install]: hugo-0.158.0+/#upgrade
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
 [Install PostCSS]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [Lychee]: https://github.com/lycheeverse/lychee

--- a/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
@@ -8,8 +8,6 @@ author: >-
 body_class: release-highlights
 tags: [hugo, upgrade]
 params:
-  # Frozen at publish time (shadows the site param); see maintainer notes,
-  # "Hugo versions".
   hugoMinVersion: 0.157.0
 # prettier-ignore
 cSpell:ignore: dartsass libsass IPTC multihost libwebp opentelemetry

--- a/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
@@ -7,6 +7,10 @@ author: >-
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 body_class: release-highlights
 tags: [hugo, upgrade]
+params:
+  # Frozen at publish time (shadows the site param); see maintainer notes,
+  # "Hugo versions".
+  hugoMinVersion: 0.157.0
 # prettier-ignore
 cSpell:ignore: dartsass libsass IPTC multihost libwebp opentelemetry
 ---
@@ -297,12 +301,12 @@ your convenience, we link to required and optional actions for each section.
 
 For projects using the new sites matrix features who also want the latest fixes
 and updated support for aliases in the context of multidimensional sites, we
-recommend using Hugo [0.157.0][hugo-min-version] or later:
+recommend using Hugo [{{% param hugoMinVersion %}}][hugo-min-version] or later:
 
 ```yaml
 module:
   hugoVersion:
-    min: '0.157.0'
+    min: '{{% _param hugoMinVersion %}}'
 ```
 
 [0.152.0]: https://github.com/gohugoio/hugo/releases/tag/v0.152.0
@@ -312,7 +316,8 @@ module:
   https://discourse.gohugo.io/t/why-does-glob-negation-require-a-space-after/56651
 [files]: https://gohugo.io/configuration/module/#files
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
-[hugo-min-version]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
+[hugo-min-version]:
+  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoMinVersion %}}>
 [hvm]: https://github.com/jmooring/hvm
 [multidimensional content model]:
   https://gohugo.io/about/features/#multidimensional-content-model

--- a/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.152.0+.md
@@ -297,12 +297,12 @@ your convenience, we link to required and optional actions for each section.
 
 For projects using the new sites matrix features who also want the latest fixes
 and updated support for aliases in the context of multidimensional sites, we
-recommend using Hugo [{{% param hugoMinVersion %}}][hugo-min-version] or later:
+recommend using Hugo [0.157.0][hugo-min-version] or later:
 
 ```yaml
 module:
   hugoVersion:
-    min: '{{% _param hugoMinVersion %}}'
+    min: '0.157.0'
 ```
 
 [0.152.0]: https://github.com/gohugoio/hugo/releases/tag/v0.152.0
@@ -312,8 +312,7 @@ module:
   https://discourse.gohugo.io/t/why-does-glob-negation-require-a-space-after/56651
 [files]: https://gohugo.io/configuration/module/#files
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
-[hugo-min-version]:
-  <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoMinVersion %}}>
+[hugo-min-version]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [hvm]: https://github.com/jmooring/hvm
 [multidimensional content model]:
   https://gohugo.io/about/features/#multidimensional-content-model

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -11,14 +11,15 @@ body_class: release-highlights
 tags: [hugo, upgrade]
 params:
   # Frozen at publish time; see maintainer notes, "Hugo versions".
-  hugoTarget: 0.164.0
+  hugoSupportedVersion: 0.164.0
 # prettier-ignore
 cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
 ---
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
-{{% param hugoTarget %}} that are relevant to Docsy users. It is a companion
-post to the Docsy [0.16.0](0.16.0/) release and upgrade guide, which covers the
+{{% param hugoSupportedVersion %}} that are relevant to Docsy users. It is a
+companion post to the Docsy [0.16.0](0.16.0/) release and upgrade guide, which
+covers the
 [Hugo versions that Docsy 0.16.0 requires and validates](0.16.0/#hugo).
 
 ## Upgrade summary
@@ -42,7 +43,8 @@ Docsy site to 0.16.0.
   - [Faster builds and stricter templates](#hugo-0-164-0)
   - [Notable changes](#notable-changes)
 - {{% _param FAS rocket primary %}} Jump to
-  [Upgrade to Hugo {{% param hugoTarget %}}](#upgrade) once you're ready.
+  [Upgrade to Hugo {{% param hugoSupportedVersion %}}](#upgrade) once you're
+  ready.
 
 ## Language API deprecations (0.158.0) {#language-apis}
 
@@ -298,21 +300,21 @@ stopping at the minimum 0.160.1.
 - On Hugo 0.164.0, `hugo gen chromastyles` gains `--mode` and `--modeSelector`
   flags for generating combined light/dark syntax-highlighting stylesheets.
 
-## {{% _param FAS rocket primary %}} Upgrade to Hugo {{% param hugoTarget %}} {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to Hugo {{% param hugoSupportedVersion %}} {#upgrade}
 
 After addressing applicable breaking changes and deprecations, upgrade to Hugo
-{{% param hugoTarget %}}.
+{{% param hugoSupportedVersion %}}.
 
 If you use the [hugo-extended][] npm package:
 
 ```sh
-npm install hugo-extended@{{% _param hugoTarget %}} --save-dev
+npm install hugo-extended@{{% _param hugoSupportedVersion %}} --save-dev
 ```
 
 If you use [hvm][]:
 
 ```sh
-hvm use {{% _param hugoTarget %}}
+hvm use {{% _param hugoSupportedVersion %}}
 ```
 
 <section class="td-checkbox-list-wrapper">

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -10,7 +10,6 @@ author: >-
 body_class: release-highlights
 tags: [hugo, upgrade]
 params:
-  # Frozen at publish time; see maintainer notes, "Hugo versions".
   hugoSupportedVersion: 0.164.0
 # prettier-ignore
 cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -10,7 +10,7 @@ author: >-
 body_class: release-highlights
 tags: [hugo, upgrade]
 # prettier-ignore
-cSpell:ignore: amp AVIF CatmullRom chromastyles goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
+cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
 ---
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
@@ -61,19 +61,14 @@ one large downstream Docsy site.
 
 {{% _param BREAKING %}} **Applies to all sites upgrading to Docsy 0.16.0.**
 
-- Upgrade Hugo to 0.160.1 or later. Prefer 0.164.0.
-- If your project declares `module.hugoVersion.min`, set it to at least
-  `0.160.1`.
-- If you use `hugo-extended`, pin a compatible version in your site:
+- Upgrade Hugo to 0.160.1 or later. Prefer 0.164.0; for install commands, see
+  [Upgrade to Hugo 0.164.0](#upgrade).
+- If your project declares a minimum Hugo version, set it to at least 0.160.1:
 
-  ```sh
-  npm install hugo-extended@0.164.0 --save-dev
-  ```
-
-- If you use [hvm][], select the latest compatible Hugo release:
-
-  ```sh
-  hvm use 0.164.0
+  ```yaml
+  module:
+    hugoVersion:
+      min: 0.160.1
   ```
 
 ## Language API deprecations (0.158.0) {#language-apis}
@@ -133,14 +128,11 @@ release. If you are moving through this range, do not stop at 0.159.2. Docsy
 
 **Applies if** you briefly tested or deployed Hugo 0.159.2.
 
-- Upgrade to Hugo 0.160.1 or later.
 - Search generated HTML for `&amp;amp;` in link URLs.
-- Pay closest attention to monolingual sites without custom link render hooks.
-
-Multilingual single-host sites are usually shielded because Hugo's
-`useEmbedded: auto` behavior activates the embedded link render hook. Sites with
-custom link render hooks are also usually shielded. The safest path is still to
-use Hugo 0.160.1 or later.
+- Pay closest attention to monolingual sites without custom link render hooks:
+  multilingual single-host sites are usually shielded by Hugo's
+  `useEmbedded: auto` link render hook, and custom link render hooks also
+  usually shield a site.
 
 ## Template and module cleanup (0.159.x-0.160.x) {#template-module-cleanup}
 
@@ -161,26 +153,20 @@ scripts.
 - If you use `hugo convert`, review generated output before committing it.
 
 **Applies if** your site uses Goldmark passthrough, `RenderShortcodes`, or
-multilingual root sections. Prefer Hugo 0.160.1 or later and include these pages
-in smoke tests. Hugo 0.160.1 fixed relevant regressions around passthrough
-elements in headings, shortcode rendering context markers, and multilingual root
-section generation.
+multilingual root sections. Hugo 0.160.1 -- Docsy 0.16.0's minimum -- fixed
+regressions in this range around passthrough elements in headings, shortcode
+rendering context markers, and multilingual root section generation; include
+such pages in your smoke tests.
 
 ## {{% _param BREAKING %}} Node-managed tools (0.161.x) {#node-tools}
 
 Hugo 0.161.x runs Node-based tools such as PostCSS, Babel, and Tailwind under
-Node's `--permission` sandbox. This requires **Node 22 or later**. Docsy
-continues to recommend Node LTS 24 for supported builds.
+Node's `--permission` sandbox. This requires **Node 22 or later**.
 
 Docsy sites commonly use PostCSS for CSS processing, so this can be a practical
-breaking change even when the Docsy theme itself has not changed.
-
-Hugo 0.163.2 fixes an `ERR_ACCESS_DENIED` regression in this permission model
-that could abort builds when `node_modules` lives outside the project tree, such
-as in a CI provider's shared cache (for example, Netlify). Hugo 0.163.3 extends
-the same work so that config-file resolution also finds `.mjs` and `.cjs`
-variants of PostCSS and Babel configs. Both are reasons to prefer 0.163.3 or
-later for PostCSS pipelines.
+breaking change even when the Docsy theme itself has not changed. Hugo 0.163.2
+and 0.163.3 fix regressions in this permission model, so prefer 0.163.3 or later
+for PostCSS pipelines; the actions below give the specifics.
 
 ### Actions {#node-tools-actions}
 
@@ -391,18 +377,6 @@ hvm use 0.164.0
 - [ ] [Hugo 0.164.0 actions](#hugo-0-164-0-actions)
 
 </section>
-
-## Recommended minimum Hugo version {#min-hugo-version}
-
-Docsy 0.16.0 requires Hugo 0.160.1 or later:
-
-```yaml
-module:
-  hugoVersion:
-    min: 0.160.1
-```
-
-For local builds, deployments, and new upgrades, we recommend Hugo 0.164.0.
 
 <!-- prettier-ignore-start -->
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -9,13 +9,16 @@ author: >-
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
 body_class: release-highlights
 tags: [hugo, upgrade]
+params:
+  # Frozen at publish time; see maintainer notes, "Hugo versions".
+  hugoTarget: 0.164.0
 # prettier-ignore
 cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
 ---
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
-0.164.0 that are relevant to Docsy users. It is a companion post to the Docsy
-[0.16.0](0.16.0/) release and upgrade guide, which covers the
+{{% param hugoTarget %}} that are relevant to Docsy users. It is a companion
+post to the Docsy [0.16.0](0.16.0/) release and upgrade guide, which covers the
 [Hugo versions that Docsy 0.16.0 requires and validates](0.16.0/#hugo).
 
 ## Upgrade summary
@@ -38,8 +41,8 @@ Docsy site to 0.16.0.
   - [Template and module cleanup](#template-module-cleanup)
   - [Faster builds and stricter templates](#hugo-0-164-0)
   - [Notable changes](#notable-changes)
-- {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.164.0](#upgrade)
-  once you're ready.
+- {{% _param FAS rocket primary %}} Jump to
+  [Upgrade to Hugo {{% param hugoTarget %}}](#upgrade) once you're ready.
 
 ## Language API deprecations (0.158.0) {#language-apis}
 
@@ -295,21 +298,21 @@ stopping at the minimum 0.160.1.
 - On Hugo 0.164.0, `hugo gen chromastyles` gains `--mode` and `--modeSelector`
   flags for generating combined light/dark syntax-highlighting stylesheets.
 
-## {{% _param FAS rocket primary %}} Upgrade to Hugo 0.164.0 {#upgrade}
+## {{% _param FAS rocket primary %}} Upgrade to Hugo {{% param hugoTarget %}} {#upgrade}
 
 After addressing applicable breaking changes and deprecations, upgrade to Hugo
-0.164.0.
+{{% param hugoTarget %}}.
 
 If you use the [hugo-extended][] npm package:
 
 ```sh
-npm install hugo-extended@0.164.0 --save-dev
+npm install hugo-extended@{{% _param hugoTarget %}} --save-dev
 ```
 
 If you use [hvm][]:
 
 ```sh
-hvm use 0.164.0
+hvm use {{% _param hugoTarget %}}
 ```
 
 <section class="td-checkbox-list-wrapper">

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -15,10 +15,8 @@ cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling gold
 
 This post summarizes breaking, security, and notable changes in Hugo 0.158.0 to
 0.164.0 that are relevant to Docsy users. It is a companion post to the Docsy
-[0.16.0](0.16.0/) release and upgrade guide.
-
-Docsy 0.16.0 requires Hugo 0.160.1 or later. The Docsy project build is tested
-with Hugo 0.164.0, which is the recommended target for this upgrade range.
+[0.16.0](0.16.0/) release and upgrade guide, which covers the
+[Hugo versions that Docsy 0.16.0 requires and validates](0.16.0/#hugo).
 
 ## Upgrade summary
 
@@ -27,8 +25,6 @@ Docsy site to 0.16.0.
 
 - Review {{% _param BADGE BREAKING warning %}} changes:
   <a id="breaking-changes"></a>
-  - {{% _param BREAKING %}}
-    [Docsy now requires Hugo 0.160.1 or later](#hugo-version)
   - {{% _param BREAKING %}}
     [Node 22+ is required for Hugo-managed Node tools](#node-tools)
   - {{% _param BREAKING %}}
@@ -45,32 +41,6 @@ Docsy site to 0.16.0.
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to Hugo 0.164.0](#upgrade)
   once you're ready.
 
-## {{% _param BREAKING %}} Hugo version for Docsy 0.16.0 {#hugo-version}
-
-Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
-**0.160.1**. For the rationale behind that minimum, see
-[Hugo 0.160.1+ support](0.16.0/#hugo) in the release post.
-
-We recommend upgrading directly to **Hugo 0.164.0**: the later releases include
-security fixes, 0.164.0
-[fixes a long-standing template-rendering slowdown](#hugo-0-164-0), and these
-are the versions validated across Docsy, the Docsy example site, and at least
-one large downstream Docsy site.
-
-### Actions {#hugo-version-actions}
-
-{{% _param BREAKING %}} **Applies to all sites upgrading to Docsy 0.16.0.**
-
-- Upgrade Hugo to 0.160.1 or later. Prefer 0.164.0; for install commands, see
-  [Upgrade to Hugo 0.164.0](#upgrade).
-- If your project declares a minimum Hugo version, set it to at least 0.160.1:
-
-  ```yaml
-  module:
-    hugoVersion:
-      min: 0.160.1
-  ```
-
 ## Language API deprecations (0.158.0) {#language-apis}
 
 Hugo 0.158.0 renamed several language configuration keys and template methods.
@@ -78,7 +48,7 @@ The old names log deprecation notices first, then move toward warnings and
 eventual errors on Hugo's deprecation timeline.
 
 Docsy's own templates and docs now use the new names — one of the changes behind
-0.16.0's [raised Hugo minimum](#hugo-version).
+0.16.0's [raised Hugo minimum](0.16.0/#hugo).
 
 ### Actions {#language-api-actions}
 
@@ -365,7 +335,7 @@ hvm use 0.164.0
 
 #### Required actions, as applicable {#required-actions}
 
-- [ ] [Hugo version actions](#hugo-version-actions)
+- [ ] [Hugo version actions](0.16.0/#hugo-actions) in the release post
 - [ ] [Node tooling actions](#node-tools-actions)
 - [ ] [Security actions](#security-actions)
 

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
@@ -125,8 +125,9 @@ steps.
 This section applies to all [installation options](/docs/get-started/), not just
 Hugo-module setups.
 
-Docsy builds its CSS without [PostCSS](https://postcss.org/) by default, so most
-sites don't need it. Install PostCSS only if:
+Docsy builds its CSS without [PostCSS](https://postcss.org/) by default -- the
+shipped CSS targets the [Browserslist `defaults`][browserslist-defaults]
+browsers -- so most sites don't need it. Install PostCSS only if:
 
 - Your site has a **[right-to-left (RTL)][rtl]** language, or
 - You post-process your own CSS with a project-root
@@ -153,6 +154,7 @@ site
 - [Start site from scratch (for experts)](start-from-scratch/)
 
 <!-- prettier-ignore-start -->
+[browserslist-defaults]: https://github.com/browserslist/browserslist
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
 [node-lts]: https://nodejs.org/en/about/releases/
 [postcss]: https://www.npmjs.com/package/postcss

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,26 +141,20 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 **New**:
 
 - **Favicon discovery**: you can now drop a site's conventionally named favicon
-  files (`favicon.ico`, `favicon.svg`, `apple-touch-icon.png`, and optional
-  square `favicon-NxN.png` and `apple-touch-icon-NxN.png` variants) into
-  `static/` and the theme discovers and links them -- no favicons partial
-  required. A new `gen-favicons` helper generates raster icons from a source
-  SVG. See [0.16.0 release report][0.16.0-blog-favicons] and [Add your
+  files into `static/` and the theme discovers and links them -- no favicons
+  partial required. A new `gen-favicons` helper generates raster icons from a
+  source SVG. See [0.16.0 release report][0.16.0-blog-favicons] and [Add your
   favicons][favicons] ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
-- **Default favicons** removed from the theme; sites now supply their own.
-  Conventional `static/` filenames are discovered and linked automatically (see
-  **Favicon discovery** under **New** above), so a custom partial is only needed
-  for non-default filenames or extra links. See [0.16.0 release
+- **Default favicons** removed from the theme; sites now supply their own --
+  most simply via **Favicon discovery** (see **New** above). See [0.16.0 release
   report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
   **[0.160.1][hugo-0.160.1]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
   For the rationale, see [0.16.0 release report][0.16.0-blog-hugo] ([#2668][],
-  [#2677][]). Note: the language config keys deprecated by Hugo 0.158.0 still
-  work in your site config, but consider renaming them; see [Hugo 0.158+ upgrade
-  guide][] ([#2593][]).
+  [#2677][]).
 - **Theme folder move**: the canonical theme now lives in `theme/`; consuming
   sites need a one-line install-path update for their install mode. See [0.16.0
   release report][0.16.0-blog-theme-folder] ([#2617][]).
@@ -172,8 +166,8 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 **Other changes**:
 
-- Migrated the theme and docs off deprecated Hugo language APIs. Thanks
-  [@deining][] for the groundwork in [#2594][] and [#2578][]!
+- Migrated the theme and docs off deprecated Hugo language APIs ([#2593][]).
+  Thanks [@deining][] for the groundwork in [#2594][] and [#2578][]!
 - Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
   minimum supported Hugo version remains 0.160.1. See [Hugo 0.158+ upgrade
   guide][] ([#2581][]).
@@ -181,11 +175,8 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   runtime dependencies, and the root package orchestrates the `docsy.dev` and
   `theme` workspaces ([#2617][]).
 - **PostCSS is opt-in for non-RTL sites**: Docsy runs `postCSS` only for sites
-  with RTL languages or that provide a project-root
-  `postcss.config.{js,mjs,cjs}`, so other sites no longer need
-  `autoprefixer`/`postcss`/`postcss-cli`. Sites with RTL languages still install
-  their own PostCSS toolchain plus `rtlcss`. Docsy's CSS targets the
-  Browserslist `defaults` browsers. See [0.16.0 release
+  with RTL languages or a project-root `postcss.config.{js,mjs,cjs}`; other
+  sites no longer need a PostCSS toolchain. See [0.16.0 release
   report][0.16.0-blog-postcss] ([#2668][]).
 - Moved cached-sidebar activation on large sites (above `sidebar_cache_limit`)
   from per-page inline jQuery to the shared `chrome-nav.js` hydration path;

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -70,9 +70,10 @@ Only current-state pages — docs and the changelog's
 [official support](/project/about/changelog/#official-support) section — render
 these versions live, via the `hugoMinVersion` site param and the `hugo-version`
 shortcode. Blog posts are historical snapshots and render versions
-time-insensitively: declare each version a post repeats as a page param, frozen
+time-insensitively: a post that renders one of these version params freezes it
 in its front matter, so updating the post (say, for a patch release) means
-editing one field. Page params take precedence over site params, so the same
+editing one field. (Version literals in narrative text are already
+time-insensitive.) Page params take precedence over site params, so the same
 `{{%/* param hugoMinVersion */%}}` call is frozen in a post and live in docs.
 Guarded by [test:hugo-versions](#test-suites).
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -68,9 +68,13 @@ guarded by [test:hugo-versions](#test-suites).
 
 Only current-state pages — docs and the changelog's
 [official support](/project/about/changelog/#official-support) section — render
-these versions computed, via `hugoMinVersion` and the `hugo-version` shortcode.
-Blog posts are historical snapshots: hard-code version literals there, since a
-computed value silently rewrites the post when the version next moves.
+these versions live, via the `hugoMinVersion` site param and the `hugo-version`
+shortcode. Blog posts are historical snapshots and render versions
+time-insensitively: declare each version a post repeats as a page param, frozen
+in its front matter, so updating the post (say, for a patch release) means
+editing one field. Page params take precedence over site params, so the same
+`{{%/* param hugoMinVersion */%}}` call is frozen in a post and live in docs.
+Guarded by [test:hugo-versions](#test-suites).
 
 ### Minimum Hugo version
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -14,14 +14,17 @@ Keep project content DRY by writing each fact in the artifact whose purpose and
 audience it serves. Each artifact links to the more detailed ones rather than
 restating them:
 
-- **[Changelog][]**: a lean record of _what changed_, for devs who want a quick
-  overview. No upgrade advice, implementation detail, or background. Entries
-  link to the release report for details and cite a change's key issues — PRs
-  only when there is no key issue, such as for contributor credit.
+- **[Changelog][]**: a lean record of _what changed_, for developers who want a
+  quick overview. No upgrade advice, implementation detail, or background.
+  Entries link to the release report for details and cite a change's key issues
+  — PRs only when there is no key issue, such as for contributor credit.
 - **Release and upgrade blog posts**: what's new, what to watch out for, and
   actionable upgrade guidance — the historical narrative. Link to the site docs
   for current behavior and reference detail. Don't enumerate PRs and issues;
-  link an open tracker only where it adds follow-up context.
+  link an open tracker only where it adds follow-up context. Upgrades are a
+  chore, so keep posts maximally actionable yet lean: the release summary reads
+  like a selective table of contents — a link per section with a clause of
+  guiding glue — and each fact appears in one section, its home.
 - **Site docs** (`docs/`): Docsy _as it is now_. Minimal historical references
   or links to issues and PRs.
 - **[Release notes][] and [milestones][]**: the exhaustive record — generated

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -66,6 +66,12 @@ The repo tracks two distinct Hugo versions, as documented below. Their
 declarations, synchronization requirements, and relative-version constraints are
 guarded by [test:hugo-versions](#test-suites).
 
+Only current-state pages — docs and the changelog's
+[official support](/project/about/changelog/#official-support) section — render
+these versions computed, via `hugoMinVersion` and the `hugo-version` shortcode.
+Blog posts are historical snapshots: hard-code version literals there, since a
+computed value silently rewrites the post when the version next moves.
+
 ### Minimum Hugo version
 
 Docsy declares the minimum Hugo version required to support the features that

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -87,11 +87,9 @@ test('Hugo minimum is at most the officially supported version', () => {
   assert.ok((cmp ?? 0) <= 0, `minimum ${minimum} <= pin ${supported}`);
 });
 
-// Blog posts are historical snapshots: they must render Hugo versions
-// time-insensitively (see maintainer notes, "Hugo versions"). A version param
-// used in a post must be frozen in the post's front matter — page params take
-// precedence over site params — and the live hugo-version shortcode is
-// off-limits.
+// Blog posts are historical snapshots: any Hugo version a post renders must be
+// frozen as a page param in its front matter, never rendered live (see
+// maintainer notes, "Hugo versions").
 test('blog posts freeze the Hugo versions that they render', () => {
   const blogDir = path.join(repoRoot, 'docsy.dev/content/en/blog');
   const posts = fs

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -86,3 +86,39 @@ test('Hugo minimum is at most the officially supported version', () => {
     .find((d) => d !== 0);
   assert.ok((cmp ?? 0) <= 0, `minimum ${minimum} <= pin ${supported}`);
 });
+
+// Blog posts are historical snapshots: they must render Hugo versions
+// time-insensitively (see maintainer notes, "Hugo versions"). A version param
+// used in a post must be frozen in the post's front matter — page params take
+// precedence over site params — and the live hugo-version shortcode is
+// off-limits.
+test('blog posts freeze the Hugo versions that they render', () => {
+  const blogDir = path.join(repoRoot, 'docsy.dev/content/en/blog');
+  const posts = fs
+    .readdirSync(blogDir, { recursive: true })
+    .filter((f) => f.endsWith('.md'));
+  assert.ok(posts.length > 0, 'blog posts are found');
+
+  const versionParams = ['hugoMinVersion', 'hugoTarget'];
+  let frozenUses = 0;
+  for (const post of posts) {
+    const text = fs.readFileSync(path.join(blogDir, post), 'utf8');
+    assert.doesNotMatch(
+      text,
+      /\{\{[%<]\s*hugo-version\b/,
+      `${post} renders versions time-insensitively`,
+    );
+    const frontMatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+    for (const param of versionParams) {
+      const use = new RegExp(String.raw`\{\{[%<]\s*_?param\s+"?${param}\b`);
+      if (!use.test(text)) continue;
+      frozenUses++;
+      assert.match(
+        frontMatter,
+        new RegExp(String.raw`^\s+${param}:`, 'm'),
+        `${post} front matter freezes ${param}`,
+      );
+    }
+  }
+  assert.ok(frozenUses > 0, 'at least one post uses a frozen version param');
+});

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -87,17 +87,24 @@ test('Hugo minimum is at most the officially supported version', () => {
   assert.ok((cmp ?? 0) <= 0, `minimum ${minimum} <= pin ${supported}`);
 });
 
+const blogDir = path.join(repoRoot, 'docsy.dev/content/en/blog');
+const blogPosts = () =>
+  fs.readdirSync(blogDir, { recursive: true }).filter((f) => f.endsWith('.md'));
+const frontMatterOf = (text) => text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+
+// The version params that posts freeze, mapped to their live values.
+const liveVersions = {
+  hugoMinVersion: declarations['theme/theme.toml'],
+  hugoSupportedVersion: pin,
+};
+
 // Blog posts are historical snapshots: any Hugo version a post renders must be
 // frozen as a page param in its front matter, never rendered live (see
 // maintainer notes, "Hugo versions").
 test('blog posts freeze the Hugo versions that they render', () => {
-  const blogDir = path.join(repoRoot, 'docsy.dev/content/en/blog');
-  const posts = fs
-    .readdirSync(blogDir, { recursive: true })
-    .filter((f) => f.endsWith('.md'));
+  const posts = blogPosts();
   assert.ok(posts.length > 0, 'blog posts are found');
 
-  const versionParams = ['hugoMinVersion', 'hugoSupportedVersion'];
   let frozenUses = 0;
   for (const post of posts) {
     const text = fs.readFileSync(path.join(blogDir, post), 'utf8');
@@ -106,8 +113,8 @@ test('blog posts freeze the Hugo versions that they render', () => {
       /\{\{[%<]\s*hugo-version\b/,
       `${post} renders versions time-insensitively`,
     );
-    const frontMatter = text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
-    for (const param of versionParams) {
+    const frontMatter = frontMatterOf(text);
+    for (const param of Object.keys(liveVersions)) {
       const use = new RegExp(String.raw`\{\{[%<]\s*_?param\s+"?${param}\b`);
       if (!use.test(text)) continue;
       frozenUses++;
@@ -119,4 +126,23 @@ test('blog posts freeze the Hugo versions that they render', () => {
     }
   }
   assert.ok(frozenUses > 0, 'at least one post uses a frozen version param');
+});
+
+// Frozen versions snapshot publish-time values, so until a post is published
+// they must track the live declarations. Also keeps companion posts in
+// agreement. Dormant for published posts, whose values age by design.
+test('draft posts freeze the currently declared Hugo versions', () => {
+  for (const post of blogPosts()) {
+    const frontMatter = frontMatterOf(
+      fs.readFileSync(path.join(blogDir, post), 'utf8'),
+    );
+    if (!/^draft: true$/m.test(frontMatter)) continue;
+    for (const [param, live] of Object.entries(liveVersions)) {
+      const frozen = frontMatter.match(
+        new RegExp(String.raw`^\s+${param}:\s*(\S+)`, 'm'),
+      )?.[1];
+      if (frozen === undefined) continue;
+      assert.equal(frozen, live(), `${post} freezes the current ${param}`);
+    }
+  }
 });

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -99,7 +99,7 @@ test('blog posts freeze the Hugo versions that they render', () => {
     .filter((f) => f.endsWith('.md'));
   assert.ok(posts.length > 0, 'blog posts are found');
 
-  const versionParams = ['hugoMinVersion', 'hugoTarget'];
+  const versionParams = ['hugoMinVersion', 'hugoSupportedVersion'];
   let frozenUses = 0;
   for (const post of posts) {
     const text = fs.readFileSync(path.join(blogDir, post), 'utf8');

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -92,14 +92,26 @@ const blogPosts = () =>
   fs.readdirSync(blogDir, { recursive: true }).filter((f) => f.endsWith('.md'));
 const frontMatterOf = (text) => text.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
 
+// Hugo resolves a page param only when it is a top-level front-matter field or
+// a direct child of `params:`; a deeper-nested param is silently ignored and
+// the live site value is rendered instead.
+const pageParamOf = (frontMatter, param) => {
+  const entry = (prefix) =>
+    new RegExp(String.raw`^${prefix}${param}:[ \t]*['"]?([^'"\s]+)`, 'm');
+  const paramsBlock = frontMatter.match(/^params:\n((?: +.*\n?)*)/m)?.[1] ?? '';
+  return (
+    frontMatter.match(entry(''))?.[1] ?? paramsBlock.match(entry('  '))?.[1]
+  );
+};
+
 // The version params that posts freeze, mapped to their live values.
 const liveVersions = {
   hugoMinVersion: declarations['theme/theme.toml'],
   hugoSupportedVersion: pin,
 };
 
-// Blog posts are historical snapshots: any Hugo version a post renders must be
-// frozen as a page param in its front matter, never rendered live (see
+// Blog posts are historical snapshots: a post that renders one of the declared
+// version params must freeze it in its front matter, never render it live (see
 // maintainer notes, "Hugo versions").
 test('blog posts freeze the Hugo versions that they render', () => {
   const posts = blogPosts();
@@ -119,9 +131,9 @@ test('blog posts freeze the Hugo versions that they render', () => {
       if (!use.test(text)) continue;
       frozenUses++;
       assert.match(
-        frontMatter,
-        new RegExp(String.raw`^\s+${param}:`, 'm'),
-        `${post} front matter freezes ${param}`,
+        pageParamOf(frontMatter, param) ?? '',
+        /^\d+\.\d+\.\d+$/,
+        `${post} freezes ${param} as an effective page param`,
       );
     }
   }
@@ -138,11 +150,28 @@ test('draft posts freeze the currently declared Hugo versions', () => {
     );
     if (!/^draft: true$/m.test(frontMatter)) continue;
     for (const [param, live] of Object.entries(liveVersions)) {
-      const frozen = frontMatter.match(
-        new RegExp(String.raw`^\s+${param}:\s*(\S+)`, 'm'),
-      )?.[1];
+      const frozen = pageParamOf(frontMatter, param);
       if (frozen === undefined) continue;
       assert.equal(frozen, live(), `${post} freezes the current ${param}`);
     }
+  }
+});
+
+// A draft guide whose title advertises an upper version bound must keep it on
+// the frozen target: advancing hugoSupportedVersion forces the guide's title
+// and coverage to be reviewed.
+test('draft post titles cover the frozen supported Hugo version', () => {
+  for (const post of blogPosts()) {
+    const frontMatter = frontMatterOf(
+      fs.readFileSync(path.join(blogDir, post), 'utf8'),
+    );
+    if (!/^draft: true$/m.test(frontMatter)) continue;
+    const bound = frontMatter.match(/^title:.*\b(\d+\.\d+)\.x\b/m)?.[1];
+    if (!bound) continue;
+    const target = pageParamOf(frontMatter, 'hugoSupportedVersion');
+    assert.ok(
+      target?.startsWith(`${bound}.`),
+      `${post} title bound ${bound}.x covers hugoSupportedVersion ${target}`,
+    );
   }
 });


### PR DESCRIPTION
Applies the [Content placement](https://docsy.dev/project/about/maintainer-notes/#content-placement) guidance (one home per fact; lean and DRY) to the 0.16.0 release artifacts:

- Defers restated mechanics to their canonical homes: the release post links the Hugo guide's language-API renames, the docs' fresh-install setup and PostCSS guidance, and the official support policy instead of restating them.
- Trims changelog entries to the what-changed bar: drops upgrade advice, the favicon filename list, and PostCSS behavior detail.
- Homes the Browserslist `defaults` compatibility statement in the docs (Install PostCSS).
- Reworks the post's Release summary as a selective ToC and removes intra-page restatements.
- Applies the same pass to the companion Hugo 0.158+ upgrade guide, making the release post the sole owner of the Hugo version requirements.
- Blog posts now render Hugo versions time-insensitively, frozen as page params in their front matter; this fixes the 0.152 guide, whose published recommendation had silently drifted from 0.157.0 to 0.160.1. Documented in the maintainer notes and guarded by `test:hugo-versions`: frozen params must be effective (where Hugo resolves them), draft posts must freeze the currently declared values, and draft-guide title bounds must cover the frozen target.

Preview: [release post](https://deploy-preview-2682--docsydocs.netlify.app/blog/2026/0.16.0/) · [Hugo guide](https://deploy-preview-2682--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/) · [changelog](https://deploy-preview-2682--docsydocs.netlify.app/project/about/changelog/#next)