### PR TITLE
Refresh 0.16.0 release artifacts through 9b1d9951, update blog posts

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -319,6 +319,8 @@ https://github.com/google/docsy/issues/2615,200,1782498231
 https://github.com/google/docsy/issues/2617,200,1782498231
 https://github.com/google/docsy/issues/2659,200,1782563371
 https://github.com/google/docsy/issues/2668,200,1782784208
+https://github.com/google/docsy/issues/2683,200,1785081670
+https://github.com/google/docsy/issues/2689,200,1785081670
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234
 https://github.com/google/docsy/issues/375,200,1782498235

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -321,6 +321,7 @@ https://github.com/google/docsy/issues/2659,200,1782563371
 https://github.com/google/docsy/issues/2668,200,1782784208
 https://github.com/google/docsy/issues/2683,200,1785081670
 https://github.com/google/docsy/issues/2689,200,1785081670
+https://github.com/google/docsy/issues/2691,200,1785178993
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234
 https://github.com/google/docsy/issues/375,200,1782498235
@@ -593,6 +594,7 @@ https://github.com/prettier/prettier/issues/15528,200,1782563367
 https://github.com/prettier/prettier/issues/15720,200,1782563368
 https://github.com/protocolbuffers/protocolbuffers.github.io,200,1782498549
 https://github.com/sarahmaddox,200,1782498238
+https://github.com/shurup,200,1785178993
 https://github.com/tektoncd,200,1782498549
 https://github.com/theupdateframework/theupdateframework.io/pull/105,200,1782498236
 https://github.com/theupdateframework/theupdateframework.io/pull/126,200,1782498234

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -13,7 +13,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 044-over-main-2b0fba2f
+  buildId: &tdBuildId 045-over-main-9b1d9951
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 044-over-main-2b0fba2f
+  buildId: &tdBuildId 045-over-main-9b1d9951
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.15.0
   dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 044-over-main-2b0fba2f
+  buildId: &tdBuildId 045-over-main-9b1d9951
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -24,9 +24,9 @@ cSpell:ignore: CatmullRom favicons TOF
 {{% card header="Highlights" %}}
 
 - {{% _param FAS_LG cubes primary %}}
