### PR TITLE
Set version to v0.16.1-dev

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -254,6 +254,7 @@ https://github.com/google/docsy/blob/v0.7.0/assets/scss/main.scss,200,1782498241
 https://github.com/google/docsy/blob/v0.7.0/layouts/partials/footer.html,200,1782498240
 https://github.com/google/docsy/commits/main,200,1782563369
 https://github.com/google/docsy/compare/v0.15.0...main,200,1782563370
+https://github.com/google/docsy/compare/v0.15.0...v0.16.0,200,1785360538
 https://github.com/google/docsy/compare/v0.8.0...v0.9.0,200,1782498238
 https://github.com/google/docsy/discussions,200,1782563367
 https://github.com/google/docsy/discussions/1308,200,1782498228
@@ -516,9 +517,12 @@ https://github.com/google/docsy/pull/941,200,1782498225
 https://github.com/google/docsy/pulls,200,1782563369
 https://github.com/google/docsy/releases,200,1782563368
 https://github.com/google/docsy/releases/latest,200,1782563369
+https://github.com/google/docsy/releases/latest?FIXME=v0.16.1,200,1785360538
+https://github.com/google/docsy/releases/latest?FIXME=v0.17.0,200,1785360538
 https://github.com/google/docsy/releases/new,200,1782498229
 https://github.com/google/docsy/releases/tag/v0.10.0,200,1782498237
 https://github.com/google/docsy/releases/tag/v0.11.0,200,1782498235
+https://github.com/google/docsy/releases/tag/v0.16.0,200,1785360538
 https://github.com/google/docsy/releases/tag/v0.7.0,200,1782498239
 https://github.com/google/docsy/releases/tag/v0.9.0,200,1782498237
 https://github.com/google/docsy/releases/v0.10.0,200,1782498226
@@ -530,6 +534,7 @@ https://github.com/google/docsy/releases/v0.14.1,200,1782498222
 https://github.com/google/docsy/releases/v0.14.2,200,1782498222
 https://github.com/google/docsy/releases/v0.14.3,200,1782498222
 https://github.com/google/docsy/releases/v0.15.0,200,1782563370
+https://github.com/google/docsy/releases/v0.16.0,200,1785360538
 https://github.com/google/docsy/releases/v0.2.0,200,1782498229
 https://github.com/google/docsy/releases/v0.3.0,200,1782498229
 https://github.com/google/docsy/releases/v0.4.0,200,1782498229
@@ -887,7 +892,9 @@ https://www.docsy.dev/blog/2025/0.12.0/,200,1782498244
 https://www.docsy.dev/blog/2025/0.13.0/,200,1782498244
 https://www.docsy.dev/blog/2026/0.14.0/,200,1782498244
 https://www.docsy.dev/blog/2026/0.15.0/,200,1782498244
+https://www.docsy.dev/blog/2026/0.16.0/,200,1785360538
 https://www.docsy.dev/blog/2026/hugo-0.152.0+/,200,1782498244
+https://www.docsy.dev/blog/2026/hugo-0.158.0+/,200,1785360538
 https://www.docsy.dev/community/,200,1782563367
 https://www.docsy.dev/docs/,200,1782498226
 https://www.docsy.dev/docs/best-practices/,200,1782563367
@@ -910,6 +917,7 @@ https://www.docsy.dev/docs/content/versioning/,200,1782498237
 https://www.docsy.dev/docs/contributing/,200,1782563367
 https://www.docsy.dev/docs/deployment/,200,1782563367
 https://www.docsy.dev/docs/deployment/amazon/,200,1782498243
