### PR TITLE
Mermaid: pin default version, drop `latest`

### DIFF
--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -330,6 +330,7 @@ https://github.com/google/docsy/issues/2668,200,1782784208
 https://github.com/google/docsy/issues/2683,200,1785081670
 https://github.com/google/docsy/issues/2689,200,1785081670
 https://github.com/google/docsy/issues/2691,200,1785178993
+https://github.com/google/docsy/issues/2703,200,1786216878
 https://github.com/google/docsy/issues/331,200,1782498237
 https://github.com/google/docsy/issues/349,200,1782498234
 https://github.com/google/docsy/issues/375,200,1782498235

--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -311,9 +311,9 @@ sequenceDiagram
 Support of Mermaid diagrams is automatically enabled as soon as you use a
 `mermaid` code block on your page.
 
-By default, Docsy loads a pinned, known-good version of Mermaid, updated through
-the theme's regular dependency-update process. To use a different version,
-specify it in your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+By default, Docsy loads a pinned, known-good version of Mermaid that is bumped
+with each theme release. To use a different version, specify it in your
+configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- markdownlint-disable no-shortcut-ref-link -->
 <!-- prettier-ignore-start -->
@@ -321,18 +321,18 @@ specify it in your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 {{< tab header="Configuration file:" disabled=true />}}
 {{< tab header="hugo.toml" lang="toml" >}}
 [params.mermaid]
-version = "11.6.0"
+version = "11.16.1"
 {{< /tab >}}
 {{< tab header="hugo.yaml" lang="yaml" >}}
 params:
   mermaid:
-    version: 11.6.0
+    version: 11.16.1
 {{< /tab >}}
 {{< tab header="hugo.json" lang="json" >}}
 {
   "params": {
     "mermaid": {
-      "version": "11.6.0"
+      "version": "11.16.1"
     }
   }
 }
@@ -340,6 +340,10 @@ params:
 {{< /tabpane >}}
 <!-- prettier-ignore-end -->
 <!-- markdownlint-enable no-shortcut-ref-link -->
+
+Use an exact version (`X.Y.Z`): floating versions such as `latest` or `11` are
+re-resolved by the CDN on each request, reintroducing the failure mode that the
+pinned default avoids.
 
 If needed, you can define custom settings for your diagrams, such as themes,
 padding in your `hugo.toml`/`hugo.yaml`/`hugo.json`.

--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -311,9 +311,9 @@ sequenceDiagram
 Support of Mermaid diagrams is automatically enabled as soon as you use a
 `mermaid` code block on your page.
 
-By default, Docsy pulls in the latest officially released version of Mermaid at
-build time. If that doesn't fit your needs, you can specify the wanted mermaid
-version inside your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+By default, Docsy loads a pinned, known-good version of Mermaid, updated through
+the theme's regular dependency-update process. To use a different version,
+specify it in your configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- markdownlint-disable no-shortcut-ref-link -->
 <!-- prettier-ignore-start -->

--- a/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
+++ b/docsy.dev/content/en/docs/content/diagrams-and-formulae/index.md
@@ -261,12 +261,12 @@ variety of different diagram types, including flowcharts, sequence diagrams,
 class diagrams, state diagrams, ER diagrams, user journey diagrams, Gantt charts
 and pie charts.
 
-With Mermaid support enabled in Docsy, you can include the text definition of a
-Mermaid diagram inside a code block, and it will automatically be rendered by
-the browser as soon as the page loads.
+Mermaid support is automatically enabled when you use a `mermaid` code block on
+your page: the browser renders the text definition to a diagram as soon as the
+page loads.
 
 The great advantage of this is anyone who can edit the page can now edit the
-diagram - no more hunting for the original tools and version to make a new edit.
+diagram: no more hunting for the original tools and version to make a new edit.
 
 For example, the following defines a sequence diagram:
 
