### PR TITLE
Release 0.16.0 preparation

### DIFF
--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -11,9 +11,9 @@
 #   status: archived # Then fetch include
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -1,9 +1,9 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -1,9 +1,9 @@
 # cSpell:ignore pagelinks
 
 tdVersion:
-  latest: &tdLatestVers v0.15.0
-  dev: &tdDevVers v0.15.1-dev
-  buildId: &tdBuildId 046-over-main-7b2117a9
+  latest: &tdLatestVers v0.16.0
+  dev: &tdDevVers v0.16.1-dev
+  buildId: &tdBuildId ''
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -63,10 +63,8 @@ session (Linux and macOS).
 
 > [!IMPORTANT]
 >
-> For upgrades to [0.16.0][] or later, use the [Update Docsy](/docs/update/)
-> procedure.
-
-[0.16.0]: /blog/2026/0.16.0/
+> For upgrades to [0.16.0](/blog/2026/0.16.0/) or later, use the
+> [Update Docsy](/docs/update/) procedure.
 
 - If using NPM:
 

--- a/docsy.dev/content/en/blog/2025/0.12.0.md
+++ b/docsy.dev/content/en/blog/2025/0.12.0.md
@@ -66,10 +66,7 @@ session (Linux and macOS).
 > For upgrades to [0.16.0][] or later, use the [Update Docsy](/docs/update/)
 > procedure.
 
-<!-- TODO(tag-time): once the 0.16.0 post publishes, re-point this link to
-     /blog/2026/0.16.0/; see the release-prep wrapup checklist. -->
-
-[0.16.0]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/
+[0.16.0]: /blog/2026/0.16.0/
 
 - If using NPM:
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -85,7 +85,7 @@ and release automation out of the theme's way.
 
 The version-update commands below run at their place in the [order of steps][]
 -- after any Node and Hugo updates. Set `VERSION` to the Docsy version you want
-to install:
+to install in a manner compatible with your shell, for example:
 
 ```sh
 VERSION=v0.16.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -218,7 +218,7 @@ of Docsy's [official support policy][].
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Bootstrap and Font Awesome via npm {#npm-deps}
 
 **Applies to Hugo-module installs**, which need one new upgrade step. Sites that
-install Docsy from GitHub with npm, or via clone or submodule, are unaffected —
+install Docsy from GitHub with npm, or via clone or submodule, are unaffected --
 they continue to get Bootstrap and Font Awesome through Docsy's `postinstall`.
 
 Docsy now sources Bootstrap and Font Awesome from npm rather than importing each

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -52,6 +52,7 @@ cSpell:ignore: CatmullRom favicons TOF
 
 ## Ready to upgrade? <a id="breaking-changes"></a>
 
+- :warning: Respect the [order of steps][]: Node and Hugo before the theme.
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} [Theme folder move](#theme-folder)
   - {{% _param BREAKING %}} [Minimum Hugo version](#hugo)
@@ -59,7 +60,6 @@ cSpell:ignore: CatmullRom favicons TOF
   - {{% _param BREAKING %}} [Bootstrap and Font Awesome via npm](#npm-deps)
 - Review the companion [Hugo 0.158+ upgrade guide][hugo-upgrade] if your site is
   not already building cleanly with Hugo {{% param hugoSupportedVersion %}}.
-  Recommended order: upgrade Hugo first, then apply the Docsy changes below.
 - Optionally skim:
   - {{% _param NEW %}} [Docsy on the npm registry](#npm-registry)
   - {{% _param NEW %}} [Favicon discovery](#favicons)
@@ -425,6 +425,15 @@ committed link cache for fast, reproducible checks.
 
 Follow [Update Docsy][] and as you do:
 
+{{< comment >}}
+
+Getting the upgrade order wrong can break the upgrade process. So we repeat the
+warning from [Breaking changes](#breaking-changes) here, in case a reader
+"jumped in" directly to this section.
+
+{{< /comment >}}
+
+- :warning: Respect the [order of steps][]: Node and Hugo before the theme.
 - Apply the config changes from this release's
   [theme folder move](#theme-folder-actions); the Update Docsy pages already
   show the post-move install paths.
@@ -519,6 +528,7 @@ About this release:
 [more]: #theme-folder
 [official support policy]: /project/about/changelog/#official-support
 [Other installation options]: /docs/get-started/other-options/
+[order of steps]: /docs/update/#update-order
 [overrides]: /docs/update/#update-overrides
 [Update Docsy]: /docs/update/
 [update-hugo]: /docs/update/#update-hugo

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -117,7 +117,7 @@ You still request the plain release version. To verify the update, confirm that
 your site's `go.mod` now records `github.com/google/docsy/theme` at the version
 you requested.
 
-#### GitHub NPM package sites {#npm-sites}
+#### GitHub npm installs {#npm-sites}
 
 {{% _param BREAKING %}} **Applies if** your site installs Docsy from GitHub with
 npm.
@@ -525,7 +525,7 @@ About this release:
 [hugo-npm-pack]: https://gohugo.io/hugo-modules/nodejs-dependencies/
 [Install PostCSS]: /docs/get-started/docsy-as-module/installation-prerequisites/#install-postcss
 [Lychee]: https://github.com/lycheeverse/lychee
-[more]: #theme-folder
+[more]: #npm-deps
 [official support policy]: /project/about/changelog/#official-support
 [Other installation options]: /docs/get-started/other-options/
 [order of steps]: /docs/update/#update-order

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -84,8 +84,12 @@ and release automation out of the theme's way.
 ### Actions {#theme-folder-actions}
 
 The version-update commands below run at their place in the [order of steps][]
--- after any Node and Hugo updates. Replace _`VERSION`_ with the Docsy version
-you want to install, for example `v0.16.0`.
+-- after any Node and Hugo updates. Set `VERSION` to the Docsy version you want
+to install:
+
+```sh
+VERSION=v0.16.0
+```
 
 #### Hugo module sites
 
@@ -109,7 +113,7 @@ module:
 Then update the module:
 
 ```sh
-hugo mod get github.com/google/docsy/theme@VERSION
+hugo mod get github.com/google/docsy/theme@$VERSION
 hugo mod tidy
 ```
 
@@ -142,7 +146,7 @@ themesDir: node_modules
 The install command shape is otherwise unchanged:
 
 ```sh
-npm install --save-dev google/docsy#semver:VERSION
+npm install --save-dev google/docsy#semver:$VERSION
 ```
 
 #### Git clone or Git submodule sites {#clone-submodule-sites}
@@ -160,11 +164,11 @@ theme: docsy
 theme: docsy/theme
 ```
 
-Then update your clone or submodule to _`VERSION`_ using your existing update
+Then update your clone or submodule to `$VERSION` using your existing update
 workflow -- for example, for a submodule:
 
 ```sh
-git -C themes/docsy fetch --tags && git -C themes/docsy checkout VERSION
+git -C themes/docsy fetch --tags && git -C themes/docsy checkout $VERSION
 ```
 
 Then re-run the theme's install step from inside `themes/docsy/`:

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -1,9 +1,8 @@
 ---
 title: Release 0.16.0 report and upgrade guide
 linkTitle: Release 0.16.0
-date: 2026-06-15
-lastmod: 2026-07-28
-draft: true
+date: 2026-07-29
+lastmod: 2026-07-29
 description: >-
   Release report and upgrade guide for Docsy 0.16.0, covering the new
   @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and
@@ -517,8 +516,8 @@ About this release:
 [Add your favicons]: /docs/content/iconsimages/#add-your-favicons
 [check]: /docs/update/#check
 [chrome]: /docs/deployment/chrome/
