### PR TITLE
Release 0.16.0 preparation

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -11,9 +11,9 @@
 #   status: archived # Then fetch include
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -1,9 +1,9 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -1,9 +1,9 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -63,10 +63,8 @@ session (Linux and macOS).
 
 > [!IMPORTANT]
 >
-> For upgrades to [0.16.0][] or later, use the [Update Docsy](/docs/update/)
-> procedure.
-
-[0.16.0]: /blog/2026/0.16.0/
+> For upgrades to [0.16.0](/blog/2026/0.16.0/) or later, use the
+> [Update Docsy](/docs/update/) procedure.
 
 - If using NPM:
 

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -66,10 +66,7 @@ session (Linux and macOS).
 > For upgrades to [0.16.0][] or later, use the [Update Docsy](/docs/update/)
 > procedure.
 
-<!-- TODO(tag-time): once the 0.16.0 post publishes, re-point this link to
-     /blog/2026/0.16.0/; see the release-prep wrapup checklist. -->
-
-[0.16.0]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/
+[0.16.0]: /blog/2026/0.16.0/
 
 - If using NPM:
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -1,9 +1,8 @@
 ---
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
-date: 2026-06-15
-lastmod: 2026-07-28
-draft: true
+date: 2026-07-29
+lastmod: 2026-07-29
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the new
   @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and
@@ -517,8 +516,8 @@ About this release:
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [check]: /docs/update/#check
 [chrome]: /docs/deployment/chrome/