@@ -308,12 +308,10 @@ sequenceDiagram
     Docsy user->>Docsy user: Being happy
 ```
 
-Support of Mermaid diagrams is automatically enabled as soon as you use a
-`mermaid` code block on your page.
-
-By default, Docsy loads a pinned, known-good version of Mermaid that is bumped
-with each theme release. To use a different version, specify it in your
-configuration file `hugo.toml`/`hugo.yaml`/`hugo.json`:
+Docsy loads Mermaid from the jsDelivr CDN at page load. By default it loads a
+pinned version, currently 11.16.1, updated with each theme release. To use a
+different version, specify it in your configuration file
+`hugo.toml`/`hugo.yaml`/`hugo.json`:
 
 <!-- markdownlint-disable no-shortcut-ref-link -->
 <!-- prettier-ignore-start -->
@@ -342,8 +340,8 @@ params:
 <!-- markdownlint-enable no-shortcut-ref-link -->
 
 Use an exact version (`X.Y.Z`): floating versions such as `latest` or `11` are
-re-resolved by the CDN on each request, reintroducing the failure mode that the
-pinned default avoids.
+re-resolved by the CDN on each request, so your site's diagrams can break
+without any change on your part.
 
 If needed, you can define custom settings for your diagrams, such as themes,
 padding in your `hugo.toml`/`hugo.yaml`/`hugo.json`.

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -157,7 +157,9 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 **Other changes**:
 
-- ...
+- Pinned the default Mermaid version to 11.16.1 instead of resolving `latest`
+  from the CDN at build time; sites can still override it via
+  `params.mermaid.version` ([#2703][]).
 
 [**Experimental**](#experimental):
 
@@ -169,6 +171,7 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
   unreviewed dependency scripts are disabled ([#2700][]).
 
 [#2700]: https://github.com/google/docsy/pull/2700
+[#2703]: https://github.com/google/docsy/issues/2703
 [0.16.1]: https://github.com/google/docsy/releases/latest?FIXME=v0.16.1
 [0.17.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.17.0
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -157,9 +157,9 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 **Other changes**:
 
-- Pinned the default Mermaid version to 11.16.1 instead of resolving `latest`
-  from the CDN at build time; sites can still override it via
-  `params.mermaid.version` ([#2703][]).
+- Pinned the default Mermaid version to 11.16.1; pages previously loaded
+  whatever `latest` resolved to on the CDN at page load. Sites can still
+  override the version via `params.mermaid.version` ([#2703][]).
 
 [**Experimental**](#experimental):
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -159,7 +159,9 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 - Pinned the default Mermaid version to 11.16.1; pages previously loaded
   whatever `latest` resolved to on the CDN at page load. Sites can still
-  override the version via `params.mermaid.version` ([#2703][]).
+  override the version via
+  [`params.mermaid.version`](/docs/content/diagrams-and-formulae/#diagrams-with-mermaid)
+  ([#2703][]).
 
 [**Experimental**](#experimental):
 

--- a/docsy.dev/content/en/project/about/changelog.md
+++ b/docsy.dev/content/en/project/about/changelog.md
@@ -159,8 +159,7 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 - Pinned the default Mermaid version to 11.16.1; pages previously loaded
   whatever `latest` resolved to on the CDN at page load. Sites can still
-  override the version via
-  [`params.mermaid.version`](/docs/content/diagrams-and-formulae/#diagrams-with-mermaid)
+  override the version via [`params.mermaid.version`][mermaid-version]
   ([#2703][]).
 
 [**Experimental**](#experimental):
@@ -174,6 +173,7 @@ For the full list of changes, see the [0.16.1][] or [0.17.0][] release page.
 
 [#2700]: https://github.com/google/docsy/pull/2700
 [#2703]: https://github.com/google/docsy/issues/2703
+[mermaid-version]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
 [0.16.1]: https://github.com/google/docsy/releases/latest?FIXME=v0.16.1
 [0.17.0]: https://github.com/google/docsy/releases/latest?FIXME=v0.17.0
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -118,6 +118,16 @@ it, run:
 Docs render this version live through the `hugo-version` shortcode
 (`hugo.Version`): docsy.dev builds always run the pinned Hugo.
 
+### Default Mermaid version {#mermaid-version}
+
+The Mermaid version that Docsy loads by default is pinned in the
+`scripts/mermaid.html` partial (sites override it via `params.mermaid.version`).
+Keep the pin current through the regular dependency-update process: bump it to
+the latest Mermaid stable when preparing a release, along with the docs page on
+[diagrams][] that mentions it.
+
+[diagrams]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
+
 ## Test suites
 
 From the repo root:

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -124,8 +124,9 @@ The Mermaid version that Docsy loads by default is pinned in the
 `theme/layouts/_partials/scripts/mermaid.html` partial (sites override it via
 `params.mermaid.version`). No script or automation updates the pin yet: bump it
 to the latest Mermaid stable during the
-[release-prep audit](#release-prep-audit), along with the [diagrams][] page's
-override examples, which show the pinned version.
+[release-prep audit](#release-prep-audit), along with the [diagrams][] page,
+which states the pinned version. Verify that a Mermaid-bearing page (the
+diagrams page, for example) renders with the new pin.
 
 [diagrams]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -121,10 +121,11 @@ Docs render this version live through the `hugo-version` shortcode
 ### Default Mermaid version {#mermaid-version}
 
 The Mermaid version that Docsy loads by default is pinned in the
-`scripts/mermaid.html` partial (sites override it via `params.mermaid.version`).
-Keep the pin current through the regular dependency-update process: bump it to
-the latest Mermaid stable when preparing a release, along with the docs page on
-[diagrams][] that mentions it.
+`theme/layouts/_partials/scripts/mermaid.html` partial (sites override it via
+`params.mermaid.version`). No script or automation updates the pin yet: bump it
+to the latest Mermaid stable during the
+[release-prep audit](#release-prep-audit), along with the [diagrams][] page's
+override examples, which show the pinned version.
 
 [diagrams]: /docs/content/diagrams-and-formulae/#diagrams-with-mermaid
 
@@ -183,6 +184,10 @@ For each PR/commit in `git log v<prev>..main`:
 4. Be especially alert to: new/renamed params, partials, shortcodes, layouts,
    CSS classes, i18n keys, default-behavior shifts, and changes to the version
    menu, navigation, or other rendered output.
+
+Also check pinned script dependencies for drift: bump the
+[default Mermaid version](#mermaid-version) to the latest stable as part of the
+prep PR.
 
 Capture the audit as a working document and summarize its findings (the
 classifications and where each item is covered) in the release-prep PR

--- a/theme/layouts/_partials/scripts/mermaid.html
+++ b/theme/layouts/_partials/scripts/mermaid.html
@@ -1,4 +1,4 @@
-{{ $version := .Site.Params.mermaid.version | default "latest" -}}
+{{ $version := .Site.Params.mermaid.version | default "11.16.1" -}}
 
 {{ $cdnurl := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.esm.min.mjs" $version -}}
 {{ with try (resources.GetRemote $cdnurl) -}}


### PR DESCRIPTION
- Fixes #2703
- **Pins** the default Mermaid version to 11.16.1 (current stable):
  - Pinned jsDelivr URLs are immutable-cached, closing the alias re-resolution outage class (open-telemetry/opentelemetry.io#11157) and the load-whatever-was-just-published exposure
  - Default only: sites that explicitly set a floating `params.mermaid.version` (`latest`, `11`) keep the old behavior; the docs now warn against such values
- **Keep-current**: maintainer notes gain a release-prep bump note; no new machinery
- **Previews**:
  - [Diagrams and formulae](https://deploy-preview-2704--docsydocs.netlify.app/docs/content/diagrams-and-formulae/#diagrams-with-mermaid)
  - [Maintainer notes § Default Mermaid version](https://deploy-preview-2704--docsydocs.netlify.app/project/about/maintainer-notes/#mermaid-version)
  - [Changelog](https://deploy-preview-2704--docsydocs.netlify.app/project/about/changelog/#next)