+https://www.docsy.dev/docs/deployment/chrome/,200,1785360538
 https://www.docsy.dev/docs/deployment/github-pages/,200,1782498243
 https://www.docsy.dev/docs/deployment/local/,200,1782498238
 https://www.docsy.dev/docs/deployment/netlify/,200,1782498239

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -13,7 +13,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 001-over-main-9e5d51b7
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 001-over-main-9e5d51b7
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId ''
+  buildId: &tdBuildId 001-over-main-9e5d51b7
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/examples/index.md
+++ b/docsy.dev/content/en/examples/index.md
@@ -63,8 +63,8 @@ The Docsy project provides two site starter templates:
 
 | Site                               | Repo                                      | Docsy            |
 | ---------------------------------- | ----------------------------------------- | ---------------- |
-| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | v0.15.0 (latest) |
-| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | v0.15.0 (latest) |
+| [Goldydocs][] - main Docsy example | <{{% param github_repo %}}-example>       | v0.16.0 (latest) |
+| [Docsy starter][]                  | <https://github.com/chalin/docsy-starter> | v0.16.0 (latest) |
 
 In addition to these example starters, there are several live sites using the
 theme. Consider adding your Docsy-based site to this page once you have a

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -141,6 +141,31 @@ functionality, depending on scope. Prefer narrow, focused PRs where possible.
 
 </details>
 
+## v0.16.1 or v0.17.0 - UNRELEASED {#next}
+
+> **UNRELEASED: this planned version is still under development**
+
+For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
+
+[**Breaking changes**](#breaking-change):
+
+- ...
+
+**New**:
+
+- ...
+
+**Other changes**:
+
+- ...
+
+[**Experimental**](#experimental):
+
+- ...
+
+[0.16.1]: https://github.com/google/docsy/releases/latest?FIXME=v0.16.1
+[0.17.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.17.0
+
 ## v0.16.0 {#v0.16.0}
 
 For an introduction to this release, see the [0.16.0 release report][]. For

--- a/docsy.dev/lychee.toml
+++ b/docsy.dev/lychee.toml
@@ -34,12 +34,4 @@ exclude = [
   '^https://docsearch\.algolia\.com/',               # bot-wall (403) on the apply page
   '^https://prismjs\.com/download\.html#',           # download-builder state hash, not an anchor
   '^https://portal\.aws\.amazon\.com/',              # SPA signup flow, fragment is a client route
-
-  # Remove after 0.16.0 ships: the release tag and the version dropdown's
-  # "latest" links to pages new/draft in this cycle (absent on v0.15.0 prod).
-  '^https://github\.com/google/docsy/releases/(tag/)?v0\.16\.0$',
-  '^https://github\.com/google/docsy/compare/v0\.15\.0\.\.\.v0\.16\.0$',
-  '^https://www\.docsy\.dev/docs/deployment/chrome/$',
-  '^https://www\.docsy\.dev/blog/2026/0\.16\.0/$',
-  '^https://www\.docsy\.dev/blog/2026/hugo-0\.158\.0\+/$',
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.16.0",
+  "version": "0.16.1-dev+001-over-main-9e5d51b7",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.16.0",
+  "version": "0.16.1-dev+001-over-main-9e5d51b7",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Post-0.16.0-release followup, per the maintainer notes § [Post Docsy-release followup](https://www.docsy.dev/project/about/maintainer-notes/#post-docsy-release-followup):

- **Dev version stamp**: `0.16.1-dev+001-over-main-9e5d51b7` via `set:version:git-info`
- **Retires the 0.16.0-scoped lychee exclusions**: the formerly excluded URLs (release tag/compare, new-in-cycle pages) now exist on prod and check clean (link check: 0 errors)
- **Changelog**: seeds the next-release entry from the ENTRY TEMPLATE
- **Examples page**: Starter-templates table bumped to v0.16.0 ([chalin/docsy-starter#15](https://github.com/chalin/docsy-starter/pull/15) has landed, so both starters are on 0.16.0)
- **Previews**:
  - [Changelog](https://deploy-preview-2697--docsydocs.netlify.app/project/about/changelog/)
  - [Examples](https://deploy-preview-2697--docsydocs.netlify.app/examples/)