-  <span>**[Packaging modernization](#theme-folder)**: the theme now lives in
-  `theme/`, [its dependencies come from npm](#npm-deps), and Docsy itself is now
-  [published to the npm registry](#npm-registry) as `@docsy/theme`</span>
+  <span>**[First-class npm support](#npm-registry)**: Docsy is now in the npm
+  registry as `@docsy/theme`, theme dependencies [come from npm](#npm-deps), and
+  [more packaging updates](#theme-folder)</span>
 - {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
   their icons — drop conventionally named files into `static/` and Docsy
   discovers and links them; one less thing to hand-maintain</span>

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -118,7 +118,7 @@ records `github.com/google/docsy/theme` at the version you requested.
 #### GitHub NPM package sites {#npm-sites}
 
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
-npm and uses `themesDir: node_modules`.
+npm.
 
 GitHub npm installs are now for [development and testing
 only][official support policy]; for production use, switch to the new

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -36,20 +36,15 @@ cSpell:ignore: CatmullRom favicons TOF
 
 ## Release summary
 
-- **[Theme folder move](#theme-folder)**: the canonical theme now lives under
-  `theme/`; each install mode needs a one-line path update
-- **[Hugo 0.160.1+ support](#hugo)**: the theme minimum was raised from 0.146.0;
-  the project build now runs Hugo {{% param hugoSupportedVersion %}}
-- **[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies now
-  come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
-  [PostCSS is opt-in](#postcss) for non-RTL sites
-- **[Docsy on the npm registry](#npm-registry)**: the theme is now published as
-  `@docsy/theme`, the simplest way to install Docsy with npm
-- **[Favicons](#favicons)**: no more default artwork -- sites supply their own
-  icons, discovered from `static/` by filename convention
-- **[Shared chrome build mode](#shared-chrome)** (experimental): emits the
-  repeated chrome once per language and restores it in the browser, so one build
-  serves both readers and link checkers
+- **Packaging modernization**:
+  - [Theme folder move](#theme-folder): a one-line path update per install mode
+  - [Bootstrap and Font Awesome via npm](#npm-deps);
+    [PostCSS now opt-in](#postcss) for non-RTL sites
+  - [Docsy on the npm registry](#npm-registry): the new `@docsy/theme` package
+- **[Hugo 0.160.1+ support](#hugo)**: theme minimum raised from 0.146.0
+- **New features**:
+  - [Favicon discovery](#favicons) from `static/`
+  - [Shared chrome build mode](#shared-chrome) (experimental)
 - **[Other notable changes](#other-notable-changes)**: repository package
   layout, and build and test guards
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -26,13 +26,11 @@ cSpell:ignore: CatmullRom favicons TOF
 - {{% _param FAS_LG cubes primary %}}
   <span>**[First-class npm support](#npm-registry)**: install Docsy from the
   registry, and [more][]</span>
-- {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
-  their icons — drop conventionally named files into `static/` and Docsy
-  discovers and links them; one less thing to hand-maintain</span>
+- {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: drop your
+  icons into `static/` and Docsy does the rest</span>
 - {{% _param FAS_LG bolt warning %}} <span>**[Shared chrome](#shared-chrome)**
-  (experimental): an opt-in build mode that emits repeated chrome once per
-  language and restores it in the browser, for considerably faster link-checking
-  of large sites; `full` stays the default</span>
+  (experimental): a build mode for much faster link checking of large
+  sites</span>
 
 {{% /card %}}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -44,8 +44,9 @@ cSpell:ignore: CatmullRom favicons TOF
 - **New features**:
   - [Favicon discovery](#favicons) from `static/`
   - [Shared chrome build mode](#shared-chrome) (experimental)
-- **[Other notable changes](#other-notable-changes)**: repository package
-  layout, and build and test guards
+- **[Other notable changes](#other-notable-changes)**, and
+  [for maintainers](#for-maintainers): repository package layout, and build and
+  test guards
 
 ## Ready to Upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
 
@@ -61,9 +62,9 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param NEW %}} [Docsy on the npm registry](#npm-registry)
   - {{% _param NEW %}} [Favicon discovery](#favicons)
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
-  - {{% _param CLEANUP %}} [Repository packaging cleanup](#package-layout)
   - {{% _param CLEANUP %}} [PostCSS is opt-in for non-RTL sites](#postcss)
-  - [Other notable changes](#other-notable-changes)
+  - [Other notable changes](#other-notable-changes), and
+    [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.16.0](#upgrade) once
   you are ready.
 
@@ -401,6 +402,15 @@ or previews -- especially for a large or multilingual site.
 
 ## Other notable changes {#other-notable-changes}
 
+- **Russian UI strings**: synced with the English originals and corrected.
+
+For every remaining change, see the [0.16.0][] release page.
+
+## For maintainers {#for-maintainers}
+
+Changes in this section affect Docsy maintainers and contributors, not consuming
+sites.
+
 ### {{% _param CLEANUP %}} Repository and package layout {#package-layout}
 
 The Docsy repository now has a clearer package boundary:
@@ -410,8 +420,8 @@ The Docsy repository now has a clearer package boundary:
 - `docsy.dev/` owns the website build and site-specific tooling.
 - The repository root owns workspace orchestration, release tooling, and tests.
 
-This is mostly a maintainer-facing cleanup. The user-facing effect is the theme
-path change covered in [Theme folder move](#theme-folder).
+The user-facing effect is the theme path change covered in
+[Theme folder move](#theme-folder).
 
 ### {{% _param CLEANUP %}} Build and test guards {#build-test-guards}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -5,10 +5,9 @@ date: 2026-06-15
 lastmod: 2026-07-26
 draft: true
 description: >-
-  Release report and upgrade guide for Docsy 0.16.0, covering the theme folder
-  move, the raised minimum Hugo (0.160.1), npm-sourced Bootstrap and Font
-  Awesome, the new @docsy/theme npm package, favicon handling, an experimental
-  shared chrome build mode, and repository packaging cleanup.
+  Release report and upgrade guide for Docsy 0.16.0, covering the new
+  @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and
+  favicon discovery.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -252,11 +252,11 @@ dependency set drifts.
 
 ## {{% _param NEW %}} Docsy on the npm registry {#npm-registry}
 
-Docsy is following Hugo's lead in making [npm dependencies](#npm-deps)
-first-class, and taking it one step further: the theme itself is now published
-to the npm registry as [`@docsy/theme`][]. The registry package delivers the
-theme with Bootstrap and Font Awesome as ordinary npm dependencies, with no
-extra toolchain or install step:
+Hugo made [npm dependencies of modules][hugo-npm-pack] first-class;
+[Docsy follows that lead](#npm-deps) and takes it one step further: the theme
+itself is now published to the npm registry as [`@docsy/theme`][]. The registry
+package delivers the theme with Bootstrap and Font Awesome as ordinary npm
+dependencies, with no extra toolchain or install step:
 
 ```sh
 npm install --save-dev @docsy/theme

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -252,11 +252,11 @@ dependency set drifts.
 
 ## {{% _param NEW %}} Docsy on the npm registry {#npm-registry}
 
-Docsy is following Hugo's lead in offering first-class support for
-[npm dependencies](#npm-deps) -- and taking it one step further: the theme
-itself is now published to the npm registry as [`@docsy/theme`][]. The registry
-package delivers the theme with Bootstrap and Font Awesome as ordinary npm
-dependencies -- no extra toolchain or install step:
+Docsy is following Hugo's lead in making [npm dependencies](#npm-deps)
+first-class -- and taking it one step further: the theme itself is now published
+to the npm registry as [`@docsy/theme`][]. The registry package delivers the
+theme with Bootstrap and Font Awesome as ordinary npm dependencies -- no extra
+toolchain or install step:
 
 ```sh
 npm install --save-dev @docsy/theme

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -532,9 +532,9 @@ About this release:
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#next
-[docsy-example]: https://github.com/google/docsy-example
 [compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [Docsy as an NPM package]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
+[docsy-example]: https://github.com/google/docsy-example
 [experimental]: /project/about/changelog/#experimental
 [hugo-language-apis]: hugo-0.158.0+/#language-apis
 [hugo-upgrade]: hugo-0.158.0+/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -59,7 +59,7 @@ cSpell:ignore: CatmullRom favicons TOF
   Recommended order: upgrade Hugo first, then apply the Docsy changes below.
 - Optionally skim:
   - {{% _param NEW %}} [Docsy on the npm registry](#npm-registry)
-  - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
+  - {{% _param NEW %}} [Favicon discovery](#favicons)
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
   - {{% _param CLEANUP %}} [Repository packaging cleanup](#package-layout)
   - {{% _param CLEANUP %}} [PostCSS is opt-in for non-RTL sites](#postcss)
@@ -75,9 +75,8 @@ This is the main structural change in 0.16.0.
 For most sites, the upgrade is intentionally small: update the place where Hugo
 looks for the theme. The exact edit depends on how your site installs Docsy.
 
-This change lets the project keep the installable theme surface lean while
-moving repository-only tooling, website tooling, tests, and release automation
-out of the theme's way.
+This keeps the installable theme surface lean, with maintainer tooling, tests,
+and release automation out of the theme's way.
 
 ### Actions {#theme-folder-actions}
 
@@ -110,10 +109,10 @@ hugo mod get github.com/google/docsy/theme@VERSION
 hugo mod tidy
 ```
 
-You still request the plain release version, as in the command above; each
-release also creates the matching nested Hugo module tag, such as
-`theme/v0.16.0`. To verify the update, confirm that your site's `go.mod` now
-records `github.com/google/docsy/theme` at the version you requested.
+You still request the plain release version; each release also creates the
+matching nested Hugo module tag, such as `theme/v0.16.0`. To verify the update,
+confirm that your site's `go.mod` now records `github.com/google/docsy/theme` at
+the version you requested.
 
 #### GitHub NPM package sites {#npm-sites}
 
@@ -197,9 +196,8 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 Sites building with an older Hugo version must upgrade Hugo before or while
 upgrading Docsy.
 
-The Docsy project build is validated with **Hugo
-{{% param hugoSupportedVersion %}}**, as are the Docsy example site and at least
-one large downstream Docsy site. We recommend moving directly to
+The Docsy project build and example site are validated with **Hugo
+{{% param hugoSupportedVersion %}}**. We recommend moving directly to
 {{% param hugoSupportedVersion %}} unless your project has a reason to pin a
 lower version. For the detailed Hugo changes between 0.158.0 and
 {{% param hugoSupportedVersion %}}, see the companion [Hugo 0.158+ upgrade
@@ -223,10 +221,10 @@ of Docsy's [official support policy][].
 
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Bootstrap and Font Awesome via npm {#npm-deps}
 
-**Applies to Hugo-module installs.** If your site uses Docsy as a Hugo module,
-the upgrade needs one new step (see [Actions](#npm-deps-actions)). Sites that
-install Docsy from GitHub with npm, or via clone or submodule, are unaffected —
-they continue to get Bootstrap and Font Awesome through Docsy's `postinstall`.
+**Applies to Hugo-module installs**, which need one new upgrade step (see
+[Actions](#npm-deps-actions)). Sites that install Docsy from GitHub with npm, or
+via clone or submodule, are unaffected — they continue to get Bootstrap and Font
+Awesome through Docsy's `postinstall`.
 
 Docsy now sources Bootstrap and Font Awesome from npm rather than importing each
 project's GitHub repository as a Hugo module. Those imports were a workaround,

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -475,8 +475,8 @@ use:[^vers-note]
 Give your assistant this post and the companion [Hugo guide][hugo-upgrade] as
 context: they are written to double as operating instructions, with applies-if
 gates, per-mode actions, verification steps, and sanity checks. During review,
-an AI agent following only these posts upgraded the Docsy example site end to
-end.
+these posts were exercised by an AI agent against the [Docsy example
+site][docsy-example].
 
 ### {{% _param FAS arrow-rotate-left warning %}} Rolling back {#rollback}
 
@@ -532,6 +532,7 @@ About this release:
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#next
+[docsy-example]: https://github.com/google/docsy-example
 [compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
 [Docsy as an NPM package]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 [experimental]: /project/about/changelog/#experimental

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -68,8 +68,8 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param CLEANUP %}} [PostCSS is opt-in for non-RTL sites](#postcss)
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
-- {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.16.0](#upgrade) once
-  you are ready, or [ask your agent](#upgrading-with-ai).
+- {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.16.0](#upgrade)
+  yourself, or [ask an AI agent](#upgrading-with-ai).
 
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Theme folder move {#theme-folder}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -120,7 +120,12 @@ records `github.com/google/docsy/theme` at the version you requested.
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
 npm and uses `themesDir: node_modules`.
 
-Change the theme path:
+GitHub npm installs are now for [development and testing
+only][official support policy]; for production use, switch to the new
+[`@docsy/theme` registry package](#npm-registry). Its
+[Actions](#npm-registry-actions) cover this starting state.
+
+If you stay on the GitHub install, change the theme path:
 
 ```yaml
 # OLD
@@ -137,10 +142,6 @@ The install command shape is otherwise unchanged:
 ```sh
 npm install --save-dev google/docsy#semver:VERSION
 ```
-
-Alternatively, switch to the new
-[`@docsy/theme` registry package](#npm-registry); for the commands and the
-config edit, see its [Actions](#npm-registry-actions).
 
 #### Git clone or Git submodule sites {#clone-submodule-sites}
 
@@ -265,9 +266,8 @@ npm install --save-dev @docsy/theme
 For setup details, see [Docsy as an NPM package][].
 
 Official releases are now defined channel-agnostically: a stable semver version
-from the npm registry, the Hugo module, or a GitHub release tag. npm installs of
-Docsy from GitHub (`google/docsy`) are now for development and testing only; see
-the [official support policy][].
+from the npm registry, the Hugo module, or a GitHub release tag. For details,
+see the [official support policy][].
 
 ### Actions {#npm-registry-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -30,6 +30,9 @@ cSpell:ignore: CatmullRom favicons TOF
 - {{% _param FAS_LG bolt warning %}} <span>**[Shared chrome](#shared-chrome)**
   (experimental): a build mode for much faster link checking of large
   sites</span>
+- {{% _param FAS_LG robot info %}}
+  <span>**[Agent-ready upgrade guide](#upgrading-with-ai)**: hand this post to
+  your AI assistant</span>
 
 {{% /card %}}
 
@@ -471,9 +474,11 @@ use:[^vers-note]
 
 Give your assistant this post and the companion [Hugo guide][hugo-upgrade] as
 context: they are written to double as operating instructions, with applies-if
-gates, per-mode actions, verification steps, and sanity checks.
+gates, per-mode actions, verification steps, and sanity checks. During review,
+an AI agent following these posts — and nothing else — upgraded the Docsy
+example site end to end.
 
-### Rolling back {#rollback}
+### {{% _param FAS arrow-rotate-left warning %}} Rolling back {#rollback}
 
 To roll back, re-pin Docsy to [0.15.0][] and restore the pre-0.16 theme path
 (`github.com/google/docsy` for Hugo modules, or `docsy` for `theme:` installs).

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -404,7 +404,7 @@ or previews -- especially for a large or multilingual site.
 
 - **Russian UI strings**: synced with the English originals and corrected.
 
-For every remaining change, see the [0.16.0][] release page.
+For this and all other changes, see the [0.16.0][] release page.
 
 ## For maintainers {#for-maintainers}
 
@@ -433,6 +433,11 @@ committed link cache for fast, reproducible checks.
 
 ## {{% _param FAS rocket primary %}} Upgrade to 0.16.0 {#upgrade}
 
+> {{% _param FAS robot info %}} **Upgrading with AI?** Give your assistant this
+> post and the companion [Hugo guide][hugo-upgrade] as context: they are written
+> to double as operating instructions, with applies-if gates, per-mode actions,
+> verification steps, and sanity checks.
+
 Some upgrade steps are the same for each Docsy release, such as updating your
 Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0][]: follow them, using version **0.16.0** where the guide refers to
@@ -451,12 +456,19 @@ use:[^vers-note]
     version. Later Hugo or Node versions may work; see the [official support
     policy][].
 
-> [!NOTE]
+> [!NOTE]- **Need to roll back?**
 >
-> **Need to roll back?** Re-pin Docsy to [0.15.0][] and restore the pre-0.16
-> theme path (`github.com/google/docsy` for Hugo modules, or `docsy` for
-> `theme:` installs). Then re-run your install mode's update commands (as in
-> [Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0.
+> Re-pin Docsy to [0.15.0][] and restore the pre-0.16 theme path
+> (`github.com/google/docsy` for Hugo modules, or `docsy` for `theme:`
+> installs). Then re-run your install mode's update commands (as in
+> [Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0. If
+> you switched to the [registry package](#npm-registry), reinstall from GitHub
+> instead:
+>
+> ```sh
+> npm uninstall @docsy/theme
+> npm install --save-dev google/docsy#semver:v0.15.0
+> ```
 
 <section class="td-checkbox-list-wrapper">
 
@@ -481,10 +493,9 @@ use:[^vers-note]
 ## What's next?
 
 The 0.16.0 release completes the theme-folder move and its packaging arc,
-including publishing the theme to the npm registry. The experimental
-[shared chrome build mode](#shared-chrome) evolves under [#2689][], and further
-favicon improvements, such as light- and dark-mode variants, are tracked in
-[#2357][].
+including publishing the theme to the npm registry. Work towards the next
+release is tracked under [Release 0.17.0 preparation][#2691] and the [0.17.0
+milestone][].
 
 <!-- prettier-ignore -->
 > [!INFO]- Your opinion counts!
@@ -509,9 +520,9 @@ About this release:
 - Git history since [0.15.0][compare-0.15.0]
 
 <!-- prettier-ignore-start -->
-[#2357]: https://github.com/google/docsy/issues/2357
 [#2615]: https://github.com/google/docsy/issues/2615
-[#2689]: https://github.com/google/docsy/issues/2689
+[#2691]: https://github.com/google/docsy/issues/2691
+[0.17.0 milestone]: https://github.com/google/docsy/milestone/26
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -57,6 +57,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
   not already building cleanly with Hugo {{% param hugoSupportedVersion %}}.
+  Recommended order: upgrade Hugo first, then apply the Docsy changes below.
 - Optionally skim:
   - {{% _param NEW %}} [Docsy on the npm registry](#npm-registry)
   - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
@@ -112,7 +113,8 @@ hugo mod tidy
 
 You still request the plain release version, as in the command above; each
 release also creates the matching nested Hugo module tag, such as
-`theme/v0.16.0`.
+`theme/v0.16.0`. To verify the update, confirm that your site's `go.mod` now
+records `github.com/google/docsy/theme` at the version you requested.
 
 #### GitHub NPM package sites {#npm-sites}
 
@@ -138,8 +140,8 @@ npm install --save-dev google/docsy#semver:VERSION
 ```
 
 Alternatively, switch to the new
-[`@docsy/theme` registry package](#npm-registry), whose theme path is
-`@docsy/theme`.
+[`@docsy/theme` registry package](#npm-registry); for the commands and the
+config edit, see its [Actions](#npm-registry-actions).
 
 #### Git clone or Git submodule sites {#clone-submodule-sites}
 
@@ -157,7 +159,13 @@ theme: docsy/theme
 ```
 
 Then update your clone or submodule to _`VERSION`_ using your existing update
-workflow, and re-run the theme's install step from inside `themes/docsy/`:
+workflow — for example, for a submodule:
+
+```sh
+git -C themes/docsy fetch --tags && git -C themes/docsy checkout VERSION
+```
+
+Then re-run the theme's install step from inside `themes/docsy/`:
 
 ```sh
 npm run postinstall
@@ -178,11 +186,11 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 
 - Theme templates use Hugo language APIs introduced in **0.158.0**; older Hugo
   versions fail with template errors.
-- The theme's [npm-sourced dependencies](#npm-deps) rely on `hugo mod npm pack`
-  support introduced in **0.159.0**. On older Hugo versions the pack step exits
-  successfully but writes empty dependency lists, so the failure surfaces only
-  later, as a hard-to-trace SCSS import error — Hugo's minimum-version warning
-  is the only early signal.
+- The theme's [npm-sourced dependencies](#npm-deps) rely on the workspace-aware
+  `hugo mod npm pack` support that Hugo **0.159.0** added. On older Hugo
+  versions the pack step exits successfully but writes empty dependency lists,
+  so the failure surfaces only later, as a hard-to-trace SCSS import error —
+  Hugo's minimum-version warning is the only early signal.
 - **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
   such as Markdown-link escaping, and passthrough and shortcode rendering.
 
@@ -217,8 +225,8 @@ of Docsy's [official support policy][].
 
 **Applies to Hugo-module installs.** If your site uses Docsy as a Hugo module,
 the upgrade needs one new step (see [Actions](#npm-deps-actions)). Sites that
-install Docsy as an npm package or via clone or submodule are unaffected — they
-continue to get Bootstrap and Font Awesome through Docsy's `postinstall`.
+install Docsy from GitHub with npm, or via clone or submodule, are unaffected —
+they continue to get Bootstrap and Font Awesome through Docsy's `postinstall`.
 
 Docsy now sources Bootstrap and Font Awesome from npm rather than importing each
 project's GitHub repository as a Hugo module. Those imports were a workaround,
@@ -274,8 +282,17 @@ the [official support policy][].
   npm install --save-dev @docsy/theme
   ```
 
-- Update the theme path in your site config from `docsy/theme` to
-  `@docsy/theme`.
+- Update the theme path in your site config; the quotes are required in YAML:
+
+  ```yaml
+  # OLD (docsy/theme for 0.16, docsy before the theme folder move)
+  theme: docsy/theme
+  themesDir: node_modules
+
+  # NEW
+  theme: '@docsy/theme'
+  themesDir: node_modules
+  ```
 
 ## {{% _param CLEANUP %}} PostCSS is opt-in for non-RTL sites {#postcss}
 
@@ -412,7 +429,9 @@ committed link cache for fast, reproducible checks.
 Some upgrade steps are the same for each Docsy release, such as updating your
 Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0][]: follow them, using version **0.16.0** where the guide refers to
-0.12.0. For this release, use:[^vers-note]
+0.12.0 — except for its **Update Docsy** step, whose commands this release's
+[theme folder move](#theme-folder-actions) replaces. For this release,
+use:[^vers-note]
 
 - **Docsy**: [0.15.0][] -> [0.16.0][]
 - **Hugo**: [0.157.0][] ->
@@ -429,19 +448,19 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 >
 > **Need to roll back?** Re-pin Docsy to [0.15.0][] and restore the pre-0.16
 > theme path (`github.com/google/docsy` for Hugo modules, or `docsy` for
-> `theme:` installs). Then reverse the [Upgrade to Docsy 0.12.0][]
-> package-update steps.
+> `theme:` installs). Then re-run your install mode's update commands (as in
+> [Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0.
 
 <section class="td-checkbox-list-wrapper">
 
 ### {{% _param FAS square-check primary %}} Sanity checks
 
-- [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
-      {{% param hugoSupportedVersion %}}.
 - [ ] [Check your Docsy install path](#theme-folder-actions) for your install
       mode.
 - [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
       `hugo mod npm pack` and `npm install`.
+- [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
+      {{% param hugoSupportedVersion %}}.
 - [ ] [Check your favicon output](#favicons-actions), especially if you relied
       on Docsy's old default icons.
 - [ ] For multilingual sites, review language config keys and custom language

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -2,13 +2,13 @@
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
 date: 2026-06-15
-lastmod: 2026-07-17
+lastmod: 2026-07-26
 draft: true
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the theme folder
-  move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, favicon
-  handling, an experimental shared chrome build mode, and repository packaging
-  cleanup.
+  move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, the new
+  @docsy/theme npm package, favicon handling, an experimental shared chrome
+  build mode, and repository packaging cleanup.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -25,7 +25,8 @@ cSpell:ignore: CatmullRom favicons TOF
 
 - {{% _param FAS_LG cubes primary %}}
   <span>**[Packaging modernization](#theme-folder)**: the theme now lives in
-  `theme/`, and [its dependencies now come from npm](#npm-deps)</span>
+  `theme/`, [its dependencies come from npm](#npm-deps), and Docsy itself is now
+  [published to the npm registry](#npm-registry) as `@docsy/theme`</span>
 - {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
   their icons — drop conventionally named files into `static/` and Docsy
   discovers and links them; one less thing to hand-maintain</span>
@@ -45,6 +46,8 @@ cSpell:ignore: CatmullRom favicons TOF
 - **[Bootstrap and Font Awesome via npm](#npm-deps)**: theme dependencies now
   come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
   [PostCSS is opt-in](#postcss) for non-RTL sites
+- **[Docsy on the npm registry](#npm-registry)**: the theme is now published as
+  `@docsy/theme` -- the simplest way to install Docsy with npm
 - **[Favicons](#favicons)**: no more default artwork -- sites supply their own
   icons, discovered from `static/` by filename convention
 - **[Shared chrome build mode](#shared-chrome)** (experimental): emits the
@@ -63,6 +66,7 @@ cSpell:ignore: CatmullRom favicons TOF
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
   not already building cleanly with Hugo {{% param hugoSupportedVersion %}}.
 - Optionally skim:
+  - {{% _param NEW %}} [Docsy on the npm registry](#npm-registry)
   - {{% _param NEW %}} New [favicon discovery](#favicons) behavior
   - {{% _param NEW %}} Experimental [shared chrome build mode](#shared-chrome)
   - {{% _param CLEANUP %}} [Repository packaging cleanup](#package-layout)
@@ -141,6 +145,10 @@ The install command shape is otherwise unchanged:
 npm install --save-dev google/docsy#semver:VERSION
 ```
 
+Alternatively, switch to the new
+[`@docsy/theme` registry package](#npm-registry), whose theme path is
+`@docsy/theme`.
+
 #### Git clone or Git submodule sites {#clone-submodule-sites}
 
 {{% _param BREAKING %}} **Applies if** your site keeps Docsy under
@@ -162,6 +170,13 @@ workflow, and re-run the theme's install step from inside `themes/docsy/`:
 ```sh
 npm run postinstall
 ```
+
+> [!WARNING]
+>
+> Run `npm run postinstall`, not `npm install`: with 0.16.0's repository layout,
+> a plain `npm install` inside `themes/docsy/` also pulls the repository's
+> maintainer workspaces (roughly 1.5 GB); `postinstall` installs only the
+> theme's runtime dependencies (about 34 MB).
 
 For a fresh clone or submodule setup, see [Other installation options][].
 
@@ -237,13 +252,74 @@ npm install
 Re-run `hugo mod npm pack` whenever you update Docsy; Hugo warns when the
 dependency set drifts.
 
+## {{% _param NEW %}} Docsy on the npm registry {#npm-registry}
+
+Docsy is now published to the npm registry as [`@docsy/theme`][], completing the
+packaging story above: the registry package delivers the theme with Bootstrap
+and Font Awesome as ordinary npm dependencies -- no extra toolchain or install
+step:
+
+```sh
+npm install --save-dev @docsy/theme
+```
+
+with the site config:
+
+```yaml
+theme: '@docsy/theme'
+themesDir: node_modules
+```
+
+For setup details, see [Docsy as an NPM package][].
+
+Official releases are now defined channel-agnostically -- a stable semver
+version from the npm registry, the Hugo module, or a GitHub release tag. An npm
+install of Docsy from GitHub (`google/docsy`) is unsupported, even for a stable
+release; see the [official support policy][].
+
+### Actions {#npm-registry-actions}
+
+{{% _param NEW %}} **Applies if** your site installs Docsy from GitHub with npm
+(`google/docsy#semver:…`).
+
+- Switch to the registry package:
+
+  ```sh
+  npm uninstall docsy
+  npm install --save-dev @docsy/theme
+  ```
+
+- Update the theme path in your site config from `docsy/theme` to
+  `@docsy/theme`.
+
 ## {{% _param CLEANUP %}} PostCSS is opt-in for non-RTL sites {#postcss}
 
 Docsy now runs `postCSS` only for sites with RTL languages (which need it for
-`rtlcss`) or that provide a project-root `postcss.config.{js,mjs,cjs}`. Other
-sites no longer need a PostCSS toolchain at all and can drop `autoprefixer`,
-`postcss`, and `postcss-cli` from their dependencies. For the current install
-guidance, see [Install PostCSS][].
+`rtlcss`, a PostCSS plugin) or that provide a project-root
+`postcss.config.{js,mjs,cjs}`. Other sites no longer need a PostCSS toolchain at
+all.
+
+Nothing is lost in dropping the pass: its only job on non-RTL CSS was
+Autoprefixer, and modern browsers have largely obviated vendor prefixing.
+Docsy's shipped CSS targets the Browserslist `defaults` browsers -- see [Install
+PostCSS][] -- and against those browsers Autoprefixer leaves the theme's CSS
+byte-for-byte unchanged, so the pass had quietly become a no-op that only
+imposed a toolchain requirement.
+
+### Actions {#postcss-actions}
+
+{{% _param CLEANUP %}} **Applies if** your site has no RTL language and no
+`postcss.config.*` of its own.
+
+- Drop `autoprefixer`, `postcss`, and `postcss-cli` from your dependencies; your
+  builds no longer need them.
+
+**Applies if** your site needs PostCSS: it has an RTL language, or you want
+Autoprefixer or other PostCSS plugins for your own CSS.
+
+- Keep your PostCSS toolchain as documented in [Install PostCSS][]. A
+  project-root `postcss.config.{js,mjs,cjs}` opts your production build back
+  into the PostCSS pass.
 
 ## {{% _param BREAKING %}} / {{% _param NEW %}} Favicons {#favicons}
 
@@ -277,11 +353,13 @@ default favicon files.
   behavior documented in [Add your favicons][].
 
 If you have a source SVG and ImageMagick installed, you can generate the common
-raster files with the new helper:
+raster files with the new helper. For an npm package install of Docsy:
 
 ```sh
 npx --no-install gen-favicons static/favicon.svg static/
 ```
+
+For the equivalent command under other install modes, see [Add your favicons][].
 
 ## {{% _param NEW %}} Shared chrome build mode {#shared-chrome}
 
@@ -391,10 +469,9 @@ Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 
 ## What's next?
 
-The 0.16.0 release closes the main user-facing pieces of the theme-folder move.
-Follow-up repository cleanup and future packaging work continue under [Finalize
-monorepo setup - 26Q2 (#2617)][#2617]. The experimental
-[shared chrome build mode](#shared-chrome) evolves under [#2659][], and further
+The 0.16.0 release completes the theme-folder move and its packaging arc,
+including publishing the theme to the npm registry. The experimental
+[shared chrome build mode](#shared-chrome) evolves under [#2689][], and further
 favicon improvements, such as light- and dark-mode variants, are tracked in
 [#2357][].
 
@@ -423,18 +500,19 @@ About this release:
 <!-- prettier-ignore-start -->
 [#2357]: https://github.com/google/docsy/issues/2357
 [#2615]: https://github.com/google/docsy/issues/2615
-[#2617]: https://github.com/google/docsy/issues/2617
-[#2659]: https://github.com/google/docsy/issues/2659
+[#2689]: https://github.com/google/docsy/issues/2689
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0
 [0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-supported-version]:
   <https://github.com/gohugoio/hugo/releases/tag/v{{% param hugoSupportedVersion %}}>
+[`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [chrome]: /docs/deployment/chrome/
 [CL@0.16.0]: /project/about/changelog/#next
 [compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
+[Docsy as an NPM package]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 [experimental]: /project/about/changelog/#experimental
 [hugo-language-apis]: hugo-0.158.0+/#language-apis
 [hugo-upgrade]: hugo-0.158.0+/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -433,11 +433,6 @@ committed link cache for fast, reproducible checks.
 
 ## {{% _param FAS rocket primary %}} Upgrade to 0.16.0 {#upgrade}
 
-> {{% _param FAS robot info %}} **Upgrading with AI?** Give your assistant this
-> post and the companion [Hugo guide][hugo-upgrade] as context: they are written
-> to double as operating instructions, with applies-if gates, per-mode actions,
-> verification steps, and sanity checks.
-
 Some upgrade steps are the same for each Docsy release, such as updating your
 Docsy package or Hugo module. Those steps are described in [Upgrade to Docsy
 0.12.0][]: follow them, using version **0.16.0** where the guide refers to
@@ -456,28 +451,10 @@ use:[^vers-note]
     version. Later Hugo or Node versions may work; see the [official support
     policy][].
 
-> [!NOTE]- **Need to roll back?**
->
-> Re-pin Docsy to [0.15.0][] and restore the pre-0.16 theme path
-> (`github.com/google/docsy` for Hugo modules, or `docsy` for `theme:`
-> installs). Then re-run your install mode's update commands (as in
-> [Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0. If
-> you switched to the [registry package](#npm-registry), reinstall from GitHub
-> instead:
->
-> ```sh
-> npm uninstall @docsy/theme
-> npm install --save-dev google/docsy#semver:v0.15.0
-> ```
-
 <section class="td-checkbox-list-wrapper">
 
 ### {{% _param FAS square-check primary %}} Sanity checks
 
-- [ ] [Check your Docsy install path](#theme-folder-actions) for your install
-      mode.
-- [ ] For Hugo module sites, [pull theme npm deps](#npm-deps-actions) with
-      `hugo mod npm pack` and `npm install`.
 - [ ] **Build your site** locally with Hugo 0.160.1 or later, preferably
       {{% param hugoSupportedVersion %}}.
 - [ ] [Check your favicon output](#favicons-actions), especially if you relied
@@ -489,6 +466,26 @@ use:[^vers-note]
       changes.
 
 </section>
+
+### {{% _param FAS robot info %}} Upgrading with AI? {#upgrading-with-ai}
+
+Give your assistant this post and the companion [Hugo guide][hugo-upgrade] as
+context: they are written to double as operating instructions, with applies-if
+gates, per-mode actions, verification steps, and sanity checks.
+
+### Rolling back {#rollback}
+
+To roll back, re-pin Docsy to [0.15.0][] and restore the pre-0.16 theme path
+(`github.com/google/docsy` for Hugo modules, or `docsy` for `theme:` installs).
+Then re-run your install mode's update commands (as in
+[Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0. If
+you switched to the [registry package](#npm-registry), reinstall from GitHub
+instead:
+
+```sh
+npm uninstall @docsy/theme
+npm install --save-dev google/docsy#semver:v0.15.0
+```
 
 ## What's next?
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -24,9 +24,8 @@ cSpell:ignore: CatmullRom favicons TOF
 {{% card header="Highlights" %}}
 
 - {{% _param FAS_LG cubes primary %}}
-  <span>**[First-class npm support](#npm-registry)**: Docsy is now in the npm
-  registry as `@docsy/theme`, theme dependencies [come from npm](#npm-deps), and
-  [more][]</span>
+  <span>**[First-class npm support](#npm-registry)**: install Docsy from the
+  registry, and [more][]</span>
 - {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
   their icons — drop conventionally named files into `static/` and Docsy
   discovers and links them; one less thing to hand-maintain</span>

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -38,8 +38,8 @@ cSpell:ignore: CatmullRom favicons TOF
 
 - **Packaging modernization**:
   - [Theme folder move](#theme-folder): a one-line path update per install mode
-  - [Bootstrap and Font Awesome via npm](#npm-deps);
-    [PostCSS now opt-in](#postcss) for non-RTL sites
+  - Hugo modules now source [Bootstrap and Font Awesome via npm](#npm-deps)
+  - [PostCSS now opt-in](#postcss) for non-RTL sites
   - [Docsy on the npm registry](#npm-registry): the new `@docsy/theme` package
 - **[Hugo 0.160.1+ support](#hugo)**: theme minimum raised from 0.146.0
 - **New features**:
@@ -258,9 +258,9 @@ npm install --save-dev @docsy/theme
 For setup details, see [Docsy as an NPM package][].
 
 Official releases are now defined channel-agnostically: a stable semver version
-from the npm registry, the Hugo module, or a GitHub release tag. An npm install
-of Docsy from GitHub (`google/docsy`) is unsupported, even for a stable release;
-see the [official support policy][].
+from the npm registry, the Hugo module, or a GitHub release tag. npm installs of
+Docsy from GitHub (`google/docsy`) are now for development and testing only; see
+the [official support policy][].
 
 ### Actions {#npm-registry-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -22,6 +22,9 @@ cSpell:ignore: CatmullRom favicons TOF
 
 {{% card header="Highlights" %}}
 
+- {{% _param FAS_LG robot info %}}
+  <span>**[Agent-ready upgrade guide](#upgrading-with-ai)**: hand this post to
+  your AI assistant</span>
 - {{% _param FAS_LG cubes primary %}}
   <span>**[First-class npm support](#npm-registry)**: install Docsy from the
   registry, and [more][]</span>
@@ -30,9 +33,6 @@ cSpell:ignore: CatmullRom favicons TOF
 - {{% _param FAS_LG bolt warning %}} <span>**[Shared chrome](#shared-chrome)**
   (experimental): a build mode for much faster link checking of large
   sites</span>
-- {{% _param FAS_LG robot info %}}
-  <span>**[Agent-ready upgrade guide](#upgrading-with-ai)**: hand this post to
-  your AI assistant</span>
 
 {{% /card %}}
 
@@ -51,7 +51,7 @@ cSpell:ignore: CatmullRom favicons TOF
   [for maintainers](#for-maintainers): repository package layout, and build and
   test guards
 
-## Ready to Upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
+## Ready to upgrade? <a id="breaking-changes"></a> {#ready-to-upgrade}
 
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} [Theme folder move](#theme-folder)
@@ -69,7 +69,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - [Other notable changes](#other-notable-changes), and
     [for maintainers](#for-maintainers)
 - {{% _param FAS rocket primary %}} Jump to [Upgrade to 0.16.0](#upgrade) once
-  you are ready.
+  you are ready, or [ask your agent](#upgrading-with-ai).
 
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Theme folder move {#theme-folder}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -2,7 +2,7 @@
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-27
 draft: true
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the new

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -6,9 +6,9 @@ lastmod: 2026-07-26
 draft: true
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the theme folder
-  move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, the new
-  @docsy/theme npm package, favicon handling, an experimental shared chrome
-  build mode, and repository packaging cleanup.
+  move, the raised minimum Hugo (0.160.1), npm-sourced Bootstrap and Font
+  Awesome, the new @docsy/theme npm package, favicon handling, an experimental
+  shared chrome build mode, and repository packaging cleanup.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -41,7 +41,7 @@ cSpell:ignore: CatmullRom favicons TOF
   - Hugo modules now source [Bootstrap and Font Awesome via npm](#npm-deps)
   - [PostCSS now opt-in](#postcss) for non-RTL sites
   - [Docsy on the npm registry](#npm-registry): the new `@docsy/theme` package
-- **[Hugo 0.160.1+ support](#hugo)**: theme minimum raised from 0.146.0
+- **[Minimum Hugo raised to 0.160.1](#hugo)**: was 0.146.0
 - **New features**:
   - [Favicon discovery](#favicons) from `static/`
   - [Shared chrome build mode](#shared-chrome) (experimental)
@@ -179,7 +179,7 @@ npm run postinstall
 
 For a fresh clone or submodule setup, see [Other installation options][].
 
-## {{% _param BREAKING %}} Hugo 0.160.1+ support {#hugo}
+## {{% _param BREAKING %}} Minimum Hugo raised to 0.160.1 {#hugo}
 
 Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 **0.160.1**. The minimum reflects three changes in this range:

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -173,10 +173,9 @@ npm run postinstall
 
 > [!WARNING]
 >
-> Run `npm run postinstall`, not `npm install`: with 0.16.0's repository layout,
-> a plain `npm install` inside `themes/docsy/` also pulls the repository's
-> maintainer workspaces (roughly 1.5 GB); `postinstall` installs only the
-> theme's runtime dependencies (about 34 MB).
+> Run `npm run postinstall`, not `npm install`: a plain `npm install` inside
+> `themes/docsy/` pulls in the repository's maintainer workspaces, not just the
+> theme's runtime dependencies.
 
 For a fresh clone or submodule setup, see [Other installation options][].
 
@@ -261,13 +260,6 @@ step:
 
 ```sh
 npm install --save-dev @docsy/theme
-```
-
-with the site config:
-
-```yaml
-theme: '@docsy/theme'
-themesDir: node_modules
 ```
 
 For setup details, see [Docsy as an NPM package][].

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -46,7 +46,7 @@ cSpell:ignore: CatmullRom favicons TOF
   come from npm via [`hugo mod npm pack`][hugo-npm-pack], and
   [PostCSS is opt-in](#postcss) for non-RTL sites
 - **[Docsy on the npm registry](#npm-registry)**: the theme is now published as
-  `@docsy/theme` -- the simplest way to install Docsy with npm
+  `@docsy/theme`, the simplest way to install Docsy with npm
 - **[Favicons](#favicons)**: no more default artwork -- sites supply their own
   icons, discovered from `static/` by filename convention
 - **[Shared chrome build mode](#shared-chrome)** (experimental): emits the
@@ -253,10 +253,10 @@ dependency set drifts.
 ## {{% _param NEW %}} Docsy on the npm registry {#npm-registry}
 
 Docsy is following Hugo's lead in making [npm dependencies](#npm-deps)
-first-class -- and taking it one step further: the theme itself is now published
+first-class, and taking it one step further: the theme itself is now published
 to the npm registry as [`@docsy/theme`][]. The registry package delivers the
-theme with Bootstrap and Font Awesome as ordinary npm dependencies -- no extra
-toolchain or install step:
+theme with Bootstrap and Font Awesome as ordinary npm dependencies, with no
+extra toolchain or install step:
 
 ```sh
 npm install --save-dev @docsy/theme
@@ -264,10 +264,10 @@ npm install --save-dev @docsy/theme
 
 For setup details, see [Docsy as an NPM package][].
 
-Official releases are now defined channel-agnostically -- a stable semver
-version from the npm registry, the Hugo module, or a GitHub release tag. An npm
-install of Docsy from GitHub (`google/docsy`) is unsupported, even for a stable
-release; see the [official support policy][].
+Official releases are now defined channel-agnostically: a stable semver version
+from the npm registry, the Hugo module, or a GitHub release tag. An npm install
+of Docsy from GitHub (`google/docsy`) is unsupported, even for a stable release;
+see the [official support policy][].
 
 ### Actions {#npm-registry-actions}
 
@@ -293,8 +293,8 @@ all.
 
 Nothing is lost in dropping the pass: its only job on non-RTL CSS was
 Autoprefixer, and modern browsers have largely obviated vendor prefixing.
-Docsy's shipped CSS targets the Browserslist `defaults` browsers -- see [Install
-PostCSS][] -- and against those browsers Autoprefixer leaves the theme's CSS
+Docsy's shipped CSS targets the Browserslist `defaults` browsers (see [Install
+PostCSS][]), and against those browsers Autoprefixer leaves the theme's CSS
 byte-for-byte unchanged, so the pass had quietly become a no-op that only
 imposed a toolchain requirement.
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -475,17 +475,16 @@ use:[^vers-note]
 Give your assistant this post and the companion [Hugo guide][hugo-upgrade] as
 context: they are written to double as operating instructions, with applies-if
 gates, per-mode actions, verification steps, and sanity checks. During review,
-an AI agent following these posts — and nothing else — upgraded the Docsy
-example site end to end.
+an AI agent following only these posts upgraded the Docsy example site end to
+end.
 
 ### {{% _param FAS arrow-rotate-left warning %}} Rolling back {#rollback}
 
 To roll back, re-pin Docsy to [0.15.0][] and restore the pre-0.16 theme path
 (`github.com/google/docsy` for Hugo modules, or `docsy` for `theme:` installs).
-Then re-run your install mode's update commands (as in
-[Theme folder move — Actions](#theme-folder-actions)) with version 0.15.0. If
-you switched to the [registry package](#npm-registry), reinstall from GitHub
-instead:
+Then re-run your install mode's [update commands](#theme-folder-actions) with
+version 0.15.0. If you switched to the [registry package](#npm-registry),
+reinstall from GitHub instead:
 
 ```sh
 npm uninstall @docsy/theme
@@ -496,8 +495,7 @@ npm install --save-dev google/docsy#semver:v0.15.0
 
 The 0.16.0 release completes the theme-folder move and its packaging arc,
 including publishing the theme to the npm registry. Work towards the next
-release is tracked under [Release 0.17.0 preparation][#2691] and the [0.17.0
-milestone][].
+release is tracked under [Release 0.17.0 preparation][#2691].
 
 <!-- prettier-ignore -->
 > [!INFO]- Your opinion counts!
@@ -524,7 +522,6 @@ About this release:
 <!-- prettier-ignore-start -->
 [#2615]: https://github.com/google/docsy/issues/2615
 [#2691]: https://github.com/google/docsy/issues/2691
-[0.17.0 milestone]: https://github.com/google/docsy/milestone/26
 [0.15.0]: https://github.com/google/docsy/releases/v0.15.0
 [0.16.0]: https://github.com/google/docsy/releases/v0.16.0
 [0.157.0]: https://github.com/gohugoio/hugo/releases/tag/v0.157.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -19,14 +19,14 @@ params:
 cSpell:ignore: CatmullRom favicons TOF
 ---
 
-<!-- markdownlint-disable no-space-in-emphasis -->
+<!-- markdownlint-disable descriptive-link-text no-space-in-emphasis -->
 
 {{% card header="Highlights" %}}
 
 - {{% _param FAS_LG cubes primary %}}
   <span>**[First-class npm support](#npm-registry)**: Docsy is now in the npm
   registry as `@docsy/theme`, theme dependencies [come from npm](#npm-deps), and
-  [more packaging updates](#theme-folder)</span>
+  [more][]</span>
 - {{% _param FAS_LG star info %}} <span>**[Favicons](#favicons)**: sites own
   their icons — drop conventionally named files into `static/` and Docsy
   discovers and links them; one less thing to hand-maintain</span>
@@ -520,6 +520,7 @@ About this release:
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
 [Install PostCSS]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [Lychee]: https://github.com/lycheeverse/lychee
+[more]: #theme-folder
 [official support policy]: /project/about/changelog/#official-support
 [Other installation options]: /docs/get-started/other-options/
 [Upgrade to Docsy 0.12.0]: /blog/2025/0.12.0/

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -252,10 +252,11 @@ dependency set drifts.
 
 ## {{% _param NEW %}} Docsy on the npm registry {#npm-registry}
 
-Docsy is now published to the npm registry as [`@docsy/theme`][], completing the
-packaging story above: the registry package delivers the theme with Bootstrap
-and Font Awesome as ordinary npm dependencies -- no extra toolchain or install
-step:
+Docsy is following Hugo's lead in offering first-class support for
+[npm dependencies](#npm-deps) -- and taking it one step further: the theme
+itself is now published to the npm registry as [`@docsy/theme`][]. The registry
+package delivers the theme with Bootstrap and Font Awesome as ordinary npm
+dependencies -- no extra toolchain or install step:
 
 ```sh
 npm install --save-dev @docsy/theme

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -2,7 +2,7 @@
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-06-14
-lastmod: 2026-07-26
+lastmod: 2026-07-27
 draft: true
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -183,7 +183,8 @@ always project-specific.
 ### Actions {#security-actions}
 
 {{% _param BREAKING %}} **Applies if** your site uses remote resources,
-hand-authored `.html` content files, or symlinked content/assets.
+hand-authored `.html` content files, symlinked content/assets, or
+`templates.Defer` inside cached partials.
 
 - Build locally with your target Hugo version and review security-related errors
   or warnings.
@@ -314,14 +315,16 @@ After addressing applicable breaking changes and deprecations, upgrade to Hugo
 If you use the [hugo-extended][] npm package:
 
 ```sh
-npm install hugo-extended@{{% _param hugoSupportedVersion %}} --save-dev
+npm install hugo-extended@{{% param hugoSupportedVersion %}} --save-dev
 ```
 
 If you use [hvm][]:
 
 ```sh
-hvm use {{% _param hugoSupportedVersion %}}
+hvm use {{% param hugoSupportedVersion %}}/extended
 ```
+
+For other installation methods, see [Install Hugo][].
 
 <section class="td-checkbox-list-wrapper">
 
@@ -363,5 +366,6 @@ hvm use {{% _param hugoSupportedVersion %}}
 [hugo-extended]: https://www.npmjs.com/package/hugo-extended
 [hugo-164-perf]: https://discourse.gohugo.io/t/hugo-building-slowly-from-release-0-128-0/57314/21
 [hvm]: https://github.com/jmooring/hvm
+[Install Hugo]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-hugo
 [Multi-language support]: /docs/language/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,7 +1,7 @@
 ---
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
-date: 2026-06-15
+date: 2026-06-14
 lastmod: 2026-07-26
 draft: true
 author: >-

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -2,7 +2,7 @@
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-06-15
-lastmod: 2026-07-17
+lastmod: 2026-07-26
 draft: true
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
@@ -85,6 +85,13 @@ Review custom template code for these replacements:
 | `.Site.LanguageCode`                      | `.Site.Language.Locale`  |
 | `(Page\|Site).Language.Weight`            | no direct replacement    |
 | `.Site.Languages` for cross-site language | `hugo.Sites` or `.Sites` |
+
+> [!NOTE]
+>
+> Page-level `.Lang` is unaffected: the deprecation applies to `.Language.Lang`,
+> not to the `Lang` method on `Page` objects. For example,
+> `where .Translations "Lang" "fr"` needs no change. A textual search for
+> `.Lang` will surface such uses; leave them as is.
 
 For current Docsy examples, see [Multi-language support][].
 

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -23,9 +23,6 @@ covers the
 
 ## Upgrade summary
 
-This guide highlights Hugo changes that may require action when upgrading a
-Docsy site to 0.16.0.
-
 - Review {{% _param BADGE BREAKING warning %}} changes:
   <a id="breaking-changes"></a>
   - {{% _param BREAKING %}}
@@ -102,18 +99,18 @@ images. It also introduced a regression that could double-escape `&` in rendered
 Markdown link URLs, producing `&amp;amp;` in HTML output.
 
 Hugo 0.160.0 fixed that regression, and Hugo 0.160.1 is the safer 0.160.x patch
-release. If you are moving through this range, do not stop at 0.159.2. Docsy
-0.16.0's minimum Hugo version, 0.160.1, already excludes this window.
+release. Docsy 0.16.0's minimum Hugo version, 0.160.1, already excludes this
+window.
 
 ### Actions {#amp-escaping-actions}
 
 **Applies if** you briefly tested or deployed Hugo 0.159.2.
 
 - Search generated HTML for `&amp;amp;` in link URLs.
-- Pay closest attention to monolingual sites without custom link render hooks:
+- Monolingual sites without custom link render hooks are the most exposed:
   multilingual single-host sites are usually shielded by Hugo's
-  `useEmbedded: auto` link render hook, and custom link render hooks also
-  usually shield a site.
+  `useEmbedded: auto` link render hook, as are sites with custom link render
+  hooks.
 
 ## Template and module cleanup (0.159.x-0.160.x) {#template-module-cleanup}
 
@@ -147,7 +144,7 @@ Node's `--permission` sandbox. This requires **Node 22 or later**.
 Docsy sites commonly use PostCSS for CSS processing, so this can be a practical
 breaking change even when the Docsy theme itself has not changed. Hugo 0.163.2
 and 0.163.3 fix regressions in this permission model, so prefer 0.163.3 or later
-for PostCSS pipelines; the actions below give the specifics.
+for PostCSS pipelines.
 
 ### Actions {#node-tools-actions}
 
@@ -177,8 +174,7 @@ Hugo tightened several security boundaries in this range:
   `os.Stat`, and `os.FileExists`.
 
 Docsy's own workspace and smoke-test install shapes were validated across these
-changes, but site-specific mounts, symlinks, and remote resource fetches are
-always project-specific.
+changes.
 
 ### Actions {#security-actions}
 

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -225,7 +225,8 @@ npm run postinstall
 ```
 
 As with the [submodule option](#option-1-docsy-as-a-git-submodule), set
-`theme: docsy/theme` in your site configuration.
+`theme: docsy/theme` in your site configuration. The note above about
+`npm run postinstall` versus `npm install` applies here as well.
 
 To work from the development version of Docsy (not recommended unless, for
 example, you plan to upstream changes to Docsy), omit the

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -176,9 +176,9 @@ your project's root directory:
     > [!NOTE]
     >
     > Run `npm run postinstall`, not `npm install`: `postinstall` installs only
-    > the theme's runtime dependencies (about 34 MB); a plain `npm install`
-    > inside `themes/docsy/` also pulls the repository's maintainer workspaces
-    > (roughly 1.5 GB).
+    > the theme's runtime dependencies; a plain `npm install` inside
+    > `themes/docsy/` also pulls the repository's maintainer workspaces -- an
+    > install more than an order of magnitude larger.
 
 4.  (Optional but recommended) To avoid having to repeat the previous step every
     time you update Docsy, consider adding [NPM scripts][] like the following to

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -177,7 +177,7 @@ your project's root directory:
     >
     > Run `npm run postinstall`, not `npm install`: `postinstall` installs only
     > the theme's runtime dependencies; a plain `npm install` inside
-    > `themes/docsy/` also pulls the repository's maintainer workspaces -- an
+    > `themes/docsy/` also pulls the repository's maintainer workspaces, an
     > install more than an order of magnitude larger.
 
 4.  (Optional but recommended) To avoid having to repeat the previous step every

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -173,6 +173,13 @@ your project's root directory:
     (cd themes/docsy && npm run postinstall)
     ```
 
+    > [!NOTE]
+    >
+    > Run `npm run postinstall`, not `npm install`: `postinstall` installs only
+    > the theme's runtime dependencies (about 34 MB); a plain `npm install`
+    > inside `themes/docsy/` also pulls the repository's maintainer workspaces
+    > (roughly 1.5 GB).
+
 4.  (Optional but recommended) To avoid having to repeat the previous step every
     time you update Docsy, consider adding [NPM scripts][] like the following to
     your project's `package.json` file:

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -150,6 +150,12 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 **New**:
 
+- **Docsy on the npm registry**: the theme is now published as
+  [`@docsy/theme`][@docsy/theme] -- install it directly from npm, with Bootstrap
+  and Font Awesome delivered as ordinary dependencies. An npm install from
+  GitHub (`google/docsy`) is now [unsupported](#official-support). See [0.16.0
+  release report][0.16.0-blog-npm-registry] and [Docsy as an NPM
+  package][option-3-npm] ([#2683][]).
 - **Favicon discovery**: you can now drop a site's conventionally named favicon
   files into `static/` and the theme discovers and links them -- no favicons
   partial required. A new `gen-favicons` helper generates raster icons from a
@@ -210,10 +216,12 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2668]: https://github.com/google/docsy/issues/2668
 [#2677]: https://github.com/google/docsy/pull/2677
+[#2683]: https://github.com/google/docsy/issues/2683
 [0.16.0 release report]: /blog/2026/0.16.0/
 [0.16.0-blog-favicons]: /blog/2026/0.16.0/#favicons
 [0.16.0-blog-hugo]: /blog/2026/0.16.0/#hugo
 [0.16.0-blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
+[0.16.0-blog-npm-registry]: /blog/2026/0.16.0/#npm-registry
 [0.16.0-blog-postcss]: /blog/2026/0.16.0/#postcss
 [0.16.0-blog-theme-folder]: /blog/2026/0.16.0/#theme-folder
 [0.16.0]: https://github.com/google/docsy/releases/tag/v0.16.0
@@ -223,6 +231,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
 [hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
+[option-3-npm]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 <!-- prettier-ignore-end -->
 
 ## v0.15.0 {#v0.15.0}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -6,8 +6,9 @@ aliases: [../changelog]
 cSpell:ignore: deining FOUC gitmodules gtag katex lookandfeel mhchem navs notoc tabpane onedark
 ---
 
-We only document **breaking changes** and release **highlights** in this page.
-For the full list of changes of any particular release, see the [release
+We document **breaking changes** and release **highlights** in this page, with
+maintainer-facing changes summarized at the end of each release section. For the
+full list of changes of any particular release, see the [release
 notes][releases].
 
 Useful links: [Releases][] & [tags][], jump to the [latest][] release, and view
@@ -185,12 +186,10 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 - Migrated the theme and docs off deprecated Hugo language APIs ([#2593][]).
   Thanks [@deining][] for the groundwork in [#2594][] and [#2578][]!
+- Synced and corrected the Russian UI strings. Thanks [@shurup][]!
 - Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
   minimum supported Hugo version remains 0.160.1. See [Hugo 0.158+ upgrade
   guide][] ([#2581][]).
-- Reorganized the repository package boundary: `theme/package.json` owns theme
-  runtime dependencies, and the root package orchestrates the `docsy.dev` and
-  `theme` workspaces ([#2617][]).
 - **PostCSS is opt-in for non-RTL sites**: Docsy runs `postCSS` only for sites
   with RTL languages or a project-root `postcss.config.{js,mjs,cjs}`; other
   sites no longer need a PostCSS toolchain. See [0.16.0 release
@@ -205,6 +204,15 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   that emits the repeated chrome (navbar, footer, left-nav) on one donor page
   per locale and restores it in the browser, so one build serves both readers
   and link checkers. See [Chrome build modes][chrome] ([#2659][]).
+
+**For maintainers**:
+
+- Reorganized the repository package boundary: `theme/package.json` owns theme
+  runtime dependencies, and the root package orchestrates the `docsy.dev` and
+  `theme` workspaces ([#2617][]).
+- Added build and test guards (Hugo deprecation output, fixture-site
+  regressions) and moved link checking from htmltest to Lychee. See [0.16.0
+  release report][0.16.0-blog-maintainers].
 
 <!-- prettier-ignore-start -->
 [#2357]: https://github.com/google/docsy/issues/2357
@@ -221,6 +229,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [0.16.0 release report]: /blog/2026/0.16.0/
 [0.16.0-blog-favicons]: /blog/2026/0.16.0/#favicons
 [0.16.0-blog-hugo]: /blog/2026/0.16.0/#hugo
+[0.16.0-blog-maintainers]: /blog/2026/0.16.0/#for-maintainers
 [0.16.0-blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [0.16.0-blog-npm-registry]: /blog/2026/0.16.0/#npm-registry
 [0.16.0-blog-postcss]: /blog/2026/0.16.0/#postcss
@@ -233,6 +242,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0
 [option-3-npm]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
+[@shurup]: https://github.com/shurup
 <!-- prettier-ignore-end -->
 
 ## v0.15.0 {#v0.15.0}

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -151,7 +151,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 **New**:
 
 - **Docsy on the npm registry**: the theme is now published as
-  [`@docsy/theme`][@docsy/theme] -- install it directly from npm, with Bootstrap
+  [`@docsy/theme`][@docsy/theme]. Install it directly from npm, with Bootstrap
   and Font Awesome delivered as ordinary dependencies. An npm install from
   GitHub (`google/docsy`) is now [unsupported](#official-support). See [0.16.0
   release report][0.16.0-blog-npm-registry] and [Docsy as an NPM

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -178,8 +178,8 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 - **Bootstrap and Font Awesome via npm**: the theme declares them as npm
   dependencies instead of importing them as Hugo modules. **Applies to
   Hugo-module installs**, which run `hugo mod npm pack` and `npm install` to
-  pull them in; npm-package and clone/submodule installs are unaffected. See
-  [0.16.0 release report][0.16.0-blog-npm-deps] ([#2668][]).
+  pull them in; other install modes are unaffected. See [0.16.0 release
+  report][0.16.0-blog-npm-deps] ([#2668][]).
 
 **Other changes**:
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -103,8 +103,8 @@ Specifically, the Docsy team **officially supports** the following:
   - Hugo module (`vX.Y.Z`)
   - GitHub [release][releases] or git tag (`vX.Y.Z`)
 
-  An npm install of Docsy from GitHub (`google/docsy`) is unsupported, even for
-  a stable release.
+  npm installs of Docsy from GitHub (`google/docsy`) are for development and
+  testing only, not production use.
 
 - **Issue reports**: over the latest official release, a current pre-release, or
   the `main` branch.
@@ -152,10 +152,11 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 - **Docsy on the npm registry**: the theme is now published as
   [`@docsy/theme`][@docsy/theme]. Install it directly from npm, with Bootstrap
-  and Font Awesome delivered as ordinary dependencies. An npm install from
-  GitHub (`google/docsy`) is now [unsupported](#official-support). See [0.16.0
-  release report][0.16.0-blog-npm-registry] and [Docsy as an NPM
-  package][option-3-npm] ([#2683][]).
+  and Font Awesome delivered as ordinary dependencies. npm installs from GitHub
+  (`google/docsy`) are now for
+  [development and testing only](#official-support). See [0.16.0 release
+  report][0.16.0-blog-npm-registry] and [Docsy as an NPM package][option-3-npm]
+  ([#2683][]).
 - **Favicon discovery**: you can now drop a site's conventionally named favicon
   files into `static/` and the theme discovers and links them -- no favicons
   partial required. A new `gen-favicons` helper generates raster icons from a

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -18,6 +18,8 @@ restating them:
   quick overview. No upgrade advice, implementation detail, or background.
   Entries link to the release report for details and cite a change's key issues
   — PRs only when there is no key issue, such as for contributor credit.
+  Maintainer-facing changes get a short **For maintainers** list at the end of
+  the release section.
 - **Release and upgrade blog posts**: what's new, what to watch out for, and
   actionable upgrade guidance — the historical narrative. Link to the site docs
   for current behavior and reference detail. Don't enumerate PRs and issues;
@@ -25,6 +27,8 @@ restating them:
   chore, so keep posts maximally actionable yet lean: the release summary reads
   like a selective table of contents — a link per section with a clause of
   guiding glue — and each fact appears in one section, its home.
+  Maintainer-facing changes are summarized in a **For maintainers** section at
+  the end of the documented changes.
 - **Site docs** (`docs/`): Docsy _as it is now_. Minimal historical references
   or links to issues and PRs.
 - **[Release notes][] and [milestones][]**: the exhaustive record — generated

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,8 +6,8 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, the raised minimum Hugo (0.160.1), npm-sourced Bootstrap and Font Awesome, the new @docsy/theme npm package, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/)
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, the new @docsy/theme npm package, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.
 - [Hugo 0.152.0-0.155.x upgrade guide](/blog/2026/hugo-0.152.0+/)

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -7,7 +7,7 @@ LLMS index: [llms.txt](/llms.txt)
 Section pages:
 
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/)
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, Hugo 0.160.1+ support, npm-sourced Bootstrap and Font Awesome, the new @docsy/theme npm package, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.
 - [Hugo 0.152.0-0.155.x upgrade guide](/blog/2026/hugo-0.152.0+/)

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the theme folder move, the raised minimum Hugo (0.160.1), npm-sourced Bootstrap and Font Awesome, the new @docsy/theme npm package, favicon handling, an experimental shared chrome build mode, and repository packaging cleanup.
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the new @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and favicon discovery.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/)
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+044-over-main-2b0fba2f",
+  "version": "0.15.1-dev+045-over-main-9b1d9951",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,18 +1,18 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-07-18
+lastmod: 2026-07-26
 range: v0.15.0..main
-last-main-commit: 494f3da6
+last-main-commit: 9b1d9951
 cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[494f3da6][], mapped to where each is covered. This is the objective "is
+[9b1d9951][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 38 commits in range are squash-merged PRs (one commit per PR), so the
+All 44 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -28,46 +28,52 @@ first-parent spine and the raw range are identical; every subject carries its
 
 ## Ledger
 
-| Change               | Issue     | Summary                                         | Class | Docs | CL   | Blog | Hugo | Notes                                     |
-| -------------------- | --------- | ----------------------------------------------- | ----- | ---- | ---- | ---- | ---- | ----------------------------------------- |
-| `843c5345` [#2641][] | [#2617][] | Move theme into `theme/` (TOF phases 0–4b)      | break | done | done | done | N/A  | Install-path change; pairs w/ [#2645][]   |
-| `94f94145` [#2645][] | [#2617][] | npm workspaces; simplify theme-deps install     | maint | done | done | done | N/A  | Packaging cleanup; pairs w/ [#2641][]     |
-| `5c5733de` [#2647][] | [#2593][] | Hugo 0.158.0; raise theme min; language APIs    | break | done | done | done | done | Floor 0.146→0.158; now 0.160.1 [#2677][]  |
-| `3e76f1f2` [#2648][] | [#2581][] | Upgrade to Hugo 0.160.1                         | maint | done | done | done | done | Combined 0.159.x + 0.160.x                |
-| `f22a352d` [#2649][] | [#2581][] | Project Hugo build 0.163.1; imaging migration   | maint | done | done | done | done | `imaging.quality` config migration        |
-| `acf3453b` [#2653][] | [#2595][] | Remove default favicons; modernize docsy.dev    | break | done | done | done | N/A  | ~18 bundled icons removed                 |
-| `c0f2ddc8` [#2654][] | [#2357][] | Discover/link `static/` favicons; icon helper   | feat  | done | done | done | N/A  | Zero-config discovery                     |
-| `f3128285` [#2656][] | [#2357][] | Square favicon variants; `gen-favicons` CLI     | feat  | done | done | done | N/A  | Refs added this pass                      |
-| `4f544377` [#2650][] | —         | Fix double `v` (`@vv0.15.0`) in version docs    | docs  | done | N/A  | N/A  | N/A  | Minor; CL omission by decision            |
-| `c2b2c7ad` [#2635][] | —         | Update `start-from-scratch.md`                  | docs  | done | N/A  | N/A  | N/A  | Superseded by [#2650][]                   |
-| `de60b6db` [#2632][] | [#2631][] | Examples page to 0.15.0; maintainer notes       | docs  | done | N/A  | N/A  | N/A  | Internal/site                             |
-| `33ce90f0` [#2637][] | —         | Update maintainer notes                         | docs  | done | N/A  | N/A  | N/A  | Release-process docs                      |
-| `9eedc5a7` [#2651][] | [#2598][] | Netlify badge → canonical URL                   | docs  | done | N/A  | N/A  | N/A  | Site cleanup                              |
-| `cfc90204` [#2646][] | [#2617][] | Repo-reorg task docs after monorepo cleanup     | docs  | N/A  | N/A  | N/A  | N/A  | Task docs                                 |
-| `d8bd0760` [#2644][] | [#2617][] | TOF plan docs & status — phase 4                | docs  | N/A  | N/A  | N/A  | N/A  | Plan/status docs                          |
-| `e20fbd8f` [#2643][] | [#2617][] | TOF tweaks & status — phase 4b                  | docs  | N/A  | N/A  | N/A  | N/A  | Plan/status docs                          |
-| `ce9942b8` [#2630][] | [#2501][] | Set version to v0.15.1-dev                      | tool  | N/A  | N/A  | N/A  | N/A  | Release-prep maintenance                  |
-| `f5167068` [#2655][] | —         | Isolate deprecation-probe test from output      | tool  | N/A  | N/A  | N/A  | N/A  | Test-only                                 |
-| `48e05f5d` [#2658][] | [#2581][] | Project Hugo build 0.163.2 (patch over 0.163.1) | maint | N/A  | done | done | done | PostCSS/Netlify `ERR_ACCESS_DENIED` fix   |
-| `6fdfd21b` [#2590][] | —         | Fix and sync the Russian locale                 | maint | N/A  | N/A  | N/A  | N/A  | Community theme i18n (`ru.yaml`)          |
-| `487050c2` [#2660][] | [#2659][] | Lean-render mode: drop repeated chrome          | feat  | done | done | done | N/A  | Chrome v1; folded into `shared` [#2662][] |
-| `3bcd6e7d` [#2661][] | [#2659][] | full-vs-shared link-check matrix (docsy.dev)    | tool  | N/A  | N/A  | N/A  | N/A  | Internal CI tooling for chrome            |
-| `b3ce9274` [#2662][] | [#2659][] | Experimental `shared` chrome build mode         | feat  | done | done | done | N/A  | One feature w/ [#2660][]; off by default  |
-| `5998cf5e` [#2663][] | [#2615][] | Draft 0.16.0 release report + Hugo guide        | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts + this workspace    |
-| `5758c063` [#2664][] | —         | Project Hugo build 0.163.3 (patch over 0.163.2) | maint | N/A  | done | done | done | Blog/Hugo-post bumps landed this refresh  |
-| `09443ba8` [#2665][] | —         | Link checking: htmltest → Lychee (docsy.dev)    | tool  | N/A  | N/A  | done | N/A  | One-line mention in build/test guards     |
-| `93948e65` [#2666][] | —         | Fix rotted externals; skip-marker migration     | docs  | done | N/A  | N/A  | N/A  | Site content fixes                        |
-| `56c2cf0e` [#2667][] | —         | Packaged root-level Lychee tooling              | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]; prettier ^3.9.3  |
-| `394e86f4` [#2669][] | —         | Fix Lychee bin entry point (npx/PATH)           | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]                   |
-| `56c5ab12` [#2670][] | [#2668][] | Bootstrap and Font Awesome from npm             | break | done | done | done | N/A  | Hugo-module installs: `hugo mod npm pack` |
-| `1aa519e7` [#2671][] | [#2668][] | Link-check CLIs → external link-cache pkg       | tool  | N/A  | N/A  | N/A  | N/A  | `docsy` pkg ships only `gen-favicons` bin |
-| `1e2d57ea` [#2672][] | [#2668][] | Get-started install docs reconciled for 0.16    | docs  | done | N/A  | N/A  | N/A  | Module paths, npm-pack step, PostCSS      |
-| `15d2f98c` [#2674][] | —         | Adopt renamed link-cache pkg (was lychee-cache) | tool  | N/A  | N/A  | N/A  | N/A  | devDependency switch only                 |
-| `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home |
-| `7c9a0608` [#2678][] | —         | Add `update:goldens` golden-refresh scripts     | tool  | N/A  | N/A  | N/A  | N/A  | Test tooling; root `fix:goldens` alias    |
-| `4e954dc1` [#2679][] | —         | Project Hugo build 0.164.0                      | maint | N/A  | done | done | done | 0.128.0+ perf fix; Chroma/sitemap churn   |
-| `6d9367e2` [#2677][] | [#2668][] | Artifact refresh; theme Hugo floor → 0.160.1    | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions  |
-| `494f3da6` [#2680][] | —         | Clarify minimum vs officially supported Hugo    | docs  | done | done | done | N/A  | User-visible: support policy surfaced     |
+| Change               | Issue     | Summary                                         | Class | Docs | CL   | Blog | Hugo | Notes                                        |
+| -------------------- | --------- | ----------------------------------------------- | ----- | ---- | ---- | ---- | ---- | -------------------------------------------- |
+| `843c5345` [#2641][] | [#2617][] | Move theme into `theme/` (TOF phases 0–4b)      | break | done | done | done | N/A  | Install-path change; pairs w/ [#2645][]      |
+| `94f94145` [#2645][] | [#2617][] | npm workspaces; simplify theme-deps install     | maint | done | done | done | N/A  | Packaging cleanup; pairs w/ [#2641][]        |
+| `5c5733de` [#2647][] | [#2593][] | Hugo 0.158.0; raise theme min; language APIs    | break | done | done | done | done | Floor 0.146→0.158; now 0.160.1 [#2677][]     |
+| `3e76f1f2` [#2648][] | [#2581][] | Upgrade to Hugo 0.160.1                         | maint | done | done | done | done | Combined 0.159.x + 0.160.x                   |
+| `f22a352d` [#2649][] | [#2581][] | Project Hugo build 0.163.1; imaging migration   | maint | done | done | done | done | `imaging.quality` config migration           |
+| `acf3453b` [#2653][] | [#2595][] | Remove default favicons; modernize docsy.dev    | break | done | done | done | N/A  | ~18 bundled icons removed                    |
+| `c0f2ddc8` [#2654][] | [#2357][] | Discover/link `static/` favicons; icon helper   | feat  | done | done | done | N/A  | Zero-config discovery                        |
+| `f3128285` [#2656][] | [#2357][] | Square favicon variants; `gen-favicons` CLI     | feat  | done | done | done | N/A  | Refs added this pass                         |
+| `4f544377` [#2650][] | —         | Fix double `v` (`@vv0.15.0`) in version docs    | docs  | done | N/A  | N/A  | N/A  | Minor; CL omission by decision               |
+| `c2b2c7ad` [#2635][] | —         | Update `start-from-scratch.md`                  | docs  | done | N/A  | N/A  | N/A  | Superseded by [#2650][]                      |
+| `de60b6db` [#2632][] | [#2631][] | Examples page to 0.15.0; maintainer notes       | docs  | done | N/A  | N/A  | N/A  | Internal/site                                |
+| `33ce90f0` [#2637][] | —         | Update maintainer notes                         | docs  | done | N/A  | N/A  | N/A  | Release-process docs                         |
+| `9eedc5a7` [#2651][] | [#2598][] | Netlify badge → canonical URL                   | docs  | done | N/A  | N/A  | N/A  | Site cleanup                                 |
+| `cfc90204` [#2646][] | [#2617][] | Repo-reorg task docs after monorepo cleanup     | docs  | N/A  | N/A  | N/A  | N/A  | Task docs                                    |
+| `d8bd0760` [#2644][] | [#2617][] | TOF plan docs & status — phase 4                | docs  | N/A  | N/A  | N/A  | N/A  | Plan/status docs                             |
+| `e20fbd8f` [#2643][] | [#2617][] | TOF tweaks & status — phase 4b                  | docs  | N/A  | N/A  | N/A  | N/A  | Plan/status docs                             |
+| `ce9942b8` [#2630][] | [#2501][] | Set version to v0.15.1-dev                      | tool  | N/A  | N/A  | N/A  | N/A  | Release-prep maintenance                     |
+| `f5167068` [#2655][] | —         | Isolate deprecation-probe test from output      | tool  | N/A  | N/A  | N/A  | N/A  | Test-only                                    |
+| `48e05f5d` [#2658][] | [#2581][] | Project Hugo build 0.163.2 (patch over 0.163.1) | maint | N/A  | done | done | done | PostCSS/Netlify `ERR_ACCESS_DENIED` fix      |
+| `6fdfd21b` [#2590][] | —         | Fix and sync the Russian locale                 | maint | N/A  | N/A  | N/A  | N/A  | Community theme i18n (`ru.yaml`)             |
+| `487050c2` [#2660][] | [#2659][] | Lean-render mode: drop repeated chrome          | feat  | done | done | done | N/A  | Chrome v1; folded into `shared` [#2662][]    |
+| `3bcd6e7d` [#2661][] | [#2659][] | full-vs-shared link-check matrix (docsy.dev)    | tool  | N/A  | N/A  | N/A  | N/A  | Internal CI tooling for chrome               |
+| `b3ce9274` [#2662][] | [#2659][] | Experimental `shared` chrome build mode         | feat  | done | done | done | N/A  | One feature w/ [#2660][]; off by default     |
+| `5998cf5e` [#2663][] | [#2615][] | Draft 0.16.0 release report + Hugo guide        | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts + this workspace       |
+| `5758c063` [#2664][] | —         | Project Hugo build 0.163.3 (patch over 0.163.2) | maint | N/A  | done | done | done | Blog/Hugo-post bumps landed this refresh     |
+| `09443ba8` [#2665][] | —         | Link checking: htmltest → Lychee (docsy.dev)    | tool  | N/A  | N/A  | done | N/A  | One-line mention in build/test guards        |
+| `93948e65` [#2666][] | —         | Fix rotted externals; skip-marker migration     | docs  | done | N/A  | N/A  | N/A  | Site content fixes                           |
+| `56c2cf0e` [#2667][] | —         | Packaged root-level Lychee tooling              | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]; prettier ^3.9.3     |
+| `394e86f4` [#2669][] | —         | Fix Lychee bin entry point (npx/PATH)           | tool  | N/A  | N/A  | N/A  | N/A  | Superseded by [#2671][]                      |
+| `56c5ab12` [#2670][] | [#2668][] | Bootstrap and Font Awesome from npm             | break | done | done | done | N/A  | Hugo-module installs: `hugo mod npm pack`    |
+| `1aa519e7` [#2671][] | [#2668][] | Link-check CLIs → external link-cache pkg       | tool  | N/A  | N/A  | N/A  | N/A  | `docsy` pkg ships only `gen-favicons` bin    |
+| `1e2d57ea` [#2672][] | [#2668][] | Get-started install docs reconciled for 0.16    | docs  | done | N/A  | N/A  | N/A  | Module paths, npm-pack step, PostCSS         |
+| `15d2f98c` [#2674][] | —         | Adopt renamed link-cache pkg (was lychee-cache) | tool  | N/A  | N/A  | N/A  | N/A  | devDependency switch only                    |
+| `a7c58f5d` [#2675][] | —         | Reconcile remaining docs w/ npm-dep changes     | docs  | done | N/A  | N/A  | N/A  | Troubleshooting page; PostCSS single home    |
+| `7c9a0608` [#2678][] | —         | Add `update:goldens` golden-refresh scripts     | tool  | N/A  | N/A  | N/A  | N/A  | Test tooling; root `fix:goldens` alias       |
+| `4e954dc1` [#2679][] | —         | Project Hugo build 0.164.0                      | maint | N/A  | done | done | done | 0.128.0+ perf fix; Chroma/sitemap churn      |
+| `6d9367e2` [#2677][] | [#2668][] | Artifact refresh; theme Hugo floor → 0.160.1    | break | done | done | done | done | npm-pack needs 0.159.0; skip regressions     |
+| `494f3da6` [#2680][] | —         | Clarify minimum vs officially supported Hugo    | docs  | done | done | done | N/A  | User-visible: support policy surfaced        |
+| `0d60f926` [#2681][] | [#2615][] | Refresh 0.16.0 release artifacts thru 494f3da6  | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts themselves             |
+| `4d8d85ef` [#2682][] | [#2615][] | Lean/DRY artifact pass; frozen version params   | tool  | N/A  | N/A  | N/A  | N/A  | Version-freeze guard in `test:hugo-versions` |
+| `79448e2b` [#2684][] | [#2683][] | `gen-favicons` → `theme/`; publishable pkg      | feat  | done | done | done | N/A  | npm-publish step 1; root bin repointed       |
+| `848374ee` [#2686][] | —         | docsy.dev: run link-check bins directly         | tool  | N/A  | N/A  | N/A  | N/A  | npm-squat hygiene: no bare `npx BIN`         |
+| `2b0fba2f` [#2687][] | —         | docsy.dev: link-cache from the npm registry     | tool  | N/A  | N/A  | N/A  | N/A  | devDependency source switch only             |
+| `9b1d9951` [#2688][] | [#2683][] | Registry install first-class; support policy    | docs  | done | done | done | N/A  | Option 3 registry-lead; two-axis policy      |
 
 ## Notes on bundled changes
 
@@ -117,13 +123,27 @@ first-parent spine and the raw range are identical; every subject carries its
   User-visible improvement: the release post's Hugo section links the policy
   (routed 2026-07-18); the changelog coverage **is** the rewritten §Official
   support section itself.
+- **npm-registry publishing** ([#2684][] + [#2688][]; tracker [#2683][]): the
+  theme became publishable as `@docsy/theme` — [#2684][] moved `gen-favicons`
+  into `theme/` and filled in the package metadata; [#2688][] made the registry
+  install first-class in the install docs and recast the official-support policy
+  in the two-axis form (production use vs issue reports), under which a GitHub
+  npm install is unsupported. `0.16.0-rc.1` is published under dist-tag `next`;
+  the stable publish is a tag-time step. [#2686][] + [#2687][] are adjacent
+  site-tooling hygiene (dependency-provided bins invoked directly, no bare
+  `npx`; link-cache installed from the registry). Blog/CL coverage: the release
+  post's npm-registry section and the changelog **New** entry (routed
+  2026-07-26).
 
 ## Linked issues
 
 - [#2615][]: Release 0.16.0 preparation — open (release tracker).
-- [#2617][]: Finalize monorepo setup — 26Q2 — open (theme-folder tracker).
-- [#2659][]: Lean/shared chrome build mode — open (chrome tracker;
-  experimental).
+- [#2617][]: Finalize monorepo setup — closed 2026-07-26 as delivered
+  (milestone-gate triage); npm-publish capstone continues as [#2683][].
+- [#2659][]: Lean/shared chrome build mode — closed 2026-07-26 as delivered
+  (experimental in 0.16.0); open follow-ups spun into [#2689][] (26Q3).
+- [#2683][]: Publish theme to the npm registry as `@docsy/theme` — open (0.16.0;
+  completes at tag time).
 - [#2581][]: Upgrade Hugo from 0.157.0 to latest — closed.
 - [#2593][]: Deprecation warnings with Hugo 0.158.0 — closed.
 - [#2668][]: npm-dep modernization (Bootstrap/Font Awesome via npm) — closed
@@ -139,8 +159,8 @@ first-parent spine and the raw range are identical; every subject carries its
 - [#2631][]: Update examples page for 0.15.0 — closed.
 - [#2501][]: Release 0.15.0 preparation — closed (milestone 23).
 - [#726][]: Add golden tests — open.
-- [#2614][]: Improve support for AI-agent doc consumption — open follow-up
-  tracker (no commits in this range; phase 2+).
+- [#2614][]: Improve support for AI-agent doc consumption — open (moved to the
+  0.18.0 milestone 2026-07-26; no commits in this range).
 
 [@deining]: https://github.com/deining
 [release report]: ../../../docsy.dev/content/en/blog/2026/0.16.0.md
@@ -200,6 +220,14 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2678]: https://github.com/google/docsy/pull/2678
 [#2679]: https://github.com/google/docsy/pull/2679
 [#2680]: https://github.com/google/docsy/pull/2680
-[494f3da6]: https://github.com/google/docsy/commit/494f3da6
+[#2681]: https://github.com/google/docsy/pull/2681
+[#2682]: https://github.com/google/docsy/pull/2682
+[#2683]: https://github.com/google/docsy/issues/2683
+[#2684]: https://github.com/google/docsy/pull/2684
+[#2686]: https://github.com/google/docsy/pull/2686
+[#2687]: https://github.com/google/docsy/pull/2687
+[#2688]: https://github.com/google/docsy/pull/2688
+[#2689]: https://github.com/google/docsy/issues/2689
+[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-07-18
+lastmod: 2026-07-26
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: 494f3da6
+last-main-commit: 9b1d9951
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -231,13 +231,18 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
       Decisions. Ongoing validation is now the minimum-Hugo lane of
       `test:smoke`, run at release step 8.
 - [ ] Replace placeholders that resolve only after tagging: the
-      `releases/tag/v0.16.0` links and the changelog `UNRELEASED`
-      heading/banner.
+      `releases/tag/v0.16.0` links, the changelog `UNRELEASED` heading/banner,
+      the release post's `[CL@0.16.0]` link (`/changelog/#next` →
+      `/changelog/#v0.16.0`, since the heading anchor changes at release), and
+      its `[compare-0.15.0]` link (`v0.15.0...main` → `v0.15.0...v0.16.0`).
 - [ ] Bump the version stamp from `0.15.1-dev` to the release version in
       `package.json` and `docsy.dev` configs (`tdVersion`/`params`).
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
       (required by the theme folder move; **not yet in the maintainer notes
-      procedure** — new this release).
+      procedure** — new this release). Verify the tag exists **before** flipping
+      the posts' `draft: true`: every install-mode Action in the release post
+      depends on it, and 0.16.0 is the first release to exercise the nested-tag
+      scheme.
 - [ ] Publish `@docsy/theme@0.16.0` to the npm registry from the tagged commit
       and re-point dist-tag `next` at it, **before** the site deploy flips the
       posts live (the post's install commands must resolve). Verify with

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -195,11 +195,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   language-API section notes Page-level `.Lang` is unaffected (a textual `.Lang`
   sweep hits such uses — the otel.io review did).
 - **PostCSS section made self-explanatory** (2026-07-26): added Actions (drop
-  the toolchain vs keep it for RTL/own-config) and the rationale — modern
-  browsers largely obviate vendor prefixing, the shipped CSS targets
-  Browserslist `defaults` (policy home: [Install PostCSS][install-postcss]), and
-  against those targets the pass was verified a byte-identical no-op, so nothing
-  is lost. Decision record: thoughtry
+  the toolchain vs keep it for RTL/own-config) and the rationale (Autoprefixer
+  verified a byte-identical no-op against the shipped CSS's browser targets).
+  Decision record: thoughtry
   `projects/docsy/tasks/repo-reorg/postcss-policy.decision.md`; public trail
   [#2668][].
 
@@ -317,8 +315,6 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2689]: https://github.com/google/docsy/issues/2689
 [9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
-[install-postcss]:
-  ../../../docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
 [link-cache]: https://github.com/chalin/link-cache
 [official support policy]:
   ../../../docsy.dev/content/en/project/about/changelog.md

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,9 +1,9 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-07-18
+lastmod: 2026-07-26
 range: v0.15.0..main
-last-main-commit: 494f3da6
+last-main-commit: 9b1d9951
 cSpell:ignore: favicons retokenization thoughtry
 ---
 
@@ -11,17 +11,17 @@ Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [494f3da6][].
+> Prepared for commits in [v0.15.0...main][] through [9b1d9951][].
 
 ## Themes (with evidence and client impact)
 
 - **Theme folder move (monorepo)** — [#2641][], [#2645][]; tracker [#2617][]
-  (open). The canonical theme now lives in `theme/`, with `theme/package.json`
-  owning Bootstrap and Font Awesome and the repo root orchestrating the
-  `docsy.dev` and `theme` npm workspaces. **Breaking**: every install mode needs
-  a one-line path update (Hugo module `…/docsy/theme`; npm/clone
-  `theme: docsy/theme`), and the release must publish the nested `theme/vX.Y.Z`
-  module tag.
+  (closed 2026-07-26). The canonical theme now lives in `theme/`, with
+  `theme/package.json` owning Bootstrap and Font Awesome and the repo root
+  orchestrating the `docsy.dev` and `theme` npm workspaces. **Breaking**: every
+  install mode needs a one-line path update (Hugo module `…/docsy/theme`;
+  npm/clone `theme: docsy/theme`), and the release must publish the nested
+  `theme/vX.Y.Z` module tag.
 - **Hugo 0.158+ support** — [#2647][], [#2648][], [#2649][], [#2658][],
   [#2664][], [#2679][]; trackers [#2581][], [#2593][] (closed); goldens
   [#726][]. Theme minimum raised to 0.160.1 (language APIs 0.158.0; npm-dep
@@ -50,15 +50,26 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   clone/submodule installs unaffected (`postinstall`). The same arc made
   **PostCSS opt-in** for non-RTL sites. [#2672][] + [#2675][] reconcile the
   get-started, updating, deployment, and RTL docs.
+- **Docsy on the npm registry** — [#2684][], [#2688][]; tracker [#2683][] (open;
+  completes at tag time). The `theme/` workspace is publishable as
+  `@docsy/theme`: registry installs get the theme with Bootstrap and Font
+  Awesome as ordinary npm dependencies (no `postinstall` hack), and the install
+  docs lead Option 3 with the registry. **New** install channel, announced in
+  the release post's npm-registry section. The official-support policy was
+  recast in two-axis form (production use vs issue reports), under which an npm
+  install from GitHub (`google/docsy`) is unsupported even for a stable release.
+  `0.16.0-rc.1` rehearsed the publish under dist-tag `next`; the stable publish
+  and `next` re-point are tag-time steps (mechanics: `docsy-npm-publish` skill).
 - **Shared chrome build mode (experimental)** — [#2660][], [#2662][]; tooling
-  [#2661][]; tracker [#2659][] (open). New opt-in `td.chrome = shared` build
-  mode: Docsy emits the repeated chrome (navbar, footer, left-nav) on one donor
-  page per language and restores it in the browser via the shipped
-  `chrome-nav.js`, so one build serves both readers and link checkers. A
-  contributor/CI-experience win; the default `full` mode and production output
-  are unchanged. The large-site cached-sidebar optimization is preserved and
-  generalized — its activation moved into `chrome-nav.js`, which now ships on
-  every page. User guide: [Chrome build modes][chrome].
+  [#2661][]; tracker [#2659][] (closed 2026-07-26; open follow-ups spun into
+  [#2689][], 26Q3). New opt-in `td.chrome = shared` build mode: Docsy emits the
+  repeated chrome (navbar, footer, left-nav) on one donor page per language and
+  restores it in the browser via the shipped `chrome-nav.js`, so one build
+  serves both readers and link checkers. A contributor/CI-experience win; the
+  default `full` mode and production output are unchanged. The large-site
+  cached-sidebar optimization is preserved and generalized — its activation
+  moved into `chrome-nav.js`, which now ships on every page. User guide: [Chrome
+  build modes][chrome].
 - **Packaging, docs, and tooling cleanup** — npm workspaces, maintainer-notes
   and examples-page refreshes, a Netlify-badge URL fix, a version-doc `vv` fix,
   and test guards (Hugo deprecation probe, fixture-site tests), plus
@@ -87,13 +98,17 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 ## Release content status
 
 - [release report][] (`blog/2026/0.16.0.md`): complete draft (`draft: true`).
-  Covers the four breaking changes plus the experimental shared chrome build
-  mode, each with Actions, an upgrade section, and sanity checks. Highlights
-  refreshed in the 2026-07-16 pass (value-first phrasing; npm-dep item added).
+  Covers the four breaking changes, the npm-registry announcement, and the
+  experimental shared chrome build mode, each with Actions, an upgrade section,
+  and sanity checks. 2026-07-26 refresh: npm-registry section added; otel.io
+  guide feedback applied (postinstall caution, favicons command qualified);
+  PostCSS section gained Actions and its rationale.
 - [Hugo upgrade guide][] (`blog/2026/hugo-0.158.0+.md`): complete draft
   (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.164.0 (DRY).
+  2026-07-26: Page-level `.Lang` unaffected note added to the language-API
+  table.
 - Changelog `v0.16.0 - UNRELEASED` section: complete; reconciled with the
-  ledger.
+  ledger. 2026-07-26: npm-registry **New** entry added.
 
 ## Decisions
 
@@ -158,35 +173,52 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   **officially supported** version (the docsy.dev pin). Policy home is the
   changelog §Official support; the release post's Hugo section and the install
   prerequisites link to it rather than restating (one home per fact).
-- Defer remaining monorepo ([#2617][]) and favicon ([#2357][]) work to post-0.16
-  trackers; neither blocks the tag.
+- Defer remaining favicon work ([#2357][], 26Q3); it doesn't block the tag. (The
+  monorepo tracker [#2617][], originally deferred alongside it, instead closed
+  as delivered at the 2026-07-26 gate — its npm-publish capstone [#2683][] ships
+  with this release.)
+- **Routed the npm-registry announcement** (2026-07-26, npm-publish plan step
+  4): a NEW release-post section completing the packaging cluster (theme folder
+  → npm deps → registry), with a switch Action for GitHub-npm installs; the
+  support-status delta links the [official support policy][] rather than
+  restating it, and the policy rewrite itself shipped with [#2688][] (routed
+  then). The changelog carries one **New** entry citing [#2683][]. Highlights
+  card: the registry claim joins the merged **Packaging modernization** entry —
+  the three-item cap holds.
+- **Applied the otel.io guide feedback** (2026-07-26; from exercising the posts
+  over opentelemetry.io, [otel#10906][]): clone/submodule Actions warn that a
+  plain `npm install` inside `themes/docsy/` pulls the maintainer workspaces
+  (~1.5 GB) where `npm run postinstall` installs only theme runtime deps (~34
+  MB); the favicons helper command is qualified as npm-package-install specific,
+  deferring per-mode commands to [Add your favicons][]; the Hugo guide's
+  language-API section notes Page-level `.Lang` is unaffected (a textual `.Lang`
+  sweep hits such uses — the otel.io review did).
+- **PostCSS section made self-explanatory** (2026-07-26): added Actions (drop
+  the toolchain vs keep it for RTL/own-config) and the rationale — modern
+  browsers largely obviate vendor prefixing, the shipped CSS targets
+  Browserslist `defaults` (policy home: [Install PostCSS][install-postcss]), and
+  against those targets the pass was verified a byte-identical no-op, so nothing
+  is lost. Decision record: thoughtry
+  `projects/docsy/tasks/repo-reorg/postcss-policy.decision.md`; public trail
+  [#2668][].
 
 ## Milestone 24 hygiene
 
-Hygiene review of [milestone #24][milestone] ahead of tagging (issues only). As
-of this pass (2026-07-16): **7 open**, **7 closed**.
+The 0.16.0 gate closed at the **2026-07-26 milestone-gate triage**
+(`docsy-milestone-triage` pass; record: thoughtry
+`projects/docsy/tasks/v0.16.0/`). [Milestone #24][milestone] now holds **2
+open**, 9 closed. Open by design:
 
-Closed (shipped in 0.16): [#2595][] (favicons), [#2593][] (Hugo deprecations),
-[#2581][] (Hugo upgrade), [#2598][] (Netlify badge), [#2431][] (predecessor of
-[#2581][]), [#2668][] (npm-dep modernization). Closed as not planned: [#2657][]
-(page-meta URL marker; Lychee's URL-pattern excludes cover those links without a
-marker).
+- [#2615][]: release tracker — closes when 0.16.0 ships.
+- [#2683][]: npm publish — the stable publish is a tag-time step.
 
-Open — disposition before/at release:
+Everything else is closed as shipped ([#2617][] monorepo and [#2659][] chrome
+closed 2026-07-26 with the chrome follow-ups spun into [#2689][]) or moved:
+[#2554][], [#2403][], [#1987][] → 0.17.0 (due 2026-08-31); [#2614][] → 0.18.0
+(due 2026-09-30) — both milestones created at the triage.
 
-| Issue                                                 | Type        | In 0.16?      | Action                                  |
-| ----------------------------------------------------- | ----------- | ------------- | --------------------------------------- |
-| [#2615][]: Release 0.16.0 preparation                 | tracker     | n/a           | Keep; close when 0.16.0 is tagged.      |
-| [#2617][]: Finalize monorepo setup — 26Q2             | tracker     | partial (TOF) | Keep open; remaining cleanup post-0.16. |
-| [#2659][]: Experimental `shared` chrome build mode    | tracker     | yes (exp.)    | Keep open; feature continues post-0.16. |
-| [#2614][]: AI-agent doc consumption                   | tracker     | no (phase 2+) | Move off the 0.16 milestone.            |
-| [#2554][]: Use 'note' role instead of 'alert'         | enhancement | no            | Reassign to a later milestone.          |
-| [#2403][]: View-page URL should use `blob` not `tree` | bug         | no            | Reassign to a later milestone.          |
-| [#1987][]: i18n for dark-mode menu button             | enhancement | no            | Reassign to a later milestone.          |
-
-Before tagging, every milestone-24 issue except the release tracker [#2615][]
-should be **closed** (shipped) or **moved** to a later milestone. Confirm the
-milestone's closed list matches the [coverage ledger](coverage.md).
+Before tagging, confirm the milestone's closed list matches the
+[coverage ledger](coverage.md).
 
 ## Tag-time checklist
 
@@ -206,16 +238,24 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
       (required by the theme folder move; **not yet in the maintainer notes
       procedure** — new this release).
+- [ ] Publish `@docsy/theme@0.16.0` to the npm registry from the tagged commit
+      and re-point dist-tag `next` at it, **before** the site deploy flips the
+      posts live (the post's install commands must resolve). Verify with
+      `npm run test:smoke`. Also new this release; mechanics:
+      `docsy-npm-publish` skill, tracker [#2683][] (close it here).
 - [ ] Milestone hygiene: close or move all milestone-24 issues except [#2615][].
+      Trued up at the 2026-07-26 gate — only [#2683][] also remains, closing
+      with the npm publish above; see Milestone 24 hygiene.
 - [ ] Post-release: refresh `docsy-example` and the examples page for 0.16.0.
       (Its Hugo floor is handled early by [docsy-example#478][], since the site
       tracks Docsy main, where npm-dep installs already require 0.160.1.)
 
 ## Post-release / deferred
 
-- Remaining monorepo cleanup: [#2617][].
+- Shared-chrome follow-ups (navbar pagelinks, non-docs sections, CCR-10):
+  [#2689][] (26Q3).
 - Favicon light/dark and further polish: [#2357][] (26Q3).
-- AI-agent doc consumption phase 2+: [#2614][].
+- AI-agent doc consumption phase 2+: [#2614][] (0.18.0).
 
 ## References
 
@@ -236,14 +276,12 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#1987]: https://github.com/google/docsy/issues/1987
 [#2357]: https://github.com/google/docsy/issues/2357
 [#2403]: https://github.com/google/docsy/issues/2403
-[#2431]: https://github.com/google/docsy/issues/2431
 [#2554]: https://github.com/google/docsy/issues/2554
 [#2578]: https://github.com/google/docsy/pull/2578
 [#2581]: https://github.com/google/docsy/issues/2581
 [#2593]: https://github.com/google/docsy/issues/2593
 [#2594]: https://github.com/google/docsy/pull/2594
 [#2595]: https://github.com/google/docsy/issues/2595
-[#2598]: https://github.com/google/docsy/issues/2598
 [#2614]: https://github.com/google/docsy/issues/2614
 [#2615]: https://github.com/google/docsy/issues/2615
 [#2617]: https://github.com/google/docsy/issues/2617
@@ -256,7 +294,6 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2653]: https://github.com/google/docsy/pull/2653
 [#2654]: https://github.com/google/docsy/pull/2654
 [#2656]: https://github.com/google/docsy/pull/2656
-[#2657]: https://github.com/google/docsy/issues/2657
 [#2658]: https://github.com/google/docsy/pull/2658
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2660]: https://github.com/google/docsy/pull/2660
@@ -273,7 +310,16 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2678]: https://github.com/google/docsy/pull/2678
 [#2679]: https://github.com/google/docsy/pull/2679
 [#2680]: https://github.com/google/docsy/pull/2680
-[494f3da6]: https://github.com/google/docsy/commit/494f3da6
+[#2683]: https://github.com/google/docsy/issues/2683
+[#2684]: https://github.com/google/docsy/pull/2684
+[#2688]: https://github.com/google/docsy/pull/2688
+[#2689]: https://github.com/google/docsy/issues/2689
+[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
+[install-postcss]:
+  ../../../docsy.dev/content/en/docs/get-started/installation-prerequisites.md
 [link-cache]: https://github.com/chalin/link-cache
+[official support policy]:
+  ../../../docsy.dev/content/en/project/about/changelog.md
+[otel#10906]: https://github.com/open-telemetry/opentelemetry.io/pull/10906
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -97,9 +97,6 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
 ## Release content status
 
-> [!NOTE] Next edit round: bump both posts' `lastmod` (still 2026-07-26; the
-> 07-27 review rounds didn't restamp them).
-
 - [release report][] (`blog/2026/0.16.0.md`): complete draft (`draft: true`).
   Covers the four breaking changes, the npm-registry announcement, and the
   experimental shared chrome build mode, each with Actions, an upgrade section,

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -318,7 +318,7 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [install-postcss]:
-  ../../../docsy.dev/content/en/docs/get-started/installation-prerequisites.md
+  ../../../docsy.dev/content/en/docs/get-started/docsy-as-module/installation-prerequisites.md
 [link-cache]: https://github.com/chalin/link-cache
 [official support policy]:
   ../../../docsy.dev/content/en/project/about/changelog.md

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -119,12 +119,12 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   [#2357][] in What's next); the changelog cites key issues, keeping PR links
   only for contributor credit ([#2594][], [#2578][]). The ledger remains the
   internal full-coverage record.
-- The highlights card is capped at **three items** (2026-07-16): a merged
-  **Packaging modernization** entry (theme folder move + npm-sourced deps, title
-  linking `#theme-folder` with an inline link to `#npm-deps`), favicons, and
-  shared chrome. The minimum-Hugo bump is deliberately not in the card: it is
-  routine (0.15 did the same), has its own section plus the companion Hugo
-  guide, and Ready-to-Upgrade lists every breaking change anyway.
+- The highlights card is capped at **three items** (2026-07-16): a packaging
+  entry (**First-class npm support** since the 2026-07-26 rework -- see the
+  routing decision below), favicons, and shared chrome. The minimum-Hugo bump is
+  deliberately not in the card: it is routine (0.15 did the same), has its own
+  section plus the companion Hugo guide, and Ready-to-Upgrade lists every
+  breaking change anyway.
 - The four breaking changes for 0.16 are the theme folder move, the minimum-Hugo
   bump, default-favicon removal, and npm-sourced Bootstrap/Font Awesome
   ([#2670][], added in the 2026-07-16 refresh). The headline **new** feature is
@@ -183,8 +183,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   support-status delta links the [official support policy][] rather than
   restating it, and the policy rewrite itself shipped with [#2688][] (routed
   then). The changelog carries one **New** entry citing [#2683][]. Highlights
-  card: the registry claim joins the merged **Packaging modernization** entry —
-  the three-item cap holds.
+  card: the packaging entry now leads with the npm story — **First-class npm
+  support**, title linking `#npm-registry`, with the theme-folder move swept
+  into "and more" (owner call, 2026-07-26) — the three-item cap holds.
 - **Applied the otel.io guide feedback** (2026-07-26; from exercising the posts
   over opentelemetry.io, [otel#10906][]): clone/submodule Actions warn that a
   plain `npm install` inside `themes/docsy/` pulls the maintainer workspaces

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -97,6 +97,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
 ## Release content status
 
+> [!NOTE] Next edit round: bump both posts' `lastmod` (still 2026-07-26; the
+> 07-27 review rounds didn't restamp them).
+
 - [release report][] (`blog/2026/0.16.0.md`): complete draft (`draft: true`).
   Covers the four breaking changes, the npm-registry announcement, and the
   experimental shared chrome build mode, each with Actions, an upgrade section,

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -189,8 +189,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 - **Applied the otel.io guide feedback** (2026-07-26; from exercising the posts
   over opentelemetry.io, [otel#10906][]): clone/submodule Actions warn that a
   plain `npm install` inside `themes/docsy/` pulls the maintainer workspaces
-  (~1.5 GB) where `npm run postinstall` installs only theme runtime deps (~34
-  MB); the favicons helper command is qualified as npm-package-install specific,
+  where `npm run postinstall` installs only theme runtime deps (caution homed in
+  the docs, [Other installation options][], order-of-magnitude phrasing); the
+  favicons helper command is qualified as npm-package-install specific,
   deferring per-mode commands to [Add your favicons][]; the Hugo guide's
   language-API section notes Page-level `.Lang` is unaffected (a textual `.Lang`
   sweep hits such uses — the otel.io review did).
@@ -269,6 +270,8 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [Add your favicons]: ../../../docsy.dev/content/en/docs/content/iconsimages.md
 [chrome]: ../../../docsy.dev/content/en/docs/deployment/chrome.md
 [maint-notes]: ../../../docsy.dev/content/en/project/about/maintainer-notes.md
+[Other installation options]:
+  ../../../docsy.dev/content/en/docs/get-started/other-options.md
 [pub-rel]:
   ../../../docsy.dev/content/en/project/about/maintainer-notes.md#publishing-a-release
 [#726]: https://github.com/google/docsy/issues/726

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.15.1-dev+044-over-main-2b0fba2f",
+  "version": "0.15.1-dev+045-over-main-9b1d9951",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Contributes to #2615
- Refreshes the 0.16.0 release artifacts and prep workspace through 9b1d9951 (the six commits since the last refresh):
  - **npm-registry announcement** (npm-publish plan step 4; tracker #2683): new release-post section with Actions for GitHub-npm installs; one changelog **New** entry; packaging-story mentions trued up. Support-status delta links the official support policy rather than restating it.
  - **Highlights card rework**: the packaging entry now leads with the npm story — **First-class npm support**: install Docsy from the registry, and more.
  - **Guide feedback applied**, from exercising the posts over an opentelemetry.io upgrade: a postinstall-not-`npm install` caution, homed in *Other installation options* (order-of-magnitude size comparison) with a slimmed point-of-action WARNING in the clone/submodule Actions; favicons helper command qualified per install mode; Hugo guide notes Page-level `.Lang` is unaffected by the `.Language.Lang` deprecation.
  - **PostCSS section** gains Actions and the nothing-is-lost rationale (prefixing largely obviated; the non-RTL pass was a verified byte-identical no-op).
  - **Workspace true-up**: ledger +6 rows (44 total); wrapup reflects the 2026-07-26 milestone gate (2 open: #2615, #2683) and adds the npm-publish tag-time step.
  - **Review follow-ups**: package build-ID refresh (045-over-main-9b1d9951), DRY pass over the new sections (registry setup mechanics live in the linked Option 3 docs).
- **Preview(s)**:
  - [0.16.0 release post § Docsy on the npm registry](https://deploy-preview-2690--docsydocs.netlify.app/blog/2026/0.16.0/#npm-registry) (and [§ PostCSS](https://deploy-preview-2690--docsydocs.netlify.app/blog/2026/0.16.0/#postcss))
  - [Hugo upgrade guide § Language APIs](https://deploy-preview-2690--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/#language-apis)
  - [Changelog § v0.16.0](https://deploy-preview-2690--docsydocs.netlify.app/project/about/changelog/#next)