-[CL@0.16.0]: /project/about/changelog/#next
-[compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
+[CL@0.16.0]: /project/about/changelog/#v0.16.0
+[compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...v0.16.0
 [Docsy as an NPM package]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 [docsy-example]: https://github.com/google/docsy-example
 [experimental]: /project/about/changelog/#experimental

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,7 +1,7 @@
 ---
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
-date: 2026-07-29
+date: 2026-07-28
 lastmod: 2026-07-29
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,9 +1,8 @@
 ---
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
-date: 2026-06-14
-lastmod: 2026-07-28
-draft: true
+date: 2026-07-29
+lastmod: 2026-07-29
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -211,12 +211,8 @@ from scratch as it provides defaults for many required configuration parameters.
   [Examples and templates](/examples/).
 - [Publish your site](/docs/deployment/).
 
-<!-- TODO(tag-time): re-point the preview-host (main--) link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
-[blog-npm-deps]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#npm-deps
+[blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [configuration file]: https://gohugo.io/configuration/introduction/#configuration-file
 [Troubleshooting]: /docs/get-started/troubleshooting/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -112,15 +112,11 @@ Use this checklist as a guide to verify that your update succeeded:
 Also perform any release-specific checks listed in the release's
 [upgrade blog post](/tags/upgrade/).
 
-<!-- TODO(tag-time): re-point the preview-host (main--) tfa link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
 [Heading self-links]: /docs/content/navigation/#heading-self-links
 [hugo-extended]: /docs/get-started/other-options/#hugo-extended-npm
 [hugo-override]: https://gohugo.io/getting-started/directory-structure/#theme-skeleton
 [lookandfeel]: /docs/content/lookandfeel/#project-style-files
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
-[tfa]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#theme-folder-actions
+[tfa]: /blog/2026/0.16.0/#theme-folder-actions
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/update/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/update/convert-site-to-module.md
@@ -244,10 +244,6 @@ git commit -m "Removed docsy git submodule"
 > Be careful when using the `rm -rf` command, make sure that you don't
 > inadvertently delete any productive data files!
 
-<!-- TODO(tag-time): re-point the preview-host (main--) link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
-[blog-npm-deps]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#npm-deps
+[blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,9 +141,7 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
-## v0.16.0 - UNRELEASED {#next}
-
-> **UNRELEASED: this planned version is still under development**
+## v0.16.0 {#v0.16.0}
 
 For an introduction to this release, see the [0.16.0 release report][]. For
 Hugo-specific notes, see the [Hugo 0.158+ upgrade guide][]. For the full list of
@@ -237,7 +235,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [0.16.0]: https://github.com/google/docsy/releases/tag/v0.16.0
 [chrome]: /docs/deployment/chrome/
 [favicons]: /docs/content/iconsimages/#add-your-favicons
-[git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
+[git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...v0.16.0
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
 [hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -38,6 +38,7 @@ exclude = [
   # Remove after 0.16.0 ships: the release tag and the version dropdown's
   # "latest" links to pages new/draft in this cycle (absent on v0.15.0 prod).
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.16\.0$',
+  '^https://github\.com/google/docsy/compare/v0\.15\.0\.\.\.v0\.16\.0$',
   '^https://www\.docsy\.dev/docs/deployment/chrome/$',
   '^https://www\.docsy\.dev/blog/2026/0\.16\.0/$',
   '^https://www\.docsy\.dev/blog/2026/hugo-0\.158\.0\+/$',

--- a/docsy.dev/tests/md-output/goldens/docs/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/index.md
@@ -6,10 +6,10 @@ LLMS index: [llms.txt](/llms.txt)
 
 <!-- markdownlint-disable-next-line no-space-in-links -->
 
-<span class="badge bg-primary text-bg-primary fs-6">v0.15.1-dev
+<span class="badge bg-primary text-bg-primary fs-6">v0.16.1-dev
 </span>
 
-Welcome to the Docsy theme user guide for version `v0.15.1-dev`. This
+Welcome to the Docsy theme user guide for version `v0.16.1-dev`. This
 guide shows you how to get started creating technical documentation sites using
 Docsy, including site customization and how to use Docsy's blocks and templates.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+046-over-main-7b2117a9",
+  "version": "0.16.0",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,18 +1,18 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 range: v0.15.0..main
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[9b1d9951][], mapped to where each is covered. This is the objective "is
+[69e597cc][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 44 commits in range are squash-merged PRs (one commit per PR), so the
+All 46 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -74,6 +74,8 @@ first-parent spine and the raw range are identical; every subject carries its
 | `848374ee` [#2686][] | —         | docsy.dev: run link-check bins directly         | tool  | N/A  | N/A  | N/A  | N/A  | npm-squat hygiene: no bare `npx BIN`         |
 | `2b0fba2f` [#2687][] | —         | docsy.dev: link-cache from the npm registry     | tool  | N/A  | N/A  | N/A  | N/A  | devDependency source switch only             |
 | `9b1d9951` [#2688][] | [#2683][] | Registry install first-class; support policy    | docs  | done | done | done | N/A  | Option 3 registry-lead; two-axis policy      |
+| `7b2117a9` [#2690][] | [#2615][] | Refresh 0.16.0 release artifacts thru 9b1d9951  | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts themselves             |
+| `69e597cc` [#2692][] | [#2615][] | Evergreen home for generic update procedure     | docs  | done | N/A  | done | N/A  | `/docs/update/`; 0.16.0 post repointed in-PR |
 
 ## Notes on bundled changes
 
@@ -228,6 +230,8 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2687]: https://github.com/google/docsy/pull/2687
 [#2688]: https://github.com/google/docsy/pull/2688
 [#2689]: https://github.com/google/docsy/issues/2689
-[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
+[#2690]: https://github.com/google/docsy/pull/2690
+[#2692]: https://github.com/google/docsy/pull/2692
+[69e597cc]: https://github.com/google/docsy/commit/69e597cc
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -238,24 +238,24 @@ Before tagging, confirm the milestone's closed list matches the
 The canonical procedure is maintainer notes, [Publishing a release][pub-rel];
 this tracks 0.16-specific status and deltas, not the full mechanics.
 
-- [ ] Flip `draft: true` → `false` on both blog posts and set their final dates.
+- [x] Flip `draft: true` → `false` on both blog posts and set their final dates.
 - [x] Validate the theme's minimum Hugo version: done 2026-07-17 via a one-off
       fixture-matrix build on 0.158.0/0.159.0; minimum raised to 0.160.1 — see
       Decisions. Ongoing validation is now the minimum-Hugo lane of
       `test:smoke`, run at release step 8.
-- [ ] Replace placeholders that resolve only after tagging: the
+- [x] Replace placeholders that resolve only after tagging: the
       `releases/tag/v0.16.0` links, the changelog `UNRELEASED` heading/banner,
       the release post's `[CL@0.16.0]` link (`/changelog/#next` →
       `/changelog/#v0.16.0`, since the heading anchor changes at release), and
       its `[compare-0.15.0]` link (`v0.15.0...main` → `v0.15.0...v0.16.0`).
-- [ ] Re-point the interim preview-host (`main--docsydocs.netlify.app`) links at
+- [x] Re-point the interim preview-host (`main--docsydocs.netlify.app`) links at
       the production `/blog/2026/0.16.0/` URLs once the post publishes: the
       `[0.16.0]` link def in `blog/2025/0.12.0.md`, the `[tfa]` link def in
       `docs/update/_index.md`, and the `[blog-npm-deps]` link defs in
       `docs/update/convert-site-to-module.md` and
       `docs/get-started/docsy-as-module/start-from-scratch.md` (each site
       carries a `TODO(tag-time)` comment; from [#2692][]).
-- [ ] Bump the version stamp from `0.15.1-dev` to the release version in
+- [x] Bump the version stamp from `0.15.1-dev` to the release version in
       `package.json` and `docsy.dev` configs (`tdVersion`/`params`).
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
       (required by the theme folder move; **not yet in the maintainer notes

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,9 +1,9 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 range: v0.15.0..main
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 cSpell:ignore: favicons retokenization thoughtry
 ---
 
@@ -11,7 +11,7 @@ Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [9b1d9951][].
+> Prepared for commits in [v0.15.0...main][] through [69e597cc][].
 
 ## Themes (with evidence and client impact)
 
@@ -346,7 +346,7 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2688]: https://github.com/google/docsy/pull/2688
 [#2689]: https://github.com/google/docsy/issues/2689
 [#2692]: https://github.com/google/docsy/pull/2692
-[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
+[69e597cc]: https://github.com/google/docsy/commit/69e597cc
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [link-cache]: https://github.com/chalin/link-cache
 [official support policy]:

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -238,6 +238,9 @@ Before tagging, confirm the milestone's closed list matches the
 The canonical procedure is maintainer notes, [Publishing a release][pub-rel];
 this tracks 0.16-specific status and deltas, not the full mechanics.
 
+- [x] Refresh-loop gate: the ledger and coordinates are current through the tip
+      the release commit builds on (`last-main-commit: 69e597cc`; refreshed
+      2026-07-29 — see the skill's tag-time gate).
 - [x] Flip `draft: true` → `false` on both blog posts and set their final dates.
 - [x] Validate the theme's minimum Hugo version: done 2026-07-17 via a one-off
       fixture-matrix build on 0.158.0/0.159.0; minimum raised to 0.160.1 — see

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.15.1-dev+046-over-main-7b2117a9",
+  "version": "0.16.0",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Contributes to #2615
- **Undrafts the 0.16.0 release post and the Hugo 0.158+ upgrade guide** (final dates set), flips the changelog `UNRELEASED` heading to `v0.16.0`, and re-points the tag-dependent links (`compare`, changelog anchor)
- **Re-points the interim preview-host links** from #2692 at the production post URL (the four `TODO(tag-time)` sites)
- **Bumps the version stamp** to 0.16.0 (`set:version`: root + theme manifests, docsy.dev configs)
- Note: the link check reports 404s on the one `v0.15.0...v0.16.0` compare URL, which resolves once the tag is pushed; everything else is green (smoke suite 6/6 against this branch)
- **Previews**:
  - [Release 0.16.0 report](https://deploy-preview-2693--docsydocs.netlify.app/blog/2026/0.16.0/)
  - [Hugo 0.158+ upgrade guide](https://deploy-preview-2693--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/)
  - [Changelog](https://deploy-preview-2693--docsydocs.netlify.app/project/about/changelog/)
