### PR TITLE
CI: don't persist checkout credentials; note about npm publishing

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -32,6 +32,8 @@ jobs:
     if: github.event_name != 'push' || github.repository == 'google/docsy'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,8 @@ jobs:
         os: [windows-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -72,6 +72,7 @@ https://docs.npmjs.com/cli/v10/using-npm/scripts,200,1782563368
 https://docs.npmjs.com/cli/v11/commands/npm-dist-tag,200,1784978353
 https://docs.npmjs.com/cli/v11/commands/npm-dist-tag/,200,1784978429
 https://docs.npmjs.com/cli/v11/commands/npm-install#description,200,1784982268
+https://docs.npmjs.com/trusted-publishers/,200,1786206945
 https://docsy.dev/,200,1782563367
 https://domsignal.com/x-frame-options-test,200,1782498238
 https://ds-docs.y.org/,200,1782498244

--- a/docsy.dev/config/_default/params.yaml
+++ b/docsy.dev/config/_default/params.yaml
@@ -13,7 +13,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId 003-over-main-be0a08fe
+  buildId: &tdBuildId 004-over-main-616df5f1
 
 version: *tdDevVers
 version_menu: *tdDevVers

--- a/docsy.dev/config/doc-rooted/params.yaml
+++ b/docsy.dev/config/doc-rooted/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId 003-over-main-be0a08fe
+  buildId: &tdBuildId 004-over-main-616df5f1
 
 version: &tdDocRootedVers Doc-rooted of Next
 version_menu: *tdLatestVers

--- a/docsy.dev/config/production/params.yaml
+++ b/docsy.dev/config/production/params.yaml
@@ -3,7 +3,7 @@
 tdVersion:
   latest: &tdLatestVers v0.16.0
   dev: &tdDevVers v0.16.1-dev
-  buildId: &tdBuildId 003-over-main-be0a08fe
+  buildId: &tdBuildId 004-over-main-616df5f1
 
 version: *tdLatestVers
 version_menu: *tdLatestVers

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -448,7 +448,7 @@ If not adjust accordingly.
 15. **Publish the theme package**:
     - Until [trusted publishing][] is adopted, authenticate for a narrow publish
       window only: `npm login` right before publishing, `npm logout` right after
-      -- whether or not publishing succeeded. If logout fails, revoke the access
+      (whether or not publishing succeeded). If logout fails, revoke the access
       token from your npm account settings.
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -448,7 +448,8 @@ If not adjust accordingly.
 15. **Publish the theme package**:
     - Until [trusted publishing][] is adopted, authenticate for a narrow publish
       window only: `npm login` right before publishing, `npm logout` right after
-      to revoke the session token.
+      -- whether or not publishing succeeded. If logout fails, revoke the
+      session token from your npm account settings.
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.
     - Verify that the `latest` and `next` dist-tags point at it.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -448,8 +448,8 @@ If not adjust accordingly.
 15. **Publish the theme package**:
     - Until [trusted publishing][] is adopted, authenticate for a narrow publish
       window only: `npm login` right before publishing, `npm logout` right after
-      -- whether or not publishing succeeded. If logout fails, revoke the
-      session token from your npm account settings.
+      -- whether or not publishing succeeded. If logout fails, revoke the access
+      token from your npm account settings.
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.
     - Verify that the `latest` and `next` dist-tags point at it.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -446,6 +446,8 @@ If not adjust accordingly.
     </details>
 
 15. **Publish the theme package**:
+    - Authenticate for a narrow publish window only: `npm login` right before
+      publishing, `npm logout` right after to revoke the session token.
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.
     - Verify that the `latest` and `next` dist-tags point at it.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -446,8 +446,9 @@ If not adjust accordingly.
     </details>
 
 15. **Publish the theme package**:
-    - Authenticate for a narrow publish window only: `npm login` right before
-      publishing, `npm logout` right after to revoke the session token.
+    - Until [trusted publishing][] is adopted, authenticate for a narrow publish
+      window only: `npm login` right before publishing, `npm logout` right after
+      to revoke the session token.
     - Publish to the npm registry from `theme/` at the tagged release commit.
     - Verify the published version.
     - Verify that the `latest` and `next` dist-tags point at it.
@@ -721,6 +722,7 @@ To test a Docsy branch or release from a consumer site, for each site:
 [theme/package.json]: <{{% param github_repo %}}/blob/main/theme/package.json>
 [theme/theme.toml]: <{{% param github_repo %}}/blob/main/theme/theme.toml>
 [themes showcase]: https://github.com/gohugoio/hugoThemesSiteBuilder#theme-configuration
+[trusted publishing]: https://docs.npmjs.com/trusted-publishers/
 [public]: /project/about/changelog/#public
 [tags]: <{{% param github_repo %}}/tags>
 <!-- prettier-ignore-end -->

--- a/docsy.dev/netlify.toml
+++ b/docsy.dev/netlify.toml
@@ -1,7 +1,6 @@
-# Hugo build configuration for Netlify
-# (https://gohugo.io/host-and-deploy/host-on-netlify/#configure-hugo-version-in-netlify)
+# Hugo comes from the pinned hugo-extended npm dep, not a HUGO_VERSION env var.
 
-# base = "docsy.dev" - set via web UI
+# The build "base" is set to docsy.dev via the Netlify web UI.
 
 [build]
 publish = "docsy.dev/public"
@@ -24,7 +23,7 @@ command = "npm run _netlify:prepare && npm run -C docsy.dev build:production"
 [context.doc-rooted.environment]
 TD_BUILD_CTX = "doc-rooted"
 
-# Redirects for slug swap: /docs/adding-content/ → /docs/content/
+# Preserve links from the /docs/adding-content/ → /docs/content/ slug swap.
 [[redirects]]
   from = "/docs/adding-content/content"
   to = "/docs/content/adding-content"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docsy",
-  "version": "0.16.1-dev+003-over-main-be0a08fe",
+  "version": "0.16.1-dev+004-over-main-616df5f1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docsy",
-      "version": "0.16.1-dev+003-over-main-be0a08fe",
+      "version": "0.16.1-dev+004-over-main-616df5f1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -2528,7 +2528,7 @@
     },
     "theme": {
       "name": "@docsy/theme",
-      "version": "0.16.1-dev+003-over-main-be0a08fe",
+      "version": "0.16.1-dev+004-over-main-616df5f1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docsy",
-  "version": "0.16.1-dev+003-over-main-be0a08fe",
+  "version": "0.16.1-dev+004-over-main-616df5f1",
   "repository": "github:google/docsy",
   "homepage": "https://www.docsy.dev",
   "license": "Apache-2.0",

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@docsy/theme",
-  "version": "0.16.1-dev+003-over-main-be0a08fe",
+  "version": "0.16.1-dev+004-over-main-616df5f1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@docsy/theme",
-      "version": "0.16.1-dev+003-over-main-be0a08fe",
+      "version": "0.16.1-dev+004-over-main-616df5f1",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.7.2",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docsy/theme",
-  "version": "0.16.1-dev+003-over-main-be0a08fe",
+  "version": "0.16.1-dev+004-over-main-616df5f1",
   "description": "A Hugo theme for technical documentation sites",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- **Credential isolation**: adds `persist-credentials: false` to both workflows' checkout steps, so the built-in token is no longer persisted into the checkout's `.git` config where dependency-controlled steps could read it
  - Both workflows already declare only top-level `contents: read`; no token is directly passed to any `run` step (pinned `actions/setup-node` still takes the default `github.token` for its version-manifest lookup)
- **Maintainer notes**: documents a narrow npm publish auth window until trusted publishing is adopted (`npm login` right before publishing, `npm logout` right after even on a failed publish, manual token revocation as the fallback)
- **netlify.toml**: comment clarifications only
- **Preview(s)**:
  - [Maintainer notes § Publishing a release](https://deploy-preview-2702--docsydocs.netlify.app/project/about/maintainer-notes/#publishing-a-release)