-[CL@0.16.0]: /project/about/changelog/#next
-[compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
+[CL@0.16.0]: /project/about/changelog/#v0.16.0
+[compare-0.15.0]: https://github.com/google/docsy/compare/v0.15.0...v0.16.0
 [Docsy as an NPM package]: /docs/get-started/other-options/#option-3-docsy-as-an-npm-package
 [docsy-example]: https://github.com/google/docsy-example
 [experimental]: /project/about/changelog/#experimental

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -4,9 +4,9 @@ linkTitle: Release 0.16.0
 date: 2026-07-29
 lastmod: 2026-07-29
 description: >-
-  Release report and upgrade guide for Docsy 0.16.0, covering the new
-  @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and
-  favicon discovery
+  Docsy is now on npm as @docsy/theme. This release also moves the theme into
+  theme/, raises the Hugo minimum, and swaps default favicons for automatic
+  discovery — each with upgrade actions.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -76,7 +76,7 @@ Docsy's canonical theme tree has moved from the repository root to `theme/`.
 This is the main structural change in 0.16.0.
 
 For most sites, the upgrade is intentionally small: update the place where Hugo
-looks for the theme. The exact edit depends on how your site installs Docsy.
+looks for the theme.
 
 This keeps the installable theme surface lean, with maintainer tooling, tests,
 and release automation out of the theme's way.
@@ -112,10 +112,9 @@ hugo mod get github.com/google/docsy/theme@VERSION
 hugo mod tidy
 ```
 
-You still request the plain release version; each release also creates the
-matching nested Hugo module tag, such as `theme/v0.16.0`. To verify the update,
-confirm that your site's `go.mod` now records `github.com/google/docsy/theme` at
-the version you requested.
+You still request the plain release version. To verify the update, confirm that
+your site's `go.mod` now records `github.com/google/docsy/theme` at the version
+you requested.
 
 #### GitHub NPM package sites {#npm-sites}
 
@@ -193,18 +192,12 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
   versions the pack step exits successfully but writes empty dependency lists,
   so the failure surfaces only later, as a hard-to-trace SCSS import error —
   Hugo's minimum-version warning is the only early signal.
-- **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range,
-  such as Markdown-link escaping, and passthrough and shortcode rendering.
-
-Sites building with an older Hugo version must upgrade Hugo before or while
-upgrading Docsy.
+- **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range.
 
 The Docsy project build and example site are validated with **Hugo
-{{% param hugoSupportedVersion %}}**. We recommend moving directly to
-{{% param hugoSupportedVersion %}} unless your project has a reason to pin a
-lower version. For the detailed Hugo changes between 0.158.0 and
-{{% param hugoSupportedVersion %}}, see the companion [Hugo 0.158+ upgrade
-guide][hugo-upgrade].
+{{% param hugoSupportedVersion %}}**. For the detailed Hugo changes between
+0.158.0 and {{% param hugoSupportedVersion %}}, see the companion [Hugo 0.158+
+upgrade guide][hugo-upgrade].
 
 This distinction — the **minimum** Hugo version versus the **officially
 supported** version that the project pins and tests — is now documented as part
@@ -224,10 +217,9 @@ of Docsy's [official support policy][].
 
 ## {{% _param BREAKING %}} / {{% _param CLEANUP %}} Bootstrap and Font Awesome via npm {#npm-deps}
 
-**Applies to Hugo-module installs**, which need one new upgrade step (see
-[Actions](#npm-deps-actions)). Sites that install Docsy from GitHub with npm, or
-via clone or submodule, are unaffected — they continue to get Bootstrap and Font
-Awesome through Docsy's `postinstall`.
+**Applies to Hugo-module installs**, which need one new upgrade step. Sites that
+install Docsy from GitHub with npm, or via clone or submodule, are unaffected —
+they continue to get Bootstrap and Font Awesome through Docsy's `postinstall`.
 
 Docsy now sources Bootstrap and Font Awesome from npm rather than importing each
 project's GitHub repository as a Hugo module. Those imports were a workaround,
@@ -297,9 +289,8 @@ see the [official support policy][].
 ## {{% _param CLEANUP %}} PostCSS is opt-in for non-RTL sites {#postcss}
 
 Docsy now runs `postCSS` only for sites with RTL languages (which need it for
-`rtlcss`, a PostCSS plugin) or that provide a project-root
-`postcss.config.{js,mjs,cjs}`. Other sites no longer need a PostCSS toolchain at
-all.
+`rtlcss`, a PostCSS plugin) or that provide their own PostCSS config. Other
+sites no longer need a PostCSS toolchain at all.
 
 Nothing is lost in dropping the pass: its only job on non-RTL CSS was
 Autoprefixer, and modern browsers have largely obviated vendor prefixing.
@@ -352,7 +343,7 @@ default favicon files.
 - Keep your override if you need custom link tags, non-default filenames, a web
   app manifest, or additional platform icons.
 - Otherwise, consider deleting the override and using the default discovery
-  behavior documented in [Add your favicons][].
+  behavior.
 
 If you have a source SVG and ImageMagick installed, you can generate the common
 raster files with the new helper. For an npm package install of Docsy:
@@ -384,23 +375,20 @@ cached menu -- 0.16.0 only moved that activation from per-page inline jQuery
 into the shipped `chrome-nav.js`, which now loads on every page regardless of
 build mode.
 
-The `shared` mode is a small first step toward a more component-oriented Docsy,
-where shared page regions are authored and shipped once. For configuration, the
-kept-or-restored contract, and current limitations, see [Chrome build
-modes][chrome]. The feature is [experimental][] and may change.
+The `shared` mode is a small first step toward a more component-oriented Docsy.
+For configuration, the kept-or-restored contract, and current limitations, see
+[Chrome build modes][chrome]. The feature is [experimental][] and may change.
 
 ### Actions {#shared-chrome-actions}
 
 {{% _param NEW %}} **Applies if** you want faster link-checking, output diffing,
 or previews -- especially for a large or multilingual site.
 
-- No action is required. `full` is the default and existing sites are
-  unaffected.
 - To try it, build with `td.chrome` set to `shared` (for example,
   `HUGO_PARAMS_TD_CHROME=shared`) for non-production builds such as
   link-checking or CI, and keep `full` for published output.
-- Because `shared` mode is experimental, don't rely on it for production HTML
-  yet. See [Chrome build modes][chrome].
+- Don't rely on `shared` mode for production HTML yet. See [Chrome build
+  modes][chrome].
 
 ## Other notable changes
 
@@ -438,8 +426,8 @@ committed link cache for fast, reproducible checks.
 Follow [Update Docsy][] and as you do:
 
 - Apply the config changes from this release's
-  [theme folder move](#theme-folder-actions): the Update Docsy pages reflect the
-  install paths that the move introduces.
+  [theme folder move](#theme-folder-actions); the Update Docsy pages already
+  show the post-move install paths.
 - Use these versions:[^vers-note]
   - **[Docsy][update-theme]**: [0.15.0][] -> [0.16.0][]
   - **[Hugo][update-hugo]**: [0.157.0][] ->
@@ -471,7 +459,8 @@ In addition to the [generic site checks][check], for this release:
 - [ ] [Check your favicon output](#favicons-actions), especially if you relied
       on Docsy's old default icons.
 - [ ] For multilingual sites, review language config keys and custom language
-      template overrides.
+      template overrides per the Hugo guide's [language-API
+      renames][hugo-language-apis].
 
 </section>
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -85,7 +85,7 @@ and release automation out of the theme's way.
 
 The version-update commands below run at their place in the [order of steps][]
 -- after any Node and Hugo updates. Set `VERSION` to the Docsy version you want
-to install in a manner compatible with your shell, for example:
+to install, in a manner compatible with your shell, for example:
 
 ```sh
 VERSION=v0.16.0

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -52,7 +52,7 @@ cSpell:ignore: CatmullRom favicons TOF
 
 ## Ready to upgrade? <a id="breaking-changes"></a>
 
-- :warning: Respect the [order of steps][]: Node and Hugo before the theme.
+- :warning: Respect the [order of steps][] to avoid breaking your build.
 - Review {{% _param BADGE BREAKING warning %}} changes:
   - {{% _param BREAKING %}} [Theme folder move](#theme-folder)
   - {{% _param BREAKING %}} [Minimum Hugo version](#hugo)
@@ -424,15 +424,11 @@ committed link cache for fast, reproducible checks.
 
 Follow [Update Docsy][] and as you do:
 
-{{< comment >}}
+{{< comment >}} Deliberate repeat of the warning from
+[Breaking changes](#breaking-changes), for readers who jump straight to this
+section. {{< /comment >}}
 
-Getting the upgrade order wrong can break the upgrade process. So we repeat the
-warning from [Breaking changes](#breaking-changes) here, in case a reader
-"jumped in" directly to this section.
-
-{{< /comment >}}
-
-- :warning: Respect the [order of steps][]: Node and Hugo before the theme.
+- :warning: Respect the [order of steps][] to avoid breaking your build.
 - Apply the config changes from this release's
   [theme folder move](#theme-folder-actions); the Update Docsy pages already
   show the post-move install paths.

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -6,7 +6,7 @@ lastmod: 2026-07-29
 description: >-
   Docsy is now on npm as @docsy/theme. This release also moves the theme into
   theme/, raises the Hugo minimum, and swaps default favicons for automatic
-  discovery — each with upgrade actions.
+  discovery, each with upgrade actions.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -258,9 +258,8 @@ npm install --save-dev @docsy/theme
 
 For setup details, see [Docsy as an NPM package][].
 
-Official releases are now defined channel-agnostically: a stable semver version
-from the npm registry, the Hugo module, or a GitHub release tag. For details,
-see the [official support policy][].
+Registry releases are official releases: the [official support policy][] now
+counts the npm package alongside the Hugo module and GitHub release tags.
 
 ### Actions {#npm-registry-actions}
 

--- a/docsy.dev/content/en/blog/2026/0.16.0.md
+++ b/docsy.dev/content/en/blog/2026/0.16.0.md
@@ -5,7 +5,7 @@ date: 2026-07-29
 lastmod: 2026-07-29
 description: >-
   Docsy is now on npm as @docsy/theme. This release also moves the theme into
-  theme/, raises the Hugo minimum, and swaps default favicons for automatic
+  theme/, raises the Hugo minimum, and drops its default favicons in favor of
   discovery, each with upgrade actions.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
@@ -21,9 +21,6 @@ cSpell:ignore: CatmullRom favicons TOF
 
 {{% card header="Highlights" %}}
 
-- {{% _param FAS_LG robot info %}}
-  <span>**[Agent-ready upgrade guide](#upgrading-with-ai)**: hand this post to
-  your AI assistant</span>
 - {{% _param FAS_LG cubes primary %}}
   <span>**[First-class npm support](#npm-registry)**: install Docsy from the
   registry, and [more][]</span>
@@ -32,6 +29,9 @@ cSpell:ignore: CatmullRom favicons TOF
 - {{% _param FAS_LG bolt warning %}} <span>**[Shared chrome](#shared-chrome)**
   (experimental): a build mode for much faster link checking of large
   sites</span>
+- {{% _param FAS_LG robot info %}}
+  <span>**[Agent-ready upgrade guide](#upgrading-with-ai)**: hand this post to
+  your AI assistant</span>
 
 {{% /card %}}
 
@@ -83,8 +83,9 @@ and release automation out of the theme's way.
 
 ### Actions {#theme-folder-actions}
 
-Replace _`VERSION`_ with the Docsy version you want to install, for example
-`v0.16.0`.
+The version-update commands below run at their place in the [order of steps][]
+-- after any Node and Hugo updates. Replace _`VERSION`_ with the Docsy version
+you want to install, for example `v0.16.0`.
 
 #### Hugo module sites
 
@@ -160,7 +161,7 @@ theme: docsy/theme
 ```
 
 Then update your clone or submodule to _`VERSION`_ using your existing update
-workflow — for example, for a submodule:
+workflow -- for example, for a submodule:
 
 ```sh
 git -C themes/docsy fetch --tags && git -C themes/docsy checkout VERSION
@@ -190,7 +191,7 @@ Docsy 0.16.0 raises the theme's minimum supported Hugo version from 0.146.0 to
 - The theme's [npm-sourced dependencies](#npm-deps) rely on the workspace-aware
   `hugo mod npm pack` support that Hugo **0.159.0** added. On older Hugo
   versions the pack step exits successfully but writes empty dependency lists,
-  so the failure surfaces only later, as a hard-to-trace SCSS import error —
+  so the failure surfaces only later, as a hard-to-trace SCSS import error --
   Hugo's minimum-version warning is the only early signal.
 - **0.160.1** excludes the known regressions in the 0.159.2 to 0.160.0 range.
 
@@ -199,8 +200,8 @@ The Docsy project build and example site are validated with **Hugo
 0.158.0 and {{% param hugoSupportedVersion %}}, see the companion [Hugo 0.158+
 upgrade guide][hugo-upgrade].
 
-This distinction — the **minimum** Hugo version versus the **officially
-supported** version that the project pins and tests — is now documented as part
+This distinction -- the **minimum** Hugo version versus the **officially
+supported** version that the project pins and tests -- is now documented as part
 of Docsy's [official support policy][].
 
 ### Actions {#hugo-actions}
@@ -465,6 +466,10 @@ In addition to the [generic site checks][check], for this release:
 - [ ] For multilingual sites, review language config keys and custom language
       template overrides per the Hugo guide's [language-API
       renames][hugo-language-apis].
+- [ ] Confirm the [theme path landed](#theme-folder-actions) for your install
+      mode.
+- [ ] For Hugo-module sites, confirm the site
+      [builds without SCSS import errors](#npm-deps-actions).
 
 </section>
 

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -3,6 +3,10 @@ title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-07-28
 lastmod: 2026-07-29
+description: >-
+  What changed in Hugo 0.158.0 through 0.164.x for Docsy sites — breaking
+  changes, deprecations, security fixes, and known regressions, with per-version
+  upgrade actions.
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)
@@ -14,10 +18,8 @@ params:
 cSpell:ignore: amp AVIF CatmullRom chromastyles contentbasename downscaling goldmark Netlify Pandoc partialCached passthrough protobuf renderSegments reStructuredText retokenizes useEmbedded userinfo
 ---
 
-This post summarizes the breaking, security, and notable changes in Hugo 0.158.0
-through {{% param hugoSupportedVersion %}} that affect Docsy sites. It is a
-companion to the [Docsy 0.16.0 release post](0.16.0/), which specifies the
-[Hugo versions that 0.16.0 requires and validates](0.16.0/#hugo).
+This post is a companion to the [Docsy 0.16.0 release post](0.16.0/), which
+specifies the [Hugo versions that 0.16.0 requires and validates](0.16.0/#hugo).
 
 ## Upgrade summary
 

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,7 +1,7 @@
 ---
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
-date: 2026-07-29
+date: 2026-07-28
 lastmod: 2026-07-29
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -1,9 +1,8 @@
 ---
 title: Hugo 0.158.0-0.164.x upgrade guide
 linkTitle: Hugo 0.158+ upgrade guide
-date: 2026-06-14
-lastmod: 2026-07-28
-draft: true
+date: 2026-07-29
+lastmod: 2026-07-29
 author: >-
   [Patrice Chalin](https://github.com/chalin) ([CNCF](https://www.cncf.io/)),
   for the [Docsy Steering Committee](/blog/2022/hello/#introducing-the-psc)

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -103,10 +103,7 @@ rendered Markdown link URLs, producing `&amp;amp;` in HTML output.
 
 Hugo [0.160.0][] fixed that regression, and Hugo [0.160.1][] is the safer
 0.160.x patch release. Docsy 0.16.0's minimum Hugo version, 0.160.1, already
-excludes this window. Monolingual sites without custom link render hooks are the
-most exposed: multilingual single-host sites are usually shielded by Hugo's
-`useEmbedded: auto` link render hook, as are sites with custom link render
-hooks.
+excludes this window.
 
 ### Actions {#amp-escaping-actions}
 
@@ -117,7 +114,6 @@ HTML for `&amp;amp;` in link URLs.
 
 Hugo 0.159.x continued several cleanup paths that may show up in older Docsy
 sites, Docsy forks, or large downstream sites with local template overrides.
-Hugo [0.160.1][] then fixed several rendering issues in this range.
 
 ### Actions {#template-module-cleanup-actions}
 
@@ -132,10 +128,10 @@ scripts.
 - If you use `hugo convert`, review generated output before committing it.
 
 **Applies if** your site uses Goldmark passthrough, `RenderShortcodes`, or
-multilingual root sections. Hugo 0.160.1 -- Docsy 0.16.0's minimum -- fixed
-regressions in this range around passthrough elements in headings, shortcode
-rendering context markers, and multilingual root section generation; include
-such pages in your smoke tests.
+multilingual root sections. Hugo [0.160.1][] fixed regressions in this range
+around passthrough elements in headings, shortcode rendering context markers,
+and multilingual root section generation; include such pages in your smoke
+tests.
 
 ## {{% _param BREAKING %}} Node-managed tools (0.161.x) {#node-tools}
 
@@ -209,14 +205,12 @@ changed internal resized-image cache keys.
 - Replace global settings with per-format settings, or remove them if they match
   Hugo defaults.
 - Keep `resampleFilter: CatmullRom` if your site relies on Docsy-style sharp
-  photographic downscaling.
+  photographic downscaling:
 
-For example:
-
-```yaml
-imaging:
-  resampleFilter: CatmullRom
-```
+  ```yaml
+  imaging:
+    resampleFilter: CatmullRom
+  ```
 
 ### Image URL churn
 
@@ -288,7 +282,7 @@ This range includes multiple security-related updates, including Go
 hardens the default code-block render hook: the language token (info string) of
 fenced code blocks is now escaped, which matters most for sites that render
 untrusted Markdown. This is a strong reason to prefer 0.163.3 or later over
-stopping at the minimum 0.160.1.
+stopping at 0.160.1.
 
 ### New features worth knowing about {#new-features}
 

--- a/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
+++ b/docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
@@ -4,7 +4,7 @@ linkTitle: Hugo 0.158+ upgrade guide
 date: 2026-07-28
 lastmod: 2026-07-29
 description: >-
-  What changed in Hugo 0.158.0 through 0.164.x for Docsy sites — breaking
+  What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking
   changes, deprecations, security fixes, and known regressions, with per-version
   upgrade actions.
 author: >-

--- a/docsy.dev/content/en/docs/deployment/chrome.md
+++ b/docsy.dev/content/en/docs/deployment/chrome.md
@@ -8,9 +8,7 @@ cSpell:ignore: pagelinks
 
 A docs site re-emits the same auto-generated _[chrome][]_ &mdash; the navbar,
 footer, and left-nav &mdash; on _every_ page, even though those regions are
-usually identical site-wide. That repetition slows the build, bloats the output,
-and slows anything that processes every page, such as a link checker; it also
-makes for noisy output diffs.
+usually identical site-wide.
 
 Use the `td.chrome` parameter to select one of two **build modes**:
 
@@ -109,8 +107,7 @@ HUGO_PARAMS_TD_CHROME=shared hugo
 
 See Hugo's [configuration with environment variables][hugo-env-config]. Then run
 your link checker against the generated `public/` output as usual: a `shared`
-build needs no checker-specific configuration, since the donor pages keep every
-chrome link reachable.
+build needs no checker-specific configuration.
 
 <!-- prettier-ignore-start -->
 [app-shell]: https://developer.chrome.com/blog/app-shell

--- a/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
+++ b/docsy.dev/content/en/docs/get-started/docsy-as-module/start-from-scratch.md
@@ -211,12 +211,8 @@ from scratch as it provides defaults for many required configuration parameters.
   [Examples and templates](/examples/).
 - [Publish your site](/docs/deployment/).
 
-<!-- TODO(tag-time): re-point the preview-host (main--) link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
-[blog-npm-deps]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#npm-deps
+[blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [configuration file]: https://gohugo.io/configuration/introduction/#configuration-file
 [Troubleshooting]: /docs/get-started/troubleshooting/
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -161,12 +161,6 @@ your project's root directory:
     echo 'theme: docsy/theme' >> hugo.yaml
     ```
 
-    > [!TIP]
-    >
-    > As of Hugo 0.110.0, the default config base filename was changed to
-    > `hugo.*` from `config.*`. If you are using hugo 0.110+, consider renaming
-    > your `config.*` to `hugo.*`.
-
 3.  Get Docsy dependencies:
 
     ```sh

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -1,6 +1,8 @@
 ---
 title: Other setup options
-description: Create a new Docsy site with Docsy using Git or NPM
+description: >-
+  Install Docsy as a Git submodule, a clone, or the @docsy/theme npm package,
+  for sites not using Hugo modules.
 date: 2021-12-08
 cSpell:ignore: hugo myproject
 weight: 2

--- a/docsy.dev/content/en/docs/get-started/other-options.md
+++ b/docsy.dev/content/en/docs/get-started/other-options.md
@@ -10,28 +10,13 @@ weight: 2
 
 <!-- markdownlint-disable no-blanks-blockquote -->
 
-If you don't want to use
-[Docsy as a Hugo Module](/docs/get-started/docsy-as-module/) (for example if you
-do not want to install Go) but still don't want to copy the theme files into
-your own repo, you can **use Docsy as a
-[Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)**. Using
-submodules also lets Hugo use the theme files from the Docsy repo, though is
-more complicated to maintain than the Hugo Modules approach. This is the
-approach used in older versions of the Docsy example site, and is still
-supported. If you are using Docsy as a submodule but would like to migrate to
-Hugo Modules, see our [migration guide](/docs/update/convert-site-to-module/).
+If [Docsy as a Hugo Module](/docs/get-started/docsy-as-module/) doesn't suit
+your site -- for example, if you don't want to install Go -- choose from these
+setup options:
 
-Alternatively if you don’t want Hugo to have to get the theme files from an
-external repo (for example, if you want to customize and maintain your own copy
-of the theme directly, or your deployment choice requires you to include a copy
-of the theme in your repository), you can **clone the files directly into your
-site source**.
-
-Finally, you can **install
-[Docsy as an NPM package](#option-3-docsy-as-an-npm-package)**.
-
-This guide provides instructions for all of these options, along with common
-prerequisites.
+- [Option 1: Docsy as a Git submodule](#option-1-docsy-as-a-git-submodule)
+- [Option 2: Clone the Docsy theme](#option-2-clone-the-docsy-theme)
+- [Option 3: Docsy as an NPM package](#option-3-docsy-as-an-npm-package)
 
 ## Prerequisites
 
@@ -121,6 +106,11 @@ nvm install --lts
 See [Install PostCSS][].
 
 ## Option 1: Docsy as a Git submodule
+
+If you are using Docsy as a
+[Git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) but would
+like to migrate to Hugo Modules, see our
+[migration guide](/docs/update/convert-site-to-module/).
 
 ### For a new site
 

--- a/docsy.dev/content/en/docs/update/_index.md
+++ b/docsy.dev/content/en/docs/update/_index.md
@@ -112,15 +112,11 @@ Use this checklist as a guide to verify that your update succeeded:
 Also perform any release-specific checks listed in the release's
 [upgrade blog post](/tags/upgrade/).
 
-<!-- TODO(tag-time): re-point the preview-host (main--) tfa link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
 [Heading self-links]: /docs/content/navigation/#heading-self-links
 [hugo-extended]: /docs/get-started/other-options/#hugo-extended-npm
 [hugo-override]: https://gohugo.io/getting-started/directory-structure/#theme-skeleton
 [lookandfeel]: /docs/content/lookandfeel/#project-style-files
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
-[tfa]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#theme-folder-actions
+[tfa]: /blog/2026/0.16.0/#theme-folder-actions
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/docs/update/convert-site-to-module.md
+++ b/docsy.dev/content/en/docs/update/convert-site-to-module.md
@@ -244,10 +244,6 @@ git commit -m "Removed docsy git submodule"
 > Be careful when using the `rm -rf` command, make sure that you don't
 > inadvertently delete any productive data files!
 
-<!-- TODO(tag-time): re-point the preview-host (main--) link below to the
-     production /blog/2026/0.16.0/ URL once the post publishes; see the
-     release-prep wrapup checklist. -->
-
 <!-- prettier-ignore-start -->
-[blog-npm-deps]: https://main--docsydocs.netlify.app/blog/2026/0.16.0/#npm-deps
+[blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 <!-- prettier-ignore-end -->

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -149,15 +149,14 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 **New**:
 
-- **[Docsy on the npm registry][0.16.0-blog-npm-registry]**: the theme is now
-  published as [`@docsy/theme`][@docsy/theme]; npm installs from GitHub
-  (`google/docsy`) are now for
-  [development and testing only](#official-support). See [Docsy as an NPM
-  package][option-3-npm] ([#2683][]).
-- **[Favicon discovery][0.16.0-blog-favicons]**: the theme now discovers and
-  links conventionally named favicon files from `static/`; a new `gen-favicons`
-  helper generates raster icons from a source SVG. See [Add your
-  favicons][favicons] ([#2357][]).
+- **[Docsy on the npm registry][0.16.0-blog-npm-registry]**: published the theme
+  as [`@docsy/theme`][@docsy/theme]; npm installs from GitHub (`google/docsy`)
+  are now for [development and testing only](#official-support). See [Docsy as
+  an NPM package][option-3-npm] ([#2683][]).
+- **[Favicon discovery][0.16.0-blog-favicons]**: added automatic discovery and
+  linking of conventionally named favicon files from `static/`, and a
+  `gen-favicons` helper that generates raster icons from a source SVG. See [Add
+  your favicons][favicons] ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
@@ -168,9 +167,9 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
   release report][0.16.0-blog-hugo] ([#2668][]).
 - **[Theme folder move][0.16.0-blog-theme-folder]**: the canonical theme now
   lives in `theme/`; install paths change for every install mode ([#2617][]).
-- **[Bootstrap and Font Awesome via npm][0.16.0-blog-npm-deps]**: the theme
-  declares them as npm dependencies instead of importing them as Hugo modules;
-  applies to Hugo-module installs only ([#2668][]).
+- **[Bootstrap and Font Awesome via npm][0.16.0-blog-npm-deps]**: declared them
+  as npm dependencies instead of importing them as Hugo modules; applies to
+  Hugo-module installs only ([#2668][]).
 
 **Other changes**:
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,9 +141,7 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
-## v0.16.0 - UNRELEASED {#next}
-
-> **UNRELEASED: this planned version is still under development**
+## v0.16.0 {#v0.16.0}
 
 For an introduction to this release, see the [0.16.0 release report][]. For
 Hugo-specific notes, see the [Hugo 0.158+ upgrade guide][]. For the full list of
@@ -237,7 +235,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [0.16.0]: https://github.com/google/docsy/releases/tag/v0.16.0
 [chrome]: /docs/deployment/chrome/
 [favicons]: /docs/content/iconsimages/#add-your-favicons
-[git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...main
+[git history since 0.15.0]: https://github.com/google/docsy/compare/v0.15.0...v0.16.0
 [Hugo 0.158+ upgrade guide]: /blog/2026/hugo-0.158.0+/
 [hugo-0.160.1]: https://github.com/gohugoio/hugo/releases/tag/v0.160.1
 [hugo-0.164.0]: https://github.com/gohugoio/hugo/releases/tag/v0.164.0

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -149,57 +149,48 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 
 **New**:
 
-- **Docsy on the npm registry**: the theme is now published as
-  [`@docsy/theme`][@docsy/theme]; npm installs from GitHub (`google/docsy`) are
-  now for [development and testing only](#official-support). See [0.16.0 release
-  report][0.16.0-blog-npm-registry] and [Docsy as an NPM package][option-3-npm]
-  ([#2683][]).
-- **Favicon discovery**: you can now drop a site's conventionally named favicon
-  files into `static/` and the theme discovers and links them -- no favicons
-  partial required. A new `gen-favicons` helper generates raster icons from a
-  source SVG. See [0.16.0 release report][0.16.0-blog-favicons] and [Add your
+- **[Docsy on the npm registry][0.16.0-blog-npm-registry]**: the theme is now
+  published as [`@docsy/theme`][@docsy/theme]; npm installs from GitHub
+  (`google/docsy`) are now for
+  [development and testing only](#official-support). See [Docsy as an NPM
+  package][option-3-npm] ([#2683][]).
+- **[Favicon discovery][0.16.0-blog-favicons]**: the theme now discovers and
+  links conventionally named favicon files from `static/`; a new `gen-favicons`
+  helper generates raster icons from a source SVG. See [Add your
   favicons][favicons] ([#2357][]).
 
 [**Breaking changes**](#breaking-change):
 
-- **Default favicons** removed from the theme; sites now supply their own --
-  most simply via **Favicon discovery** (see **New** above). See [0.16.0 release
-  report][0.16.0-blog-favicons] and [Add your favicons][favicons] ([#2595][]).
+- **[Default favicons][0.16.0-blog-favicons]** removed from the theme; sites
+  supply their own (see **Favicon discovery** above) ([#2595][]).
 - Raised the theme's minimum supported Hugo version to
-  **[0.160.1][hugo-0.160.1]** (was 0.146.0; Docsy 0.15 documented Hugo 0.157.0).
-  For the rationale, see [0.16.0 release report][0.16.0-blog-hugo] ([#2668][],
-  [#2677][]).
-- **Theme folder move**: the canonical theme now lives in `theme/`; consuming
-  sites need a one-line install-path update for their install mode. See [0.16.0
-  release report][0.16.0-blog-theme-folder] ([#2617][]).
-- **Bootstrap and Font Awesome via npm**: the theme declares them as npm
-  dependencies instead of importing them as Hugo modules. **Applies to
-  Hugo-module installs**, which run `hugo mod npm pack` and `npm install` to
-  pull them in; other install modes are unaffected. See [0.16.0 release
-  report][0.16.0-blog-npm-deps] ([#2668][]).
+  **[0.160.1][hugo-0.160.1]** (was 0.146.0). For the rationale, see the [0.16.0
+  release report][0.16.0-blog-hugo] ([#2668][]).
+- **[Theme folder move][0.16.0-blog-theme-folder]**: the canonical theme now
+  lives in `theme/`; install paths change for every install mode ([#2617][]).
+- **[Bootstrap and Font Awesome via npm][0.16.0-blog-npm-deps]**: the theme
+  declares them as npm dependencies instead of importing them as Hugo modules;
+  applies to Hugo-module installs only ([#2668][]).
 
 **Other changes**:
 
 - Migrated the theme and docs off deprecated Hugo language APIs ([#2593][]).
   Thanks [@deining][] for the groundwork in [#2594][] and [#2578][]!
 - Synced and corrected the Russian UI strings. Thanks [@shurup][]!
-- Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. The theme's
-  minimum supported Hugo version remains 0.160.1. See [Hugo 0.158+ upgrade
-  guide][] ([#2581][]).
-- **PostCSS is opt-in for non-RTL sites**: Docsy runs `postCSS` only for sites
-  with RTL languages or a project-root `postcss.config.{js,mjs,cjs}`; other
-  sites no longer need a PostCSS toolchain. See [0.16.0 release
-  report][0.16.0-blog-postcss] ([#2668][]).
-- Moved cached-sidebar activation on large sites (above `sidebar_cache_limit`)
-  from per-page inline jQuery to the shared `chrome-nav.js` hydration path;
-  rendered navigation is unchanged.
+- Upgraded the project's Hugo build to [0.164.0][hugo-0.164.0]. See [Hugo 0.158+
+  upgrade guide][] ([#2581][]).
+- **[PostCSS is opt-in for non-RTL sites][0.16.0-blog-postcss]**: sites without
+  RTL languages or their own PostCSS config no longer need a PostCSS toolchain
+  ([#2668][]).
+- Moved cached-sidebar activation on large sites from inline jQuery into the
+  shared `chrome-nav.js`, which now loads on every page; rendered navigation is
+  unchanged. See the [0.16.0 release report][0.16.0-blog-shared-chrome].
 
 [**Experimental**](#experimental):
 
-- Added a **`shared` chrome build mode** (`td.chrome`), an experimental option
-  that emits the repeated chrome (navbar, footer, left-nav) on one donor page
-  per locale and restores it in the browser, so one build serves both readers
-  and link checkers. See [Chrome build modes][chrome] ([#2659][]).
+- Added a **[`shared` chrome build mode][chrome]** (`td.chrome`) that renders
+  the repeated chrome (navbar, footer, left-nav) once per locale, for much
+  cheaper link checking of large sites ([#2659][]).
 
 **For maintainers**:
 
@@ -220,7 +211,6 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [#2617]: https://github.com/google/docsy/issues/2617
 [#2659]: https://github.com/google/docsy/issues/2659
 [#2668]: https://github.com/google/docsy/issues/2668
-[#2677]: https://github.com/google/docsy/pull/2677
 [#2683]: https://github.com/google/docsy/issues/2683
 [0.16.0 release report]: /blog/2026/0.16.0/
 [0.16.0-blog-favicons]: /blog/2026/0.16.0/#favicons
@@ -229,6 +219,7 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 [0.16.0-blog-npm-deps]: /blog/2026/0.16.0/#npm-deps
 [0.16.0-blog-npm-registry]: /blog/2026/0.16.0/#npm-registry
 [0.16.0-blog-postcss]: /blog/2026/0.16.0/#postcss
+[0.16.0-blog-shared-chrome]: /blog/2026/0.16.0/#shared-chrome
 [0.16.0-blog-theme-folder]: /blog/2026/0.16.0/#theme-folder
 [0.16.0]: https://github.com/google/docsy/releases/tag/v0.16.0
 [chrome]: /docs/deployment/chrome/

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -150,10 +150,8 @@ changes, see the [0.16.0][] release page or the [git history since 0.15.0][].
 **New**:
 
 - **Docsy on the npm registry**: the theme is now published as
-  [`@docsy/theme`][@docsy/theme]. Install it directly from npm, with Bootstrap
-  and Font Awesome delivered as ordinary dependencies. npm installs from GitHub
-  (`google/docsy`) are now for
-  [development and testing only](#official-support). See [0.16.0 release
+  [`@docsy/theme`][@docsy/theme]; npm installs from GitHub (`google/docsy`) are
+  now for [development and testing only](#official-support). See [0.16.0 release
   report][0.16.0-blog-npm-registry] and [Docsy as an NPM package][option-3-npm]
   ([#2683][]).
 - **Favicon discovery**: you can now drop a site's conventionally named favicon

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -2,7 +2,7 @@
 title: Maintainer notes
 description: Notes for Docsy maintainers
 aliases: [contributing, ../contributing]
-cSpell:ignore: hugo creatordate lycheecache
+cSpell:ignore: hugo creatordate lycheecache opentelemetry prebuild worktree
 ---
 
 For our main contributing page covering license agreements, code of conduct and
@@ -283,9 +283,10 @@ If not adjust accordingly.
     - Use the web interface to fill in the PR details.
     - Submit the PR.
 
-8.  **Test the PR** branch from selected consumer sites. For each site, create
-    a dedicated worktree + branch (kept for post-tag re-pin PRs); run the full
-    test suite and push any required adjustments to the PR.
+8.  **Test the PR branch**:
+    - **Run-edit-cycle**, after each run sub-step below:
+      - Push any adjustments to the PR.
+      - Restart this step 8 from the top, if justified.
     - Run the [smoke tests](#test-suites), which auto-target the PR branch
       pushed in the previous step and include a build at the
       [minimum Hugo version](#minimum-hugo-version):
@@ -294,31 +295,26 @@ If not adjust accordingly.
       npm run test:smoke
       ```
 
-    - For module-mode sites, point at the PR branch via `HUGO_MODULE_REPLACEMENTS`.
-    - For submodule-mode sites:
-
-      ```sh
-      cd themes/docsy
-      git fetch FORK BRANCH-NAME
-      git checkout FETCH_HEAD
-      cd .. && git add themes/docsy  # stage to survive prebuild reset
-      ```
-
-    - Run the full test suite and an A/B diff of the generated `public/` against
-      the current pin; flag any unexplained diff.
-    - Apply the release post's upgrade actions and sanity checks as written;
-      this doubles as a dry run of the post.
+    - **Test consumer sites**:
+      - Run the [consumer-site test procedure](#consumer-site-test) over
+        selected sites listed below.
+      - Remember to push any adjustments to the PR as stated above.
+      - Sites to test:
+        - [docsy-example][]
+        - [docsy-starter][]
+        - [opentelemetry.io][] or another large production site
 
 9.  **Get PR approved and merged**.
 
 10. **Pull the PR** to get the last changes.
 
-11. **Smoke-check Docsy** from the consumer-site worktrees created in step 8.
-    Update each site's Docsy pin from the PR branch tip to merged `main` and
-    run a smoke build (build + favicons + styles). Run the full suite only if
-    there was a non-trivial merge conflict or rebase.
-    - Consider updating the Docsy version for these examples in the examples
-      page.
+11. **Post-merge check from consumer sites.** In each worktree from step 8,
+    update the site's Docsy pin from the PR branch tip to merged `main`, then:
+    - Build and confirm zero warnings; re-run the site's sanity checks.
+    - Re-run the full [test procedure](#consumer-site-test) only if the merge
+      involved a non-trivial conflict or rebase.
+    - Consider updating the Docsy version for these examples in the
+      `docsy.dev/examples` page.
 
 12. **Ensure** that you're:
     - On the target `$BASE` branch
@@ -594,6 +590,50 @@ before any further changes are merged into the `main` branch:
 
 4. **Get PR approved and merged**.
 
+## Consumer-site test procedure {#consumer-site-test}
+
+To test a Docsy branch or release from a consumer site, for each site:
+
+1. **Create a dedicated worktree + branch** off the site's default branch; keep
+   it for the site's post-release Docsy-update PR.
+2. **Point the site at the target Docsy commit**, per install mode:
+   - Hugo module: set `HUGO_MODULE_REPLACEMENTS` to the Docsy checkout path —
+     env-only, no repo edits.
+   - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH`.
+   - Git submodule:
+
+     ```sh
+     cd themes/docsy
+     git fetch FORK BRANCH-NAME
+     git checkout FETCH_HEAD
+     cd .. && git add themes/docsy # stage so prebuild targets this SHA
+     ```
+
+3. **Apply the release post's upgrade actions** — all of them, before the first
+   build: check every applies-if guard against the site, including the companion
+   Hugo guide's when the release raises the Hugo minimum. This doubles as a dry
+   run of the post; report any gap or inaccuracy as feedback on it.
+4. **Build**: confirm zero errors and warnings.
+5. **Run the site's test suite**:
+   - Run `npm test` or the site's canonical test script.
+   - Confirm that all checks pass.
+   - Run the release post's sanity checks.
+6. **A/B diff the generated site**:
+   - Build at the current (pre-update) pin and set `public/` aside as a baseline
+   - Optionally make the folder a git repository for the purpose of the diff.
+   - Diff the new pin's build against the baseline; for example, without a git
+     repository run:
+
+     ```sh
+     diff -rq --exclude='*.map' BASELINE_DIR/ public/
+     ```
+
+   - Confirm at least one difference exists.
+   - Assess each difference:
+     - Map it to an announced change, or flag it as a potential regression.
+     - Investigate issues and report their root causes.
+   - Report the results.
+
 ## Release helper scripts
 
 - NPM scripts: `set:version` and `set:version:*`; `update:hugo` (see
@@ -612,6 +652,7 @@ before any further changes are merged into the `main` branch:
 [deploy/prod]: <{{% param github_repo %}}/tree/deploy/prod>
 [doc-rooted]: <{{% param github_repo %}}/tree/doc-rooted>
 [docsy-example]: <{{% param github_repo %}}-example>
+[docsy-starter]: https://github.com/cncf/docsy-starter
 [docsy.dev]: <{{% _param baseURL %}}>
 [docsy.dev/config]: <{{% param github_repo %}}/blob/main/docsy.dev/config/>
 [docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>
@@ -622,6 +663,7 @@ before any further changes are merged into the `main` branch:
 [go.mod]: <{{% param github_repo %}}/blob/main/theme/go.mod>
 [milestones]: <{{% param github_repo %}}/milestones>
 [officially supports]: /project/about/changelog/#official-support
+[opentelemetry.io]: https://github.com/open-telemetry/opentelemetry.io
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
 [Release notes]: <{{% param github_repo %}}/releases>
 [theme/hugo.yaml]: <{{% param github_repo %}}/blob/main/theme/hugo.yaml>

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -610,8 +610,8 @@ To test a Docsy branch or release from a consumer site, for each site:
 
 3. **Apply the release post's upgrade actions** -- all of them, before the first
    build: check every applies-if guard against the site, including the companion
-   Hugo guide's when the release raises the Hugo minimum. This doubles as a dry
-   run of the post; report any gap or inaccuracy as feedback on it.
+   Hugo guide's actions when the release raises the Hugo minimum. This doubles
+   as a dry run of the post; report any gap or inaccuracy as feedback on it.
 4. **Build**: confirm zero errors and warnings.
 5. **Run the site's test suite**:
    - Run `npm test` or the site's canonical test script.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -609,7 +609,9 @@ To test a Docsy branch or release from a consumer site, for each site:
      hugo mod graph | head -3
      ```
 
-   - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH`.
+   - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH` for sites that npm
+     install from GitHub (`google/docsy`); append `/theme` for sites that use
+     the registry package (`@docsy/theme`).
    - Git submodule:
 
      ```sh

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -617,7 +617,20 @@ To test a Docsy branch or release from a consumer site, for each site:
    - Run `npm test` or the site's canonical test script.
    - Confirm that all checks pass.
    - Run the release post's sanity checks.
-6. **A/B diff the generated site**:
+6. **Spot-check key pages and output files**, in the build output or a served
+   preview. Confirm that pages render with intact chrome, styles, and favicons,
+   and that the other files look sane:
+   - Home page
+   - Docs landing page, and a random docs page
+   - Blog landing page and a random blog post, when the site has a blog
+   - Some other random page
+   - The 404 page
+   - The main CSS and JS files
+   - When the site enables LLMS support: `llms.txt`, and the `.md` output of the
+     pages above
+   - `_redirects`, when present
+   - `sitemap.xml` -- note that some sites normalize it after the build
+7. **A/B diff the generated site**:
    - If the site's `public/` folder is a git repository (a setup worth adopting;
      see docsy.dev's `make:public` npm script), build at the current
      (pre-update) pin and commit the output as the baseline. `git diff` then

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -618,18 +618,19 @@ To test a Docsy branch or release from a consumer site, for each site:
    - Confirm that all checks pass.
    - Run the release post's sanity checks.
 6. **Spot-check key pages and output files**, in the build output or a served
-   preview. Confirm that pages render with intact chrome, styles, and favicons,
-   and that the other files look sane:
-   - Home page
-   - Docs landing page, and a random docs page
-   - Blog landing page and a random blog post, when the site has a blog
-   - Some other random page
-   - The 404 page
-   - The main CSS and JS files
-   - When the site enables LLMS support: `llms.txt`, and the `.md` output of the
-     pages above
-   - `_redirects`, when present
-   - `sitemap.xml` -- note that some sites normalize it after the build
+   preview:
+   - **Pages** -- confirm each renders with intact chrome, styles, and favicons:
+     - Home page
+     - Docs landing page, and a random docs page
+     - Blog landing page and a random blog post, when the site has a blog
+     - Some other random page
+     - The 404 page
+   - **Other output files** -- confirm each looks sane:
+     - The main CSS and JS files
+     - When the site enables LLMS support: `llms.txt`, and the `.md` output of
+       the pages above
+     - `_redirects`, when present
+     - `sitemap.xml` -- note that some sites normalize it after the build
 7. **A/B diff the generated site**:
    - If the site's `public/` folder is a git repository (a setup worth adopting;
      see docsy.dev's `make:public` npm script), build at the current

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -283,8 +283,9 @@ If not adjust accordingly.
     - Use the web interface to fill in the PR details.
     - Submit the PR.
 
-8.  **Test the PR** branch from selected sites, and push any required
-    adjustments.
+8.  **Test the PR** branch from selected consumer sites. For each site, create
+    a dedicated worktree + branch (kept for post-tag re-pin PRs); run the full
+    test suite and push any required adjustments to the PR.
     - Run the [smoke tests](#test-suites), which auto-target the PR branch
       pushed in the previous step and include a build at the
       [minimum Hugo version](#minimum-hugo-version):
@@ -293,22 +294,29 @@ If not adjust accordingly.
       npm run test:smoke
       ```
 
-    - If the test site uses Docsy as a Git submodule:
+    - For module-mode sites, point at the PR branch via `HUGO_MODULE_REPLACEMENTS`.
+    - For submodule-mode sites:
 
       ```sh
-      cd themes/docs
-      git fetch
-      git switch -t REPO/BRANCH-NAME # e.g. chalin/chalin-m24-0.14.0-pre-release
+      cd themes/docsy
+      git fetch FORK BRANCH-NAME
+      git checkout FETCH_HEAD
+      cd .. && git add themes/docsy  # stage to survive prebuild reset
       ```
+
+    - Run the full test suite and an A/B diff of the generated `public/` against
+      the current pin; flag any unexplained diff.
+    - Apply the release post's upgrade actions and sanity checks as written;
+      this doubles as a dry run of the post.
 
 9.  **Get PR approved and merged**.
 
 10. **Pull the PR** to get the last changes.
 
-11. **Test Docsy** from [docsy-example][] and the docsy-starter, building
-    against the release branch or commit:
-    - Apply the release post's upgrade actions and sanity checks as written;
-      this doubles as a dry run of the post.
+11. **Smoke-check Docsy** from the consumer-site worktrees created in step 8.
+    Update each site's Docsy pin from the PR branch tip to merged `main` and
+    run a smoke build (build + favicons + styles). Run the full suite only if
+    there was a non-trivial merge conflict or rebase.
     - Consider updating the Docsy version for these examples in the examples
       page.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -620,7 +620,8 @@ To test a Docsy branch or release from a consumer site, for each site:
 6. **Spot-check key pages and output files**, in the build output or a served
    preview:
    - **Pages** -- confirm each renders with intact chrome, styles, and favicons:
-     - Home page
+     - Home page -- also confirm that the `generator` meta element reports the
+       expected Hugo version (Docsy's version isn't emitted)
      - Docs landing page, and a random docs page
      - Blog landing page and a random blog post, when the site has a blog
      - Some other random page

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -298,7 +298,6 @@ If not adjust accordingly.
     - **Test consumer sites**:
       - Run the [consumer-site test procedure](#consumer-site-test) over
         selected sites listed below.
-      - Remember to push any adjustments to the PR as stated above.
       - Sites to test:
         - [docsy-example][]
         - [docsy-starter][]
@@ -313,8 +312,6 @@ If not adjust accordingly.
     - Build and confirm zero warnings; re-run the site's sanity checks.
     - Re-run the full [test procedure](#consumer-site-test) only if the merge
       involved a non-trivial conflict or rebase.
-    - Consider updating the Docsy version for these examples in the
-      `docsy.dev/examples` page.
 
 12. **Ensure** that you're:
     - On the target `$BASE` branch
@@ -619,10 +616,12 @@ To test a Docsy branch or release from a consumer site, for each site:
    - Confirm that all checks pass.
    - Run the release post's sanity checks.
 6. **A/B diff the generated site**:
-   - Build at the current (pre-update) pin and set `public/` aside as a baseline
-   - Optionally make the folder a git repository for the purpose of the diff.
-   - Diff the new pin's build against the baseline; for example, without a git
-     repository run:
+   - If the site's `public/` folder is a git repository — a setup worth
+     adopting; see docsy.dev's `make:public` npm script — build at the current
+     (pre-update) pin and commit the output as the baseline. `git diff` then
+     reports the changes directly.
+   - Otherwise, build at the current pin, set `public/` aside as a baseline
+     directory, rebuild at the new pin, and diff, for example:
 
      ```sh
      diff -rq --exclude='*.map' BASELINE_DIR/ public/

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -579,20 +579,34 @@ before any further changes are merged into the `main` branch:
    ...
    ```
 
-2. In the [Changelog][]:
+2. **Retire temporary measures** that the shipped release makes obsolete, and
+   run checks.
+
+   - Remove any temporary ignore rules from `docsy.dev/lychee.toml` and confirm
+     that the link check passes.
+   - Search for other release-scoped markers and act on those now that the
+     release is shipped, for example:
+
+     ```sh
+     git grep -En 'Remove after|TODO\(0\.' -- ':(exclude)*public*'
+     ```
+
+   - Leave markers naming a later release in place.
+
+3. In the [Changelog][]:
    - **Create a new entry** for the next release by copying the ENTRY TEMPLATE
      at the end of the file.
 
    - **Fix the new release URL**, which ends with `latest?FIXME=...`, so that it
      refers to the actual release, now that it exists.
 
-3. **Submit a PR with your changes**, using a title like:
+4. **Submit a PR with your changes**, using a title like:
 
    ```text
    Set version to {{% param version %}}
    ```
 
-4. **Get PR approved and merged**.
+5. **Get PR approved and merged**.
 
 ## Consumer-site test procedure {#consumer-site-test}
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -194,6 +194,8 @@ If not adjust accordingly.
 > the numbered steps below as a checklist in your own notes, ticking steps as
 > they complete and marking who each pending step is waiting on.
 
+<!-- markdownlint-disable-next-line no-blanks-blockquote -->
+
 > [!IMPORTANT]
 >
 > Before creating a release, do a [release-prep audit](#release-prep-audit) and

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -579,8 +579,8 @@ before any further changes are merged into the `main` branch:
    ...
    ```
 
-2. **Retire temporary measures** that the shipped release makes obsolete, and
-   run checks.
+2. **Retire temporary measures** that the shipped release makes obsolete,
+   verifying checks as you go.
 
    - Remove any temporary ignore rules from `docsy.dev/lychee.toml` and confirm
      that the link check passes.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -299,8 +299,11 @@ If not adjust accordingly.
 
 10. **Pull the PR** to get the last changes.
 
-11. **Test Docsy** from [docsy-example][] and the docsy-starter. (Consider
-    updating the Docsy version for these examples in the examples page.)
+11. **Test Docsy** from [docsy-example][] and the docsy-starter: exercise the
+    release post's upgrade actions and sanity checks over the site as written
+    (this doubles as a dry run of the post), building against the release branch
+    or commit. (Consider updating the Docsy version for these examples in the
+    examples page.)
 
 12. **Ensure** that you're:
     - On the target `$BASE` branch

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -594,7 +594,7 @@ To test a Docsy branch or release from a consumer site, for each site:
 1. **Create a dedicated worktree + branch** off the site's default branch; keep
    it for the site's post-release Docsy-update PR.
 2. **Point the site at the target Docsy commit**, per install mode:
-   - Hugo module: set `HUGO_MODULE_REPLACEMENTS` to the Docsy checkout path —
+   - Hugo module: set `HUGO_MODULE_REPLACEMENTS` to the Docsy checkout path --
      env-only, no repo edits.
    - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH`.
    - Git submodule:
@@ -606,7 +606,7 @@ To test a Docsy branch or release from a consumer site, for each site:
      cd .. && git add themes/docsy # stage so prebuild targets this SHA
      ```
 
-3. **Apply the release post's upgrade actions** — all of them, before the first
+3. **Apply the release post's upgrade actions** -- all of them, before the first
    build: check every applies-if guard against the site, including the companion
    Hugo guide's when the release raises the Hugo minimum. This doubles as a dry
    run of the post; report any gap or inaccuracy as feedback on it.
@@ -616,10 +616,11 @@ To test a Docsy branch or release from a consumer site, for each site:
    - Confirm that all checks pass.
    - Run the release post's sanity checks.
 6. **A/B diff the generated site**:
-   - If the site's `public/` folder is a git repository — a setup worth
-     adopting; see docsy.dev's `make:public` npm script — build at the current
+   - If the site's `public/` folder is a git repository (a setup worth adopting;
+     see docsy.dev's `make:public` npm script), build at the current
      (pre-update) pin and commit the output as the baseline. `git diff` then
-     reports the changes directly.
+     reports the changes directly. Do not remove `public/` if it's a symlink to
+     a different directory.
    - Otherwise, build at the current pin, set `public/` aside as a baseline
      directory, rebuild at the new pin, and diff, for example:
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -446,8 +446,7 @@ If not adjust accordingly.
 
     </details>
 
-15. **Publish the theme package**, before the deploy that publishes the release
-    post -- the post recommends installing [`@docsy/theme`][]:
+15. **Publish the theme package**:
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.
     - Verify that the `latest` and `next` dist-tags point at it.
@@ -678,7 +677,6 @@ To test a Docsy branch or release from a consumer site, for each site:
 [breaking change]: /project/about/changelog/#breaking-change
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/
-[`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [deploy/prod]: <{{% param github_repo %}}/tree/deploy/prod>
 [doc-rooted]: <{{% param github_repo %}}/tree/doc-rooted>
 [docsy-example]: <{{% param github_repo %}}-example>

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -188,18 +188,18 @@ These instructions assume the release is:
 
 If not adjust accordingly.
 
+> [!IMPORTANT]
+>
+> Before creating a release, do a [release-prep audit](#release-prep-audit) and
+> use it to drive the changelog and release-blog updates in the next two steps.
+
+<!-- markdownlint-disable-next-line no-blanks-blockquote -->
+
 > [!TIP]
 >
 > A release run can span sessions and days. Consider keeping a running copy of
 > the numbered steps below as a checklist in your own notes, ticking steps as
 > they complete and marking who each pending step is waiting on.
-
-<!-- markdownlint-disable-next-line no-blanks-blockquote -->
-
-> [!IMPORTANT]
->
-> Before creating a release, do a [release-prep audit](#release-prep-audit) and
-> use it to drive the changelog and release-blog updates in the next two steps.
 
 1.  **Change directory** to your local Docsy repo.
     - Expecting final adjustments as you prepare for the release? Create a
@@ -654,7 +654,7 @@ To test a Docsy branch or release from a consumer site, for each site:
 [deploy/prod]: <{{% param github_repo %}}/tree/deploy/prod>
 [doc-rooted]: <{{% param github_repo %}}/tree/doc-rooted>
 [docsy-example]: <{{% param github_repo %}}-example>
-[docsy-starter]: https://github.com/cncf/docsy-starter
+[docsy-starter]: https://github.com/chalin/docsy-starter
 [docsy.dev]: <{{% _param baseURL %}}>
 [docsy.dev/config]: <{{% param github_repo %}}/blob/main/docsy.dev/config/>
 [docsy.dev/config/_default/hugo.yaml]: <{{% param github_repo %}}/blob/main/docsy.dev/config/_default/hugo.yaml>

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -188,6 +188,12 @@ These instructions assume the release is:
 
 If not adjust accordingly.
 
+> [!TIP]
+>
+> A release run can span sessions and days. Consider keeping a running copy of
+> the numbered steps below as a checklist in your own notes, ticking steps as
+> they complete and marking who each pending step is waiting on.
+
 > [!IMPORTANT]
 >
 > Before creating a release, do a [release-prep audit](#release-prep-audit) and

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -602,11 +602,10 @@ To test a Docsy branch or release from a consumer site, for each site:
    it for the site's post-release Docsy-update PR.
 2. **Point the site at the target Docsy commit**, per install mode:
    - Hugo module: map the theme module to the local checkout -- env-only, no
-     repo edits -- and confirm that `hugo mod graph` reports the replacement:
+     repo edits:
 
      ```sh
      export HUGO_MODULE_REPLACEMENTS="github.com/google/docsy/theme -> DOCSY_CHECKOUT_PATH/theme"
-     hugo mod graph | head -3
      ```
 
    - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH` for sites that npm
@@ -625,6 +624,13 @@ To test a Docsy branch or release from a consumer site, for each site:
    build: check every applies-if guard against the site, including the companion
    Hugo guide's actions when the release raises the Hugo minimum. This doubles
    as a dry run of the post; report any gap or inaccuracy as feedback on it.
+   - For Hugo-module sites, confirm that the replacement is live once the import
+     path targets the theme module:
+
+     ```sh
+     hugo mod graph | grep 'github.com/google/docsy/theme'
+     ```
+
 4. **Build**: confirm zero errors and warnings.
 5. **Run the site's test suite**:
    - Run `npm test` or the site's canonical test script.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -299,11 +299,12 @@ If not adjust accordingly.
 
 10. **Pull the PR** to get the last changes.
 
-11. **Test Docsy** from [docsy-example][] and the docsy-starter: exercise the
-    release post's upgrade actions and sanity checks over the site as written
-    (this doubles as a dry run of the post), building against the release branch
-    or commit. (Consider updating the Docsy version for these examples in the
-    examples page.)
+11. **Test Docsy** from [docsy-example][] and the docsy-starter, building
+    against the release branch or commit:
+    - Apply the release post's upgrade actions and sanity checks as written;
+      this doubles as a dry run of the post.
+    - Consider updating the Docsy version for these examples in the examples
+      page.
 
 12. **Ensure** that you're:
     - On the target `$BASE` branch

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -446,11 +446,11 @@ If not adjust accordingly.
 
     </details>
 
-15. **Publish the theme package** to the npm registry, from `theme/` at the
-    tagged release commit; verify the published version and that the `latest`
-    and `next` dist-tags point at it before continuing -- the release post
-    recommends installing [`@docsy/theme`][], so the package must be live before
-    the deploy that publishes the post.
+15. **Publish the theme package**, before the deploy that publishes the release
+    post -- the post recommends installing [`@docsy/theme`][]:
+    - Publish to the npm registry from `theme/` at the tagged release commit.
+    - Verify the published version.
+    - Verify that the `latest` and `next` dist-tags point at it.
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -446,7 +446,13 @@ If not adjust accordingly.
 
     </details>
 
-15. Update the [deploy/prod][] branch from `$BASE`.
+15. **Publish the theme package** to the npm registry, from `theme/` at the
+    tagged release commit; verify the published version and that the `latest`
+    and `next` dist-tags point at it before continuing -- the release post
+    recommends installing [`@docsy/theme`][], so the package must be live before
+    the deploy that publishes the post.
+
+16. Update the [deploy/prod][] branch from `$BASE`.
 
     For stable releases from `main`, use:
 
@@ -460,10 +466,10 @@ If not adjust accordingly.
 
     The branch update will trigger a production deploy of the website.
 
-16. Wait for the production deploy to complete and check that [docsy.dev][] has
+17. Wait for the production deploy to complete and check that [docsy.dev][] has
     been updated to the new release.
 
-17. **[Draft a new release][]** using GitHub web; fill in the fields as follows:
+18. **[Draft a new release][]** using GitHub web; fill in the fields as follows:
     - Visit [tags][] to find the new release tag {{% param tdVersion.latest %}}.
 
     - Select Create a new release from the {{% param tdVersion.latest %}} tag
@@ -486,16 +492,16 @@ If not adjust accordingly.
 
     - Select **Create a discussion for this release**.
 
-18. **Publish the release**: click _Publish release_.
+19. **Publish the release**: click _Publish release_.
 
-19. Test the release with a downstream project and/or the [docsy-example][]
+20. Test the release with a downstream project and/or the [docsy-example][]
     site.
 
-20. If you find issues, determine whether they need to be fixed immediately. If
+21. If you find issues, determine whether they need to be fixed immediately. If
     so, get fixes submitted, reviewed and approved. Go back to step 1 to publish
     a dot release.
 
-21. **Update the `release` branch** once the release is final.
+22. **Update the `release` branch** once the release is final.
 
     For a stable release, fast-forward `release` to the final release commit
     from `main`:
@@ -509,7 +515,7 @@ If not adjust accordingly.
     For patch releases, the release-prep PR should already target `release`, so
     there is no separate `main` to `release` fast-forward.
 
-22. Update the [doc-rooted][] branch from [deploy/prod][]:
+23. Update the [doc-rooted][] branch from [deploy/prod][]:
 
     ```sh
     git checkout doc-rooted
@@ -525,7 +531,7 @@ If not adjust accordingly.
     If the fast-forward merge fails, stop and reconcile the branch history. Once
     pushed, wait for the Netlify deploy and check the doc-rooted preview.
 
-23. Update, create, or close GitHub milestones as appropriate.
+24. Update, create, or close GitHub milestones as appropriate.
 
 If all is well, release the Docsy example as detailed next.
 
@@ -596,8 +602,14 @@ To test a Docsy branch or release from a consumer site, for each site:
 1. **Create a dedicated worktree + branch** off the site's default branch; keep
    it for the site's post-release Docsy-update PR.
 2. **Point the site at the target Docsy commit**, per install mode:
-   - Hugo module: set `HUGO_MODULE_REPLACEMENTS` to the Docsy checkout path --
-     env-only, no repo edits.
+   - Hugo module: map the theme module to the local checkout -- env-only, no
+     repo edits -- and confirm that `hugo mod graph` reports the replacement:
+
+     ```sh
+     export HUGO_MODULE_REPLACEMENTS="github.com/google/docsy/theme -> DOCSY_CHECKOUT_PATH/theme"
+     hugo mod graph | head -3
+     ```
+
    - npm package: `npm install -D file:DOCSY_CHECKOUT_PATH`.
    - Git submodule:
 
@@ -605,7 +617,7 @@ To test a Docsy branch or release from a consumer site, for each site:
      cd themes/docsy
      git fetch FORK BRANCH-NAME
      git checkout FETCH_HEAD
-     cd .. && git add themes/docsy # stage so prebuild targets this SHA
+     cd ../.. && git add themes/docsy # stage so prebuild targets this SHA
      ```
 
 3. **Apply the release post's upgrade actions** -- all of them, before the first
@@ -666,6 +678,7 @@ To test a Docsy branch or release from a consumer site, for each site:
 [breaking change]: /project/about/changelog/#breaking-change
 [changelog]: /project/about/changelog/
 [contributing]: /docs/contributing/
+[`@docsy/theme`]: https://www.npmjs.com/package/@docsy/theme
 [deploy/prod]: <{{% param github_repo %}}/tree/deploy/prod>
 [doc-rooted]: <{{% param github_repo %}}/tree/doc-rooted>
 [docsy-example]: <{{% param github_repo %}}-example>

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -300,10 +300,10 @@ If not adjust accordingly.
     - **Test consumer sites**:
       - Run the [consumer-site test procedure](#consumer-site-test) over
         selected sites listed below.
-      - Sites to test:
-        - [docsy-example][]
-        - [docsy-starter][]
-        - [opentelemetry.io][] or another large production site
+      - Sites to test, ideally covering each install mode:
+        - Hugo module: [docsy-example][]
+        - npm package: [docsy-starter][]
+        - Git submodule: [opentelemetry.io][] or another large production site
 
 9.  **Get PR approved and merged**.
 

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -38,6 +38,7 @@ exclude = [
   # Remove after 0.16.0 ships: the release tag and the version dropdown's
   # "latest" links to pages new/draft in this cycle (absent on v0.15.0 prod).
   '^https://github\.com/google/docsy/releases/(tag/)?v0\.16\.0$',
+  '^https://github\.com/google/docsy/compare/v0\.15\.0\.\.\.v0\.16\.0$',
   '^https://www\.docsy\.dev/docs/deployment/chrome/$',
   '^https://www\.docsy\.dev/blog/2026/0\.16\.0/$',
   '^https://www\.docsy\.dev/blog/2026/hugo-0\.158\.0\+/$',

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,8 +6,8 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Release report and upgrade guide for Docsy 0.16.0, covering the new @docsy/theme npm package, the theme folder move, the raised Hugo minimum, and favicon discovery
-- [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/)
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and swaps default favicons for automatic discovery, each with upgrade actions.
+- [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.
 - [Hugo 0.152.0-0.155.x upgrade guide](/blog/2026/hugo-0.152.0+/)

--- a/docsy.dev/tests/md-output/goldens/blog/index.md
+++ b/docsy.dev/tests/md-output/goldens/blog/index.md
@@ -6,7 +6,7 @@ LLMS index: [llms.txt](/llms.txt)
 
 Section pages:
 
-- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and swaps default favicons for automatic discovery, each with upgrade actions.
+- [Release 0.16.0 report and upgrade guide](/blog/2026/0.16.0/): Docsy is now on npm as @docsy/theme. This release also moves the theme into theme/, raises the Hugo minimum, and drops its default favicons in favor of discovery, each with upgrade actions.
 - [Hugo 0.158.0-0.164.x upgrade guide](/blog/2026/hugo-0.158.0+/): What changed in Hugo 0.158.0 through 0.164.x for Docsy sites: breaking changes, deprecations, security fixes, and known regressions, with per-version upgrade actions.
 - [Release 0.15.0 report and upgrade guide](/blog/2026/0.15.0/): Release report and upgrade guide for Docsy 0.15.0, covering agent support, doc-rooted sites, version menus, community and footer links, and card shortcode rendering.
 - [Release 0.14.0 report and upgrade guide](/blog/2026/0.14.0/): Release report and upgrade guide for Docsy 0.14.0, covering markdown alert syntax, navbar style improvements, heading aliases and in-page targets, and improved separation of project and internal SCSS files.

--- a/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/get-started/index.md
@@ -68,7 +68,7 @@ Module guide as a simple and easily maintained option.
 Section pages:
 
 - [Use Docsy as a Hugo Module](/docs/get-started/docsy-as-module/): Learn how to get started with Docsy by using the theme as a Hugo Module.
-- [Other setup options](/docs/get-started/other-options/): Create a new Docsy site with Docsy using Git or NPM
+- [Other setup options](/docs/get-started/other-options/): Install Docsy as a Git submodule, a clone, or the @docsy/theme npm package, for sites not using Hugo modules.
 - [Deploy Docsy inside a Docker container](/docs/get-started/quickstart-docker/): Instructions on how to set up and run a local Docsy site with Docker.
 - [Basic site configuration](/docs/get-started/basic-configuration/): Basic configuration for new Docsy sites.
 - [Troubleshooting and known issues](/docs/get-started/troubleshooting/): Troubleshooting and known issues when installing and using Docsy.

--- a/docsy.dev/tests/md-output/goldens/docs/index.md
+++ b/docsy.dev/tests/md-output/goldens/docs/index.md
@@ -6,10 +6,10 @@ LLMS index: [llms.txt](/llms.txt)
 
 <!-- markdownlint-disable-next-line no-space-in-links -->
 
-<span class="badge bg-primary text-bg-primary fs-6">v0.15.1-dev
+<span class="badge bg-primary text-bg-primary fs-6">v0.16.1-dev
 </span>
 
-Welcome to the Docsy theme user guide for version `v0.15.1-dev`. This
+Welcome to the Docsy theme user guide for version `v0.16.1-dev`. This
 guide shows you how to get started creating technical documentation sites using
 Docsy, including site customization and how to use Docsy's blocks and templates.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.15.1-dev+046-over-main-7b2117a9",
+  "version": "0.16.0",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -1,18 +1,18 @@
 ---
 title: 0.16 coverage ledger
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 range: v0.15.0..main
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 cSpell:ignore: favicons gohugoio lycheecache
 ---
 
 The coverage ledger: one row per landed change in [v0.15.0...main][] through
-[9b1d9951][], mapped to where each is covered. This is the objective "is
+[69e597cc][], mapped to where each is covered. This is the objective "is
 everything covered, in the right place?" snapshot and the entry point for each
 refresh — add a row per new commit and route it.
 
-All 44 commits in range are squash-merged PRs (one commit per PR), so the
+All 46 commits in range are squash-merged PRs (one commit per PR), so the
 first-parent spine and the raw range are identical; every subject carries its
 `(#NNNN)` PR number.
 
@@ -74,6 +74,8 @@ first-parent spine and the raw range are identical; every subject carries its
 | `848374ee` [#2686][] | —         | docsy.dev: run link-check bins directly         | tool  | N/A  | N/A  | N/A  | N/A  | npm-squat hygiene: no bare `npx BIN`         |
 | `2b0fba2f` [#2687][] | —         | docsy.dev: link-cache from the npm registry     | tool  | N/A  | N/A  | N/A  | N/A  | devDependency source switch only             |
 | `9b1d9951` [#2688][] | [#2683][] | Registry install first-class; support policy    | docs  | done | done | done | N/A  | Option 3 registry-lead; two-axis policy      |
+| `7b2117a9` [#2690][] | [#2615][] | Refresh 0.16.0 release artifacts thru 9b1d9951  | tool  | N/A  | N/A  | N/A  | N/A  | The release artifacts themselves             |
+| `69e597cc` [#2692][] | [#2615][] | Evergreen home for generic update procedure     | docs  | done | N/A  | done | N/A  | `/docs/update/`; 0.16.0 post repointed in-PR |
 
 ## Notes on bundled changes
 
@@ -228,6 +230,8 @@ first-parent spine and the raw range are identical; every subject carries its
 [#2687]: https://github.com/google/docsy/pull/2687
 [#2688]: https://github.com/google/docsy/pull/2688
 [#2689]: https://github.com/google/docsy/issues/2689
-[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
+[#2690]: https://github.com/google/docsy/pull/2690
+[#2692]: https://github.com/google/docsy/pull/2692
+[69e597cc]: https://github.com/google/docsy/commit/69e597cc
 [link-cache]: https://github.com/chalin/link-cache
 [v0.15.0...main]: https://github.com/google/docsy/compare/v0.15.0...main

--- a/tasks/0.16/release-prep/coverage.md
+++ b/tasks/0.16/release-prep/coverage.md
@@ -167,7 +167,8 @@ first-parent spine and the raw range are identical; every subject carries its
 [@deining]: https://github.com/deining
 [release report]: ../../../docsy.dev/content/en/blog/2026/0.16.0.md
 [hugo upgrade guide]: ../../../docsy.dev/content/en/blog/2026/hugo-0.158.0+.md
-[0.16.0-changelog]: ../../../docsy.dev/content/en/project/about/changelog/#next
+[0.16.0-changelog]:
+  ../../../docsy.dev/content/en/project/about/changelog/#v0.16.0
 [#726]: https://github.com/google/docsy/issues/726
 [#2357]: https://github.com/google/docsy/issues/2357
 [#2501]: https://github.com/google/docsy/issues/2501

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -1,7 +1,7 @@
 ---
 title: 0.16 release-prep plan
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 # Release coordinates — the per-release facts the process keys off.
 prev-version: 0.15.0 # baseline tag: v0.15.0 (2026-05-01)
 version: 0.16.0
@@ -9,7 +9,7 @@ milestone: 24
 tracker-issue: 2615
 compare-range: v0.15.0..main
 version-stamp-from: 0.15.1-dev
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 hugo-post: hugo-0.158.0+ # companion Hugo upgrade post; omit if no Hugo bump
 ---
 

--- a/tasks/0.16/release-prep/index.plan.md
+++ b/tasks/0.16/release-prep/index.plan.md
@@ -34,7 +34,8 @@ Published artifacts (edited in place, not drafted here):
 
 - Release report: `docsy.dev/content/en/blog/2026/0.16.0.md`
 - Hugo upgrade post: `docsy.dev/content/en/blog/2026/hugo-0.158.0+.md`
-- Changelog: `docsy.dev/content/en/project/about/changelog.md` (`#next` section)
+- Changelog: `docsy.dev/content/en/project/about/changelog.md` (`#v0.16.0`
+  section)
 
 ## Checklist
 

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -203,7 +203,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   then). The changelog carries one **New** entry citing [#2683][]. Highlights
   card: the packaging entry now leads with the npm story — **First-class npm
   support**, title linking `#npm-registry`, with the theme-folder move swept
-  into "and more" (owner call, 2026-07-26) — the three-item cap holds.
+  into "and more" (owner call, 2026-07-26) — three product items, within the
+  cap; the Agent-ready meta-entry's +1 came later (2026-07-29, see the
+  highlights-card decision above).
 - **Applied the otel.io guide feedback** (2026-07-26; from exercising the posts
   over opentelemetry.io, [otel#10906][]): clone/submodule Actions warn that a
   plain `npm install` inside `themes/docsy/` pulls the maintainer workspaces

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -97,18 +97,20 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
 ## Release content status
 
-- [release report][] (`blog/2026/0.16.0.md`): complete draft (`draft: true`).
-  Covers the four breaking changes, the npm-registry announcement, and the
-  experimental shared chrome build mode, each with Actions, an upgrade section,
-  and sanity checks. 2026-07-26 refresh: npm-registry section added; otel.io
-  guide feedback applied (postinstall caution, favicons command qualified);
-  PostCSS section gained Actions and its rationale.
-- [Hugo upgrade guide][] (`blog/2026/hugo-0.158.0+.md`): complete draft
-  (`draft: true`). Carries per-version Hugo mechanics for 0.158.0–0.164.0 (DRY).
-  2026-07-26: Page-level `.Lang` unaffected note added to the language-API
-  table.
-- Changelog `v0.16.0 - UNRELEASED` section: complete; reconciled with the
-  ledger. 2026-07-26: npm-registry **New** entry added.
+- [release report][] (`blog/2026/0.16.0.md`): complete; undrafted 2026-07-29
+  ([#2694][], publishes with the release deploy). Covers the four breaking
+  changes, the npm-registry announcement, and the experimental shared chrome
+  build mode, each with Actions, an upgrade section, and sanity checks.
+  2026-07-26 refresh: npm-registry section added; otel.io guide feedback applied
+  (postinstall caution, favicons command qualified); PostCSS section gained
+  Actions and its rationale.
+- [Hugo upgrade guide][] (`blog/2026/hugo-0.158.0+.md`): complete; undrafted
+  2026-07-29, dated a day before the release post to pin sidebar order. Carries
+  per-version Hugo mechanics for 0.158.0–0.164.0 (DRY). 2026-07-26: Page-level
+  `.Lang` unaffected note added to the language-API table.
+- Changelog `v0.16.0` section (heading flipped from `UNRELEASED`/`#next`
+  2026-07-29): complete; reconciled with the ledger. 2026-07-26: npm-registry
+  **New** entry added.
 
 ## Decisions
 
@@ -132,9 +134,12 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   [#2357][] in What's next); the changelog cites key issues, keeping PR links
   only for contributor credit ([#2594][], [#2578][]). The ledger remains the
   internal full-coverage record.
-- The highlights card is capped at **three items** (2026-07-16): a packaging
-  entry (**First-class npm support** since the 2026-07-26 rework -- see the
-  routing decision below), favicons, and shared chrome. The minimum-Hugo bump is
+- The highlights card **targets three items** by design (2026-07-16): a
+  packaging entry (**First-class npm support** since the 2026-07-26 rework --
+  see the routing decision below), favicons, and shared chrome. A **+1 overflow
+  is tolerated** for an item added later with justification (guidance amended
+  2026-07-29): here the **Agent-ready upgrade guide** meta-entry, added with the
+  0.15-lineage agent-support arc and leading the card. The minimum-Hugo bump is
   deliberately not in the card: it is routine (0.15 did the same), has its own
   section plus the companion Hugo guide, and Ready-to-Upgrade lists every
   breaking change anyway.
@@ -257,15 +262,17 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
       `docs/update/_index.md`, and the `[blog-npm-deps]` link defs in
       `docs/update/convert-site-to-module.md` and
       `docs/get-started/docsy-as-module/start-from-scratch.md` (each site
-      carries a `TODO(tag-time)` comment; from [#2692][]).
+      carried a `TODO(tag-time)` comment, removed with the re-point; from
+      [#2692][]).
 - [x] Bump the version stamp from `0.15.1-dev` to the release version in
       `package.json` and `docsy.dev` configs (`tdVersion`/`params`).
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
       (required by the theme folder move; **not yet in the maintainer notes
-      procedure** — new this release). Verify the tag exists **before** flipping
-      the posts' `draft: true`: every install-mode Action in the release post
-      depends on it, and 0.16.0 is the first release to exercise the nested-tag
-      scheme.
+      procedure** — new this release). Verify the tag exists **before** the
+      deploy that takes the posts live: every install-mode Action in the release
+      post depends on it, and 0.16.0 is the first release to exercise the
+      nested-tag scheme. (The source-level `draft: true` flip rides the
+      release-prep PR earlier — the tag gates publication, not that edit.)
 - [ ] Publish `@docsy/theme@0.16.0` to the npm registry from the tagged commit
       and re-point dist-tag `next` at it, **before** the site deploy flips the
       posts live (the post's install commands must resolve). Verify with
@@ -349,6 +356,7 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2688]: https://github.com/google/docsy/pull/2688
 [#2689]: https://github.com/google/docsy/issues/2689
 [#2692]: https://github.com/google/docsy/pull/2692
+[#2694]: https://github.com/google/docsy/pull/2694
 [69e597cc]: https://github.com/google/docsy/commit/69e597cc
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [link-cache]: https://github.com/chalin/link-cache

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -238,24 +238,24 @@ Before tagging, confirm the milestone's closed list matches the
 The canonical procedure is maintainer notes, [Publishing a release][pub-rel];
 this tracks 0.16-specific status and deltas, not the full mechanics.
 
-- [ ] Flip `draft: true` → `false` on both blog posts and set their final dates.
+- [x] Flip `draft: true` → `false` on both blog posts and set their final dates.
 - [x] Validate the theme's minimum Hugo version: done 2026-07-17 via a one-off
       fixture-matrix build on 0.158.0/0.159.0; minimum raised to 0.160.1 — see
       Decisions. Ongoing validation is now the minimum-Hugo lane of
       `test:smoke`, run at release step 8.
-- [ ] Replace placeholders that resolve only after tagging: the
+- [x] Replace placeholders that resolve only after tagging: the
       `releases/tag/v0.16.0` links, the changelog `UNRELEASED` heading/banner,
       the release post's `[CL@0.16.0]` link (`/changelog/#next` →
       `/changelog/#v0.16.0`, since the heading anchor changes at release), and
       its `[compare-0.15.0]` link (`v0.15.0...main` → `v0.15.0...v0.16.0`).
-- [ ] Re-point the interim preview-host (`main--docsydocs.netlify.app`) links at
+- [x] Re-point the interim preview-host (`main--docsydocs.netlify.app`) links at
       the production `/blog/2026/0.16.0/` URLs once the post publishes: the
       `[0.16.0]` link def in `blog/2025/0.12.0.md`, the `[tfa]` link def in
       `docs/update/_index.md`, and the `[blog-npm-deps]` link defs in
       `docs/update/convert-site-to-module.md` and
       `docs/get-started/docsy-as-module/start-from-scratch.md` (each site
       carries a `TODO(tag-time)` comment; from [#2692][]).
-- [ ] Bump the version stamp from `0.15.1-dev` to the release version in
+- [x] Bump the version stamp from `0.15.1-dev` to the release version in
       `package.json` and `docsy.dev` configs (`tdVersion`/`params`).
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
       (required by the theme folder move; **not yet in the maintainer notes

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -1,9 +1,9 @@
 ---
 title: 0.16 release-prep wrapup
 date: 2026-06-15
-lastmod: 2026-07-26
+lastmod: 2026-07-29
 range: v0.15.0..main
-last-main-commit: 9b1d9951
+last-main-commit: 69e597cc
 cSpell:ignore: favicons retokenization thoughtry
 ---
 
@@ -11,7 +11,7 @@ Synthesized state for 0.16 release prep: themes, breaking changes, decisions,
 milestone hygiene, and the tag-time checklist. The objective per-change matrix
 lives in [coverage.md](coverage.md); this file holds the judgment layer.
 
-> Prepared for commits in [v0.15.0...main][] through [9b1d9951][].
+> Prepared for commits in [v0.15.0...main][] through [69e597cc][].
 
 ## Themes (with evidence and client impact)
 
@@ -346,7 +346,7 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 [#2688]: https://github.com/google/docsy/pull/2688
 [#2689]: https://github.com/google/docsy/issues/2689
 [#2692]: https://github.com/google/docsy/pull/2692
-[9b1d9951]: https://github.com/google/docsy/commit/9b1d9951
+[69e597cc]: https://github.com/google/docsy/commit/69e597cc
 [docsy-example#478]: https://github.com/google/docsy-example/pull/478
 [link-cache]: https://github.com/chalin/link-cache
 [official support policy]:

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -269,12 +269,12 @@ this tracks 0.16-specific status and deltas, not the full mechanics.
 - [x] Bump the version stamp from `0.15.1-dev` to the release version in
       `package.json` and `docsy.dev` configs (`tdVersion`/`params`).
 - [ ] Publish the nested Hugo module tag `theme/v0.16.0` at the release commit
-      (required by the theme folder move; **not yet in the maintainer notes
-      procedure** — new this release). Verify the tag exists **before** the
-      deploy that takes the posts live: every install-mode Action in the release
-      post depends on it, and 0.16.0 is the first release to exercise the
-      nested-tag scheme. (The source-level `draft: true` flip rides the
-      release-prep PR earlier — the tag gates publication, not that edit.)
+      (required by the theme folder move — new this release). Verify the tag
+      exists **before** the deploy that takes the posts live: every install-mode
+      Action in the release post depends on it, and 0.16.0 is the first release
+      to exercise the nested-tag scheme. (The source-level `draft: true` flip
+      rides the release-prep PR earlier — the tag gates publication, not that
+      edit.)
 - [ ] Publish `@docsy/theme@0.16.0` to the npm registry from the tagged commit
       and re-point dist-tag `next` at it, **before** the site deploy flips the
       posts live (the post's install commands must resolve). Verify with

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -139,7 +139,8 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   see the routing decision below), favicons, and shared chrome. A **+1 overflow
   is tolerated** for an item added later with justification (guidance amended
   2026-07-29): here the **Agent-ready upgrade guide** meta-entry, added with the
-  0.15-lineage agent-support arc and leading the card. The minimum-Hugo bump is
+  0.15-lineage agent-support arc (initially leading the card; moved last,
+  product items first, in the 2026-07-29 review round). The minimum-Hugo bump is
   deliberately not in the card: it is routine (0.15 did the same), has its own
   section plus the companion Hugo guide, and Ready-to-Upgrade lists every
   breaking change anyway.
@@ -202,8 +203,9 @@ lives in [coverage.md](coverage.md); this file holds the judgment layer.
   restating it, and the policy rewrite itself shipped with [#2688][] (routed
   then). The changelog carries one **New** entry citing [#2683][]. Highlights
   card: the packaging entry now leads with the npm story — **First-class npm
-  support**, title linking `#npm-registry`, with the theme-folder move swept
-  into "and more" (owner call, 2026-07-26) — three product items, within the
+  support**, title linking `#npm-registry`, with "and more" sweeping in the
+  packaging arc (owner call, 2026-07-26; `[more]` re-pointed `#theme-folder` →
+  `#npm-deps` in the 2026-07-29 review round) — three product items, within the
   cap; the Agent-ready meta-entry's +1 came later (2026-07-29, see the
   highlights-card decision above).
 - **Applied the otel.io guide feedback** (2026-07-26; from exercising the posts

--- a/tasks/0.16/release-prep/wrapup.md
+++ b/tasks/0.16/release-prep/wrapup.md
@@ -238,6 +238,9 @@ Before tagging, confirm the milestone's closed list matches the
 The canonical procedure is maintainer notes, [Publishing a release][pub-rel];
 this tracks 0.16-specific status and deltas, not the full mechanics.
 
+- [x] Refresh-loop gate: the ledger and coordinates are current through the tip
+      the release commit builds on (`last-main-commit: 69e597cc`; refreshed
+      2026-07-29 — see the skill's tag-time gate).
 - [x] Flip `draft: true` → `false` on both blog posts and set their final dates.
 - [x] Validate the theme's minimum Hugo version: done 2026-07-17 via a one-off
       fixture-matrix build on 0.158.0/0.159.0; minimum raised to 0.160.1 — see

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.15.1-dev+046-over-main-7b2117a9",
+  "version": "0.16.0",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Contributes to #2615 (supersedes #2693, closed by a head-branch rename)
- **Undrafts the 0.16.0 release post and the Hugo 0.158+ upgrade guide** (final dates set; Hugo post dated a day earlier to pin sidebar order), flips the changelog `UNRELEASED` heading to `v0.16.0`, and re-points the tag-dependent links (`compare`, changelog anchor)
- **Re-points the interim preview-host links** from #2692 at the production post URL (the four `TODO(tag-time)` sites); inlines the 0.12.0 post's link
- **Bumps the version stamp** to 0.16.0 (`set:version`: root + theme manifests, docsy.dev configs) and refreshes the md-output golden it renders into
- **Excludes the pre-tag `v0.15.0...v0.16.0` compare URL** in the Lychee config's remove-after-0.16.0-ships block (404 until the tag exists)
- **Release-prep workspace**: ledger and coordinates refreshed through `69e597cc`; tag-time checklist gains the refresh-loop gate item
- **Previews**:
  - [Release 0.16.0 report](https://deploy-preview-2694--docsydocs.netlify.app/blog/2026/0.16.0/)
  - [Hugo 0.158+ upgrade guide](https://deploy-preview-2694--docsydocs.netlify.app/blog/2026/hugo-0.158.0+/)
  - [Changelog](https://deploy-preview-2694--docsydocs.netlify.app/project/about/changelog/)
