### PR TITLE
docsy.dev: install link-cache from the npm registry

### DIFF
--- a/docsy.dev/package.json
+++ b/docsy.dev/package.json
@@ -56,7 +56,7 @@
     "afdocs": "^0.9.2",
     "cross-env": "^10.1.0",
     "hugo-extended": "0.164.0",
-    "link-cache": "github:chalin/link-cache#semver:^0.2.0",
+    "link-cache": "^0.3.0",
     "netlify-cli": "^24.0.1",
     "npm-check-updates": "^19.6.3",
     "rtlcss": "^4.3.0"


### PR DESCRIPTION
- Follow-up to #2686: switches docsy.dev's `link-cache` devDependency from the GitHub pin (`github:chalin/link-cache#semver:^0.2.0`) to the package's first npm registry release, published with the registry's strictest settings (trusted publishing, 2FA required, tokens disallowed).
- Registry installs are faster (no git clone) and immutable — a published version's tarball can't change, which matters here since lockfiles are gitignored.
- Verified: `npm install` resolves `link-cache@0.3.0` from the registry, and the `lychee-norm-cache` / `refcache` bins run from `node_modules/.bin`.