### PR TITLE
Document installing Docsy from the npm registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ project CI/CD, release process, etc.
   short names when the context is clear.
 - This project has a long history; look for existing helpers (partials,
   shortcodes, SCSS mixins, and similar) before adding new ones.
+- In site content, `version` is the published variant's identity, not always a
+  git ref; anything needing a resolvable release ref (install commands, etc.)
+  uses `tdVersion.latest` (`docsy.dev/config/_default/params.yaml`).
 
 ## User guide
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ The repo root orchestrates two npm workspaces:
 
 Releases publish a nested module tag `theme/vX.Y.Z` alongside `vX.Y.Z`.
 
+Site builds resolve the theme through the checkout's parent directory
+(`--themesDir ../..` with `theme: docsy/theme`), so the checkout directory must
+be named `docsy`. From a checkout named differently — a git worktree, for
+example — set `HUGO_THEME=`_`DIR_NAME`_`/theme`, where _`DIR_NAME`_ is the
+checkout's directory name.
+
 ## Release prep
 
 Release prep is driven by the `docsy-release-artifacts` skill, with a living

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Docsy
 
+[![npm version][npm-badge]][npm-package]
+
 <!-- markdownlint-disable no-docsy-dev-external-urls -->
 
 Docsy is a [Hugo](https://gohugo.io) theme for technical documentation sets,
@@ -63,8 +65,8 @@ To use the Docsy theme for your own site:
   customize this pre-configured basic site into your own Docsy themed site.
   [Learn more...](https://github.com/google/docsy-example)
 
-- Add Docsy to your existing Hugo site. You can add Docsy as a Hugo module, as a
-  Git submodule, or clone the Docsy theme into your project.
+- Add Docsy to your existing Hugo site. You can add Docsy as an NPM package, as
+  a Hugo module, as a Git submodule, or clone the Docsy theme into your project.
 
 See the [Get started guides](https://www.docsy.dev/docs/get-started/) for
 details about the various usage options.
@@ -108,6 +110,8 @@ This project is licensed under the Apache License 2.0, see
 [deploys]: https://app.netlify.com/sites/docsydocs/deploys
 [main-preview]: https://main--docsydocs.netlify.app/
 [netlify]: https://netlify.com
+[npm-badge]: https://img.shields.io/npm/v/%40docsy%2Ftheme
+[npm-package]: https://www.npmjs.com/package/@docsy/theme
 [official-support]:
   https://www.docsy.dev/project/about/changelog/#official-support
 [releases]: https://github.com/google/docsy/releases

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -69,6 +69,8 @@ https://docs.netlify.com/configure-builds/file-based-configuration/,200,17825633
 https://docs.npmjs.com/cli/v10/commands/npm-install#description,200,1782563368
 https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish,200,1782563368
 https://docs.npmjs.com/cli/v10/using-npm/scripts,200,1782563368
+https://docs.npmjs.com/cli/v11/commands/npm-dist-tag,200,1784978353
+https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/,200,1784978429
 https://docsy.dev/,200,1782563367
 https://domsignal.com/x-frame-options-test,200,1782498238
 https://ds-docs.y.org/,200,1782498244
@@ -693,6 +695,7 @@ https://graphviz.org/,200,1782498244
 https://groups.google.com/g/docsy-users,200,1782563367
 https://help.github.com/articles/about-pull-requests/,200,1782498227
 https://imagemagick.org/,200,1782498227
+https://img.shields.io/npm/v/%40docsy%2Ftheme,200,1784978353
 https://in-toto.io/,200,1782498230
 https://jvmperf.net/,200,1782498244
 https://katex.org/,200,1782498236

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -71,6 +71,7 @@ https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish,200,1782
 https://docs.npmjs.com/cli/v10/using-npm/scripts,200,1782563368
 https://docs.npmjs.com/cli/v11/commands/npm-dist-tag,200,1784978353
 https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/,200,1784978429
+https://docs.npmjs.com/cli/v11/commands/npm-install#description,200,1784982268
 https://docsy.dev/,200,1782563367
 https://domsignal.com/x-frame-options-test,200,1782498238
 https://ds-docs.y.org/,200,1782498244

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -169,6 +169,7 @@ https://github.com/gohugoio/hugo/releases/tag/v0.160.1,200,1784287569
 https://github.com/gohugoio/hugo/releases/tag/v0.163.2,200,1782498231
 https://github.com/gohugoio/hugo/releases/tag/v0.163.3,200,1782563370
 https://github.com/gohugoio/hugo/releases/tag/v0.164.0,200,1784242277
+https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration,200,1785057657
 https://github.com/google/.github/blob/master/CODE_OF_CONDUCT.md,200,1782563368
 https://github.com/google/docsy,200,1782563367
 https://github.com/google/docsy-example,200,1782563368
@@ -240,6 +241,7 @@ https://github.com/google/docsy/blob/main/theme/layouts/community/list.html?plai
 https://github.com/google/docsy/blob/main/theme/layouts/docs/baseof.html,200,1782498242
 https://github.com/google/docsy/blob/main/theme/layouts/docs/baseof.html?plain=1,200,1782498233
 https://github.com/google/docsy/blob/main/theme/layouts/swagger/baseof.html?plain=1,200,1782498233
+https://github.com/google/docsy/blob/main/theme/package.json,200,1785057657
 https://github.com/google/docsy/blob/main/theme/theme.toml,200,1782498229
 https://github.com/google/docsy/blob/v0.15.0/layouts/_shortcodes/card.html,200,1782498231
 https://github.com/google/docsy/blob/v0.7.0/assets/scss/main.scss,200,1782498241

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -9,7 +9,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 041-over-main-4d8d85ef
+  buildId: &tdBuildId 044-over-main-2b0fba2f
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -2,6 +2,10 @@
 #
 # Version related parameters
 #
+# `version` identifies the published site variant (badge, welcome line, version
+# menu) and is not always a git ref. Content that needs a resolvable release
+# ref -- install commands, for example -- uses `tdVersion.latest`.
+#
 # archived_version: false # TODO: generalize status
 # version:
 #   status: archived # Then fetch include

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 041-over-main-4d8d85ef
+  buildId: &tdBuildId 044-over-main-2b0fba2f
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 041-over-main-4d8d85ef
+  buildId: &tdBuildId 044-over-main-2b0fba2f
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/docs/get-started/_index.md
+++ b/docsy.dev/content/en/docs/get-started/_index.md
@@ -27,6 +27,11 @@ appropriate setup guide to get started.
 Hugo offers multiple options for using themes, all of which are supported by
 Docsy.
 
+- **Adding the theme as an NPM package**: Docsy is published to the npm registry
+  as [`@docsy/theme`](https://www.npmjs.com/package/@docsy/theme). If your
+  project already uses npm, this option adds no extra toolchain — you install
+  and update the theme like any other npm dependency. For instructions, see
+  [Docsy as an NPM package](/docs/get-started/other-options/#option-3-docsy-as-an-npm-package).
 - **Adding the theme as a Hugo Module**:
   [Hugo Modules](https://gohugo.io/hugo-modules/) are the simplest and latest
   way to use Hugo themes. Hugo uses the modules mechanism to pull in the theme

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -279,9 +279,8 @@ npm install --save-dev @docsy/theme@latest
 
 ### Development versions of Docsy
 
-Only [official Docsy releases][official-support] are supported. For development
-or testing, you can install Docsy in the following ways ([all
-unsupported][official-support]):
+Use only [official Docsy releases][official-support] for production sites. For
+Docsy development or testing, you can also install:
 
 - A pre-release, when one is available, through the `next` [dist-tag][]:
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -26,8 +26,7 @@ of the theme in your repository), you can **clone the files directly into your
 site source**.
 
 Finally, you can **install
-[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)** — no extra
-toolchain needed if your project already uses npm.
+[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)**.
 
 This guide provides instructions for all of these options, along with common
 prerequisites.
@@ -296,11 +295,10 @@ install one of the following unsupported versions:
   npm install --save-dev google/docsy
   ```
 
-  This installs the repository's default branch (`main`); to select another
-  revision, append `#` and a branch, tag, or commit, or use `#semver:` followed
-  by a version range — for details, see [npm install][]. The GitHub package is
-  named `docsy` and contains the theme files in a subfolder, so with this
-  install form use `theme: docsy/theme` in your site configuration.
+  This installs the repository's default branch (`main`); for how to select
+  another revision, see [npm install][]. The GitHub package is named `docsy` and
+  contains the theme files in a subfolder, so with this install form use
+  `theme: docsy/theme` in your site configuration.
 
 ## Preview your site
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -279,9 +279,9 @@ npm install --save-dev @docsy/theme@latest
 
 ### Development versions of Docsy
 
-Only [official Docsy releases][official-support] are supported. If you want to
-try an unreleased version of Docsy — for testing, or as a contributor — you can
-install one of the following unsupported versions:
+Only [official Docsy releases][official-support] are supported. For development
+or testing, you can install Docsy in the following ways ([all
+unsupported][official-support]):
 
 - A pre-release, when one is available, through the `next` [dist-tag][]:
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -279,8 +279,8 @@ npm install --save-dev @docsy/theme@latest
 
 ### Development versions of Docsy
 
-Use only [official Docsy releases][official-support] for production sites. For
-Docsy development or testing, you can also install:
+Use only [official Docsy releases][official-support] in production. For Docsy
+development or testing, you can also install:
 
 - A pre-release, when one is available, through the `next` [dist-tag][]:
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -145,7 +145,7 @@ your project's root directory:
     ```sh
     git submodule add https://github.com/google/docsy.git themes/docsy
     cd themes/docsy
-    git checkout {{% param version %}}
+    git checkout {{% param tdVersion.latest %}}
     ```
 
     To work from the development version of Docsy (_not recommended_), run the
@@ -207,12 +207,12 @@ maintain your own copy of the theme directly, or your deployment choice requires
 you to include a copy of the theme in your repository), you can clone the theme
 into your project's `themes` subdirectory.
 
-To clone Docsy at {{% param version %}} into your project's `themes` folder, run
-the following commands from your project's root directory:
+To clone Docsy at {{% param tdVersion.latest %}} into your project's `themes`
+folder, run the following commands from your project's root directory:
 
 ```sh
 cd themes
-git clone -b {{% param version %}} https://github.com/google/docsy
+git clone -b {{% param tdVersion.latest %}} https://github.com/google/docsy
 cd docsy
 npm run postinstall
 ```
@@ -222,7 +222,7 @@ As with the [submodule option](#option-1-docsy-as-a-git-submodule), set
 
 To work from the development version of Docsy (not recommended unless, for
 example, you plan to upstream changes to Docsy), omit the
-`-b {{% param version %}}` argument from the clone command above.
+`-b {{% param tdVersion.latest %}}` argument from the clone command above.
 
 Then consider setting up an NPM [prepare][] script, as documented in Option 1.
 
@@ -298,7 +298,7 @@ development or testing, you can also install:
   version:
 
   ```sh
-  npm install --save-dev google/docsy#semver:{{% param version %}}
+  npm install --save-dev google/docsy#semver:{{% param tdVersion.latest %}}
   ```
 
   For other revision selectors, see [npm install][]. The GitHub package is named

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -295,10 +295,16 @@ install one of the following unsupported versions:
   npm install --save-dev google/docsy
   ```
 
-  This installs the repository's default branch (`main`); for how to select
-  another revision, see [npm install][]. The GitHub package is named `docsy` and
-  contains the theme files in a subfolder, so with this install form use
-  `theme: docsy/theme` in your site configuration.
+  This installs the repository's default branch (`main`). To pin a tagged
+  version:
+
+  ```sh
+  npm install --save-dev google/docsy#semver:{{% param version %}}
+  ```
+
+  For other revision selectors, see [npm install][]. The GitHub package is named
+  `docsy` and contains the theme files in a subfolder, so with this install form
+  use `theme: docsy/theme` in your site configuration.
 
 ## Preview your site
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -2,7 +2,7 @@
 title: Other setup options
 description: Create a new Docsy site with Docsy using Git or NPM
 date: 2021-12-08
-cSpell:ignore: hugo myproject pushd popd
+cSpell:ignore: hugo myproject
 weight: 2
 ---
 
@@ -26,7 +26,8 @@ of the theme in your repository), you can **clone the files directly into your
 site source**.
 
 Finally, you can **install
-[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)**.
+[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)** — the simplest
+option if your project already uses npm.
 
 This guide provides instructions for all of these options, along with common
 prerequisites.
@@ -44,9 +45,9 @@ which supports
 [SCSS](https://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html); you
 may need to scroll down the list of releases to see it.
 
-For the tool versions that Docsy officially supports, see
-[Official support](/project/about/changelog/#official-support). For
-comprehensive Hugo documentation, see [gohugo.io](https://gohugo.io/).
+For the tool versions that Docsy officially supports, see [Official
+support][official-support]. For comprehensive Hugo documentation, see
+[gohugo.io](https://gohugo.io/).
 
 #### On Linux
 
@@ -232,21 +233,21 @@ For more information, see
 
 ## Option 3: Docsy as an NPM package
 
-You can use Docsy as an NPM module as follows:
+Docsy is published to the npm registry as [`@docsy/theme`][]. To create a new
+site that uses the Docsy NPM package:
 
-1.  Create your site and specify Docsy as the site theme:
+1.  Create your site:
 
     ```sh
     hugo new site --format yaml myproject
     cd myproject
-    echo "theme: docsy/theme\nthemesDir: node_modules" >> hugo.yaml
     ```
 
 2.  Install Docsy:
 
-    ```console
+    ```sh
     npm init -y
-    npm install --save-dev google/docsy#semver:{{% param version %}}
+    npm install --save-dev @docsy/theme
     ```
 
     > [!TIP] Hugo install tip
@@ -254,8 +255,16 @@ You can use Docsy as an NPM module as follows:
     > To also install Hugo as an NPM package, see
     > [Hugo-extended NPM package](#hugo-extended-npm).
 
-3.  Build or serve your new site using the usual Hugo commands, specifying the
-    path to the Docsy theme files. For example, build your site as follows:
+3.  Add Docsy as your site's theme by including the following in your project's
+    `hugo.yaml`:
+
+    ```yaml
+    theme: '@docsy/theme'
+    themesDir: node_modules
+    ```
+
+4.  Build or serve your new site using the usual Hugo commands. For example,
+    build your site as follows:
 
     ```console
     $ hugo
@@ -263,16 +272,35 @@ You can use Docsy as an NPM module as follows:
     ...
     ```
 
-As an alternative to specifying a `themesDir`, on some platforms, you can
-instead create a symbolic link to the Docsy theme directory as follows (Linux
-commands shown, executed from the site root folder):
+To update Docsy to the latest release, run:
 
 ```sh
-mkdir -p themes
-pushd themes
-ln -s ../node_modules/docsy
-popd
+npm install --save-dev @docsy/theme@latest
 ```
+
+### Development versions of Docsy
+
+Only [official Docsy releases][official-support] are supported. If you want to
+try an unreleased version of Docsy — for testing, or as a contributor — you can
+install one of the following unsupported versions:
+
+- A pre-release, when one is available, through the `next` [dist-tag][]:
+
+  ```sh
+  npm install --save-dev @docsy/theme@next
+  ```
+
+- Docsy directly from GitHub:
+
+  ```sh
+  npm install --save-dev google/docsy
+  ```
+
+  This installs the repository's default branch (`main`); to select another
+  revision, append `#` and a branch, tag, or commit, or use `#semver:` followed
+  by a version range. The GitHub package is named `docsy` and contains the theme
+  files in a subfolder, so with this install form use `theme: docsy/theme` in
+  your site configuration.
 
 ## Preview your site
 
@@ -305,9 +333,12 @@ from scratch as it provides defaults for many required configuration parameters.
 
 [Install PostCSS]:
   /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
+[`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
+[dist-tag]: https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/
 [lts release]: https://nodejs.org/en/about/releases/
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [npm scripts]: https://docs.npmjs.com/cli/v10/using-npm/scripts
+[official-support]: /project/about/changelog/#official-support
 [prepare]:
   https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -26,8 +26,8 @@ of the theme in your repository), you can **clone the files directly into your
 site source**.
 
 Finally, you can **install
-[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)** — the simplest
-option if your project already uses npm.
+[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)** — no extra
+toolchain needed if your project already uses npm.
 
 This guide provides instructions for all of these options, along with common
 prerequisites.
@@ -298,9 +298,9 @@ install one of the following unsupported versions:
 
   This installs the repository's default branch (`main`); to select another
   revision, append `#` and a branch, tag, or commit, or use `#semver:` followed
-  by a version range. The GitHub package is named `docsy` and contains the theme
-  files in a subfolder, so with this install form use `theme: docsy/theme` in
-  your site configuration.
+  by a version range — for details, see [npm install][]. The GitHub package is
+  named `docsy` and contains the theme files in a subfolder, so with this
+  install form use `theme: docsy/theme` in your site configuration.
 
 ## Preview your site
 
@@ -336,6 +336,7 @@ from scratch as it provides defaults for many required configuration parameters.
 [`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [dist-tag]: https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/
 [lts release]: https://nodejs.org/en/about/releases/
+[npm install]: https://docs.npmjs.com/cli/v11/commands/npm-install#description
 [nvm]:
   https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
 [npm scripts]: https://docs.npmjs.com/cli/v10/using-npm/scripts

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,8 +97,8 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest **official release** of Docsy: a stable semver version `_X_._Y_._Z_`
-  from the following sources:
+- The latest **official release** of Docsy: a stable semver version `X.Y.Z` from
+  the following sources:
   - [@docsy/theme][] npm package
   - Hugo module
   - GitHub [release][releases] or git tag
@@ -107,7 +107,7 @@ Specifically, the Docsy team **officially supports** the following:
   - The `main` branch
   - An older stable release
   - A pre- or dev release (npm dist-tag `next`)
-  - An npm install of Docsy from GitHub (`google/docsy`), including a stable
+  - An npm install of Docsy from GitHub (`google/docsy`), even for a stable
     release
 
   Issue reports against unofficial versions are welcome — they help us catch

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,10 +97,13 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest **official release** of Docsy: a stable semver version `vX.Y.Z`,
-  whether consumed as a GitHub [release][releases] or git tag, or as the
-  [@docsy/theme][] npm package. Anything else is unsupported, whether the `main`
-  branch, an older release, or a pre- or dev release (npm dist-tag `next`).
+- The latest **official release** of Docsy:
+  - A stable semver version `vX.Y.Z`, whether consumed as a GitHub
+    [release][releases] or git tag (via Hugo modules or git), or as the
+    [@docsy/theme][] npm package.
+  - Anything else is unsupported, whether the `main` branch, an older release, a
+    pre- or dev release (npm dist-tag `next`), or an npm install of Docsy from
+    GitHub (`google/docsy`) including at a release tag.
 
 - The tool versions as specified for the Docsy release you are using:
   - **Hugo**:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,11 +97,11 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest **official release** of Docsy: a stable semver version `X.Y.Z` from
-  the following sources:
-  - [@docsy/theme][] npm package
-  - Hugo module
-  - GitHub [release][releases] or git tag
+- The latest **official release** of Docsy: a stable semver version from the
+  following sources:
+  - [@docsy/theme][] npm package (`X.Y.Z`)
+  - Hugo module (`vX.Y.Z`)
+  - GitHub [release][releases] or git tag (`vX.Y.Z`)
 
   Anything else is for Docsy development and testing only, not production use:
   - The `main` branch

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,8 +97,10 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest Docsy [release][releases]. The `main` branch is a development
-  branch and is considered unstable.
+- The latest **official release** of Docsy: a stable semver version `vX.Y.Z`,
+  whether consumed as a GitHub [release][releases] or git tag, or as the
+  [@docsy/theme][] npm package. Anything else is unsupported, whether the `main`
+  branch, an older release, or a pre- or dev release (npm dist-tag `next`).
 
 - The tool versions as specified for the Docsy release you are using:
   - **Hugo**:
@@ -112,11 +114,12 @@ Specifically, the Docsy team **officially supports** the following:
 
 Everything else — including Windows — is supported on a best-effort basis.
 
-[docsy.dev/package.json]:
-  https://github.com/google/docsy/blob/main/docsy.dev/package.json
-[minimum Hugo version]:
-  /docs/get-started/docsy-as-module/installation-prerequisites/#install-hugo
+<!-- prettier-ignore-start -->
+[@docsy/theme]: https://www.npmjs.com/package/@docsy/theme
+[docsy.dev/package.json]: https://github.com/google/docsy/blob/main/docsy.dev/package.json
+[minimum Hugo version]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-hugo
 [package.json]: https://github.com/google/docsy/blob/main/package.json
+<!-- prettier-ignore-end -->
 
 ### Bug fixes
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,22 +97,17 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest **official release** of Docsy: a stable semver version from the
-  following sources:
+- **Production use**: the latest **official release** of Docsy — a stable semver
+  version from the following sources:
   - [@docsy/theme][] npm package (`X.Y.Z`)
   - Hugo module (`vX.Y.Z`)
   - GitHub [release][releases] or git tag (`vX.Y.Z`)
 
-  Anything else is for Docsy development and testing only, not production use:
-  - The `main` branch
-  - An older stable release
-  - A pre- or dev release (npm dist-tag `next`)
-  - An npm install of Docsy from GitHub (`google/docsy`), even for a stable
-    release
+  An npm install of Docsy from GitHub (`google/docsy`) is unsupported, even for
+  a stable release.
 
-  Issue reports against unofficial versions are welcome — they help us catch
-  problems before release — but fixes land in the next release; we don't patch
-  or troubleshoot unofficial versions in place.
+- **Issue reports**: over the latest official release, a current pre-release, or
+  the `main` branch.
 
 - The tool versions as specified for the Docsy release you are using:
   - **Hugo**:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -97,13 +97,22 @@ releases of Docsy, its dependencies & tools, and operating systems.
 
 Specifically, the Docsy team **officially supports** the following:
 
-- The latest **official release** of Docsy:
-  - A stable semver version `vX.Y.Z`, whether consumed as a GitHub
-    [release][releases] or git tag (via Hugo modules or git), or as the
-    [@docsy/theme][] npm package.
-  - Anything else is unsupported, whether the `main` branch, an older release, a
-    pre- or dev release (npm dist-tag `next`), or an npm install of Docsy from
-    GitHub (`google/docsy`) including at a release tag.
+- The latest **official release** of Docsy: a stable semver version `_X_._Y_._Z_`
+  from the following sources:
+  - [@docsy/theme][] npm package
+  - Hugo module
+  - GitHub [release][releases] or git tag
+
+  Anything else is for Docsy development and testing only, not production use:
+  - The `main` branch
+  - An older stable release
+  - A pre- or dev release (npm dist-tag `next`)
+  - An npm install of Docsy from GitHub (`google/docsy`), including a stable
+    release
+
+  Issue reports against unofficial versions are welcome — they help us catch
+  problems before release — but fixes land in the next release; we don't patch
+  or troubleshoot unofficial versions in place.
 
 - The tool versions as specified for the Docsy release you are using:
   - **Hugo**:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -93,8 +93,8 @@ This version is declared in three places that must agree:
 
 `theme.toml` is Hugo's legacy theme descriptor: its `min_version` is read only
 as a fallback when the module config sets none, and the file's sole remaining
-consumer is the [themes showcase][], which ingests it from the theme's git repo.
-Hence the npm package omits it ([theme/package.json][] `files`).
+external consumer is the [themes showcase][], which ingests it from the theme's
+git repo. Hence the npm package omits it ([theme/package.json][] `files`).
 
 Raising the minimum is a breaking change for theme users, only done to support
 new features or security fixes. To validate that a Docsy site actually builds

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -84,12 +84,17 @@ Docsy provides and to cover important security fixes.
 
 This version is declared in three places that must agree:
 
-- [theme/theme.toml][] `min_version` (canonical source)
-- [theme/hugo.yaml][] `module.hugoVersion.min`
+- [theme/hugo.yaml][] `module.hugoVersion.min` (canonical source)
+- [theme/theme.toml][] `min_version`
 - [docsy.dev/config/_default/hugo.yaml][] `params.hugoMinVersion`, which feeds
   the requirement statements in user-facing docs (via
   `{{%/* param hugoMinVersion */%}}`) and, through the `&hugoMinVersion` anchor,
   docsy.dev's own `module.hugoVersion.min`.
+
+`theme.toml` is Hugo's legacy theme descriptor: its `min_version` is read only
+as a fallback when the module config sets none, and the file's sole remaining
+consumer is the [themes showcase][], which ingests it from the theme's git repo.
+Hence the npm package omits it ([theme/package.json][] `files`).
 
 Raising the minimum is a breaking change for theme users, only done to support
 new features or security fixes. To validate that a Docsy site actually builds
@@ -598,7 +603,9 @@ before any further changes are merged into the `main` branch:
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
 [Release notes]: <{{% param github_repo %}}/releases>
 [theme/hugo.yaml]: <{{% param github_repo %}}/blob/main/theme/hugo.yaml>
+[theme/package.json]: <{{% param github_repo %}}/blob/main/theme/package.json>
 [theme/theme.toml]: <{{% param github_repo %}}/blob/main/theme/theme.toml>
+[themes showcase]: https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration
 [public]: /project/about/changelog/#public
 [tags]: <{{% param github_repo %}}/tags>
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/build/git-repo.md
+++ b/docsy.dev/content/en/project/build/git-repo.md
@@ -26,14 +26,26 @@ This repository's branch model is as follows:
 
 - `main`: development branch for the next theme release and next site content.
 - `release`: release and maintenance branch for the current stable theme version
-- Publishing branches used by Netlify:
-  - `deploy/prod`: production site for the current stable release docs.
-  - `doc-rooted`: production branch for the doc-rooted site variant.
-  - These branches determine what is published. They are not feature development
-    branches.
+- `deploy/prod` and `doc-rooted`: publishing branches used by Netlify. These
+  branches determine what is published (see the table below); they are not
+  feature development branches.
 
 The Goldydocs repo has the same model, except for `doc-rooted` which is not
 used.
+
+### Published sites
+
+Netlify publishes the following site variants. A variant's version identity
+(`version` and related params) comes from its config directory under
+`docsy.dev/config/`:
+
+| Site variant                         | Publishing branch | Version params |
+| ------------------------------------ | ----------------- | -------------- |
+| [Latest release][prod-site]          | `deploy/prod`     | `production/`  |
+| [Next (dev)][next-site]              | `main`            | `_default/`    |
+| [Doc-rooted (experimental)][dr-site] | `doc-rooted`      | `doc-rooted/`  |
+
+PR deploy previews build like the Next variant.
 
 ### Tags
 
@@ -101,4 +113,7 @@ Assuming the former, the patch-release workflow is as follows:
 
 [Goldydocs]: <{{% param example_site_url %}}>
 [Docsy example site repository]: <{{% param github_repo %}}-example>
+[dr-site]: https://doc-rooted--docsydocs.netlify.app
 [main Docsy repository]: <{{% param github_repo %}}>
+[next-site]: https://main--docsydocs.netlify.app
+[prod-site]: https://www.docsy.dev

--- a/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
@@ -27,6 +27,11 @@ appropriate setup guide to get started.
 Hugo offers multiple options for using themes, all of which are supported by
 Docsy.
 
+- **Adding the theme as an NPM package**: Docsy is published to the npm registry
+  as [`@docsy/theme`](https://www.npmjs.com/package/@docsy/theme). If your
+  project already uses npm, this option adds no extra toolchain — you install
+  and update the theme like any other npm dependency. For instructions, see
+  [Docsy as an NPM package](/docs/get-started/other-options/#option-3-docsy-as-an-npm-package).
 - **Adding the theme as a Hugo Module**:
   [Hugo Modules](https://gohugo.io/hugo-modules/) are the simplest and latest
   way to use Hugo themes. Hugo uses the modules mechanism to pull in the theme

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+041-over-main-4d8d85ef",
+  "version": "0.15.1-dev+044-over-main-2b0fba2f",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tests/hugo-versions.test.mjs
+++ b/tests/hugo-versions.test.mjs
@@ -22,15 +22,16 @@ function extract(relPath, re, what) {
   return m[1];
 }
 
+// First entry is the canonical min-version home; assertInSync anchors on it.
 const declarations = {
-  'theme/theme.toml': () =>
-    extract('theme/theme.toml', /^min_version\s*=\s*"([^"]+)"/m, 'min_version'),
   'theme/hugo.yaml': () =>
     extract(
       'theme/hugo.yaml',
       /^\s*hugoVersion:\s*\n(?:\s+extended:.*\n)?\s+min:\s*(\S+)/m,
       'module.hugoVersion.min',
     ),
+  'theme/theme.toml': () =>
+    extract('theme/theme.toml', /^min_version\s*=\s*"([^"]+)"/m, 'min_version'),
   'docsy.dev/config/_default/hugo.yaml': () =>
     extract(
       'docsy.dev/config/_default/hugo.yaml',
@@ -77,7 +78,7 @@ test('docsy.dev module Hugo minimum aliases the params anchor', () => {
 });
 
 test('Hugo minimum is at most the officially supported version', () => {
-  const minimum = declarations['theme/theme.toml']();
+  const minimum = declarations['theme/hugo.yaml']();
   const supported = pin();
   assert.match(supported, SEMVER, 'hugo-extended pin is X.Y.Z semver');
   const toParts = (v) => v.split('.').map(Number);
@@ -106,7 +107,7 @@ const pageParamOf = (frontMatter, param) => {
 
 // The version params that posts freeze, mapped to their live values.
 const liveVersions = {
-  hugoMinVersion: declarations['theme/theme.toml'],
+  hugoMinVersion: declarations['theme/hugo.yaml'],
   hugoSupportedVersion: pin,
 };
 

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -269,6 +269,8 @@ test(`registry install of ${REGISTRY_PKG}`, () => {
 // breaks, historically even silently (exit 0, unstyled site) — the failure
 // class that assertBuilt() exists to catch.
 test('minimum Hugo version builds the HUGO_MODULE site', () => {
+  // Extraction regex duplicated from tests/hugo-versions.test.mjs (the
+  // min-version sync suite) so each suite runs standalone; sync changes there.
   const min = readFileSync(
     path.join(repoRoot, 'theme', 'hugo.yaml'),
     'utf8',

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -272,17 +272,17 @@ test(
 );
 
 // --- declared minimum Hugo version actually builds --------------------------
-// Pins Hugo to the theme's declared minimum (theme.toml min_version) and
+// Pins Hugo to the theme's declared minimum (module.hugoVersion.min) and
 // builds the Hugo-module-mode site — the most version-sensitive path: on
 // sub-minimum Hugos, `hugo mod npm pack` emits empty deps and the build
 // breaks, historically even silently (exit 0, unstyled site) — the failure
 // class that assertBuilt() exists to catch.
 test('minimum Hugo version builds the HUGO_MODULE site', () => {
   const min = readFileSync(
-    path.join(repoRoot, 'theme', 'theme.toml'),
+    path.join(repoRoot, 'theme', 'hugo.yaml'),
     'utf8',
-  ).match(/^min_version\s*=\s*"([^"]+)"/m)?.[1];
-  assert.ok(min, 'theme.toml declares min_version');
+  ).match(/^\s*hugoVersion:\s*\n(?:\s+extended:.*\n)?\s+min:\s*(\S+)/m)?.[1];
+  assert.ok(min, 'theme/hugo.yaml declares module.hugoVersion.min');
 
   // Scratch-install hugo-extended@min under TMP (cached across runs).
   const minHugo = path.join(TMP, `hugo-${min}`, 'node_modules', '.bin', 'hugo');

--- a/tests/smoke.test.mjs
+++ b/tests/smoke.test.mjs
@@ -253,23 +253,14 @@ test('tarball install of @docsy/theme packed from this checkout', () => {
   buildThemeConsumerSite('smoke-tarball', path.join(packDest, tgz));
 });
 
-// DOCSY_THEME_PKG selects the registry spec — e.g. @docsy/theme@next to vet
-// an RC, or @docsy/theme@0.16.0. Without it the test targets the bare name,
-// which resolves to the `latest` dist-tag; it stays skipped until a stable
-// version is live there.
-const REGISTRY_PKG = process.env.DOCSY_THEME_PKG;
-test(
-  'registry install of @docsy/theme',
-  {
-    skip: REGISTRY_PKG
-      ? false
-      : '@docsy/theme has no version under `latest` yet; ' +
-        'set DOCSY_THEME_PKG (e.g. @docsy/theme@next) to target another spec',
-  },
-  () => {
-    buildThemeConsumerSite('smoke-registry', REGISTRY_PKG ?? '@docsy/theme');
-  },
-);
+// DOCSY_THEME_PKG overrides the registry spec — e.g. @docsy/theme@next to vet
+// an RC, or @docsy/theme@0.16.0 to pin a version. The default, the bare name,
+// resolves to the `latest` dist-tag: whatever the registry currently serves
+// plain `npm install @docsy/theme` users.
+const REGISTRY_PKG = process.env.DOCSY_THEME_PKG ?? '@docsy/theme';
+test(`registry install of ${REGISTRY_PKG}`, () => {
+  buildThemeConsumerSite('smoke-registry', REGISTRY_PKG);
+});
 
 // --- declared minimum Hugo version actually builds --------------------------
 // Pins Hugo to the theme's declared minimum (module.hugoVersion.min) and

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.15.1-dev+041-over-main-4d8d85ef",
+  "version": "0.15.1-dev+044-over-main-2b0fba2f",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Contributes to #2683
- **Installation direction** — the get-started guide's npm option now leads with the registry install ([`@docsy/theme`](https://www.npmjs.com/package/@docsy/theme)); git/GitHub installs move to a development-versions note (existing anchors preserved); the npm option is also surfaced on the get-started landing page and in the README
- **Release safeguards**:
  - Support policy defines what an official release is, per install channel
  - Registry smoke test always runs
  - Minimum Hugo version now has one canonical home: the theme's module config
- **Version interpolation fix** — install commands now render `tdVersion.latest`, a resolvable release tag in every site environment, instead of `version`, which identifies the site variant and is a dev identifier outside production; the published site variants are now documented in the git-repo page
- **Package boundary** — AGENTS.md documents how the theme directory is addressed when building the site from a theme checkout
- **Merge timing** — documented install commands and the README badge resolve `0.16.0-rc.1` until the tag-time stable publish re-points `latest`; merge close to tag time
- **Deferred** — the 0.16.0 release post's install snippet keeps the git flow; that delta belongs to the release-artifacts refresh
- **Previews**:
  - [Get started § npm package option](https://deploy-preview-2688--docsydocs.netlify.app/docs/get-started/other-options/#option-3-docsy-as-an-npm-package)
  - [Get started landing page](https://deploy-preview-2688--docsydocs.netlify.app/docs/get-started/)