### PR TITLE
Publish @docsy/theme via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,6 +95,8 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
+          # This pin exports a dummy NODE_AUTH_TOKEN so the registry-url
+          # config template always resolves; re-verify on setup-node bumps.
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,8 +47,9 @@ jobs:
 
       - name: 'Sanity check: tag commit is on a release branch'
         # The guards check the tag's own content for consistency; this pins
-        # the tagged commit to reviewed history (main, or release for patch
-        # releases), so a tag on an unmerged commit fails before packing.
+        # the tagged commit to main/release history (reviewed history only if
+        # those branches are push-protected: owner-checklist gates), so a tag
+        # on an unmerged commit fails before packing.
         run: >-
           git merge-base --is-ancestor HEAD origin/main || git merge-base
           --is-ancestor HEAD origin/release
@@ -85,6 +86,8 @@ jobs:
     # self-guarding if the job wiring ever changes.
     if: github.repository == 'google/docsy'
     runs-on: ubuntu-latest
+    # Bound the privileged (id-token) window; normal runs take ~1 minute.
+    timeout-minutes: 15
     # Approval boundary: publishes wait on this environment's required
     # reviewers, and the npmjs trusted-publisher registration binds to it.
     environment: npm-publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,16 @@
 #
 # The job installs nothing: the pack contract and `npm publish` need only
 # Node/npm built-ins, so no dependency code runs with the OIDC grant.
+#
+# Design note: one job packs and publishes, with the theme's own lifecycle
+# scripts enabled. That is safe only while the job stays install-free
+# (`npm publish` installs nothing, so only first-party prepack/postpack can
+# run); the guards enforce this coupling and the workflow contract around it.
+# The stricter split (a pack job without the OIDC grant handing the tarball
+# to a lifecycle-free `npm publish TARBALL` job) buys little for a
+# single-package publisher, where controlling packed content already equals
+# controlling the publish; revisit it if this workflow ever needs installs,
+# more packages, or non-human triggers.
 
 name: publish
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,11 +50,9 @@ jobs:
 
       - name: Publish @docsy/theme
         working-directory: theme
-        # The release choices ride the command line: CLI flags outrank
-        # manifest publishConfig (which may carry any npm config key, and
-        # which the guards pin); provenance is automatic under trusted
-        # publishing, but requiring it here fails loudly if it can't be
-        # attested.
+        # Deliberate CLI flags: they outrank manifest publishConfig (pinned by
+        # the guards); provenance is implicit under trusted publishing, but
+        # requiring it fails loudly if it can't be attested.
         run: >-
           npm publish --access public --provenance --tag latest --registry
           https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,9 @@
 # OIDC grant; publish holds the grant and runs no lifecycle scripts
 # (publishing a tarball, unlike a directory, executes none); its checkout
 # only feeds setup-node's .nvmrc read. Neither job installs dependencies.
+# On tag pushes this definition itself travels with the tag, so the checks
+# below bind against mistakes; malice is bounded by the tag ruleset and the
+# environment approval, not by anything written here.
 
 name: publish
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,9 @@ on:
 
 permissions: {}
 
-# One publish at a time, queued in trigger order: concurrent tag pushes could
-# otherwise be approved out of order, leaving `latest` on the older version.
+# One publish at a time: without this, concurrent tag pushes could be
+# approved out of order. An overlapping third push cancels the pending middle
+# run (fail-safe; re-run its workflow if that ever happens).
 concurrency:
   group: npm-publish
   cancel-in-progress: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,72 @@
+# Publish @docsy/theme to the npm registry when a release tag is pushed.
+#
+# Auth is npm trusted publishing (OIDC): the job's id-token permission lets
+# npm mint a short-lived, workflow-scoped credential at publish time, so no
+# long-lived npm token exists to leak or rotate, and npm attaches provenance
+# automatically. The registration binding this repo + workflow filename to the
+# package lives in the package's settings on npmjs.com.
+#
+# The job installs nothing: the pack contract and `npm publish` need only
+# Node/npm built-ins, so no dependency code runs with the OIDC grant.
+
+name: publish
+
+on:
+  push:
+    tags: ['v[0-9]*'] # Release tags; theme/v* Go-module tags don't match.
+
+permissions: {}
+
+jobs:
+  publish:
+    if: github.repository == 'google/docsy'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Mints the OIDC token that trusted publishing exchanges.
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      - name: 'Sanity check: npm meets the trusted-publishing floor'
+        run: |
+          node -e '
+            const { execSync } = require("node:child_process");
+            const floor = "11.5.1"; // first npm CLI with OIDC support
+            const v = execSync("npm --version", { encoding: "utf8" }).trim();
+            const [a, b, c] = v.split(".").map(Number);
+            const ok = a > 11 || (a === 11 && (b > 5 || (b === 5 && c >= 1)));
+            console.log(`npm ${v} (trusted-publishing floor: ${floor})`);
+            process.exit(ok ? 0 : 1);
+          '
+
+      - name: 'Sanity check: tag matches the stamped theme version'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          node -e '
+            const { version } = require("./theme/package.json");
+            const { TAG } = process.env;
+            console.log(`tag ${TAG}, @docsy/theme version ${version}`);
+            process.exit(TAG === `v${version}` ? 0 : 1);
+          '
+
+      - name: 'Sanity check: pack contract'
+        run: node --test scripts/npm-pack.test.mjs
+
+      - name: Publish @docsy/theme
+        working-directory: theme
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ "${TAG#v}" == *-* ]]; then
+            npm publish --tag next # Prereleases; stables take latest.
+          else
+            npm publish
+          fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,8 +51,10 @@ jobs:
       - name: Publish @docsy/theme
         working-directory: theme
         # Deliberate CLI flags: they outrank manifest publishConfig (pinned by
-        # the guards); provenance is implicit under trusted publishing, but
-        # requiring it fails loudly if it can't be attested.
+        # the guards) and any config layer. Scripts stay on for the theme
+        # prepack (it materializes LICENSE); provenance is implicit under
+        # trusted publishing, but requiring it fails loudly if it can't be
+        # attested.
         run: >-
-          npm publish --access public --provenance --tag latest --registry
-          https://registry.npmjs.org
+          npm publish --access public --provenance --tag latest
+          --ignore-scripts=false --registry https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,6 +38,16 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
+          # Full history: the release-branch ancestor check below needs it.
+          fetch-depth: 0
+
+      - name: 'Sanity check: tag commit is on a release branch'
+        # The guards check the tag's own content for consistency; this pins
+        # the tagged commit to reviewed history (main, or release for patch
+        # releases), so a tag on an unmerged commit fails before packing.
+        run: >-
+          git merge-base --is-ancestor HEAD origin/main || git merge-base
+          --is-ancestor HEAD origin/release
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
@@ -67,6 +77,9 @@ jobs:
 
   publish:
     needs: pack
+    # Redundant with pack's guard through needs; keeps the token-holding job
+    # self-guarding if the job wiring ever changes.
+    if: github.repository == 'google/docsy'
     runs-on: ubuntu-latest
     # Approval boundary: publishes wait on this environment's required
     # reviewers, and the npmjs trusted-publisher registration binds to it.
@@ -89,6 +102,11 @@ jobs:
         with:
           name: npm-tarball
           path: ${{ runner.temp }}/npm-tarball
+
+      - name: 'Sanity check: guards hold and the version advances the registry'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/publish-guards.mjs --registry
 
       - name: Publish @docsy/theme
         working-directory: ${{ runner.temp }}/npm-tarball

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,8 +50,11 @@ jobs:
 
       - name: Publish @docsy/theme
         working-directory: theme
-        env:
-          # Provenance is automatic under trusted publishing; requiring it
-          # explicitly fails the publish loudly if it can't be attested.
-          NPM_CONFIG_PROVENANCE: true
-        run: npm publish
+        # The release choices ride the command line: CLI flags outrank
+        # manifest publishConfig (which may carry any npm config key, and
+        # which the guards pin); provenance is automatic under trusted
+        # publishing, but requiring it here fails loudly if it can't be
+        # attested.
+        run: >-
+          npm publish --access public --provenance --tag latest --registry
+          https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # Mints the OIDC token that trusted publishing exchanges.
+      id-token: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,9 @@ jobs:
   publish:
     if: github.repository == 'google/docsy'
     runs-on: ubuntu-latest
+    # Approval boundary: publishes wait on this environment's required
+    # reviewers, and the npmjs trusted-publisher registration binds to it.
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -33,6 +36,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: 'Sanity check: npm meets the trusted-publishing floor'
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,23 +1,16 @@
-# Publish @docsy/theme to the npm registry when a release tag is pushed.
+# Publish @docsy/theme to the npm registry when a stable release tag is
+# pushed.
 #
-# Auth is npm trusted publishing (OIDC): the job's id-token permission lets
-# npm mint a short-lived, workflow-scoped credential at publish time, so no
-# long-lived npm token exists to leak or rotate. The registration binding this
-# repo + workflow filename + environment to the package lives in the package's
-# settings on npmjs.com.
+# Auth is npm trusted publishing (OIDC): the publish job's id-token permission
+# lets npm mint a short-lived, workflow-scoped credential at publish time, so
+# no long-lived npm token exists to leak or rotate. The registration binding
+# this repo + workflow filename + environment to the package lives in the
+# package's settings on npmjs.com.
 #
-# The job installs nothing: the pack contract and `npm publish` need only
-# Node/npm built-ins, so no dependency code runs with the OIDC grant.
-#
-# Design note: one job packs and publishes, with the theme's own lifecycle
-# scripts enabled. That is safe only while the job stays install-free
-# (`npm publish` installs nothing, so only first-party prepack/postpack can
-# run); the guards enforce this coupling and the workflow contract around it.
-# The stricter split (a pack job without the OIDC grant handing the tarball
-# to a lifecycle-free `npm publish TARBALL` job) buys little for a
-# single-package publisher, where controlling packed content already equals
-# controlling the publish; revisit it if this workflow ever needs installs,
-# more packages, or non-human triggers.
+# Two jobs split the trust: pack guards and builds the tarball without the
+# OIDC grant; publish holds the grant but executes no repo code (publishing a
+# tarball, unlike a directory, runs no lifecycle scripts). Neither job
+# installs dependencies.
 
 name: publish
 
@@ -30,14 +23,50 @@ on:
 permissions: {}
 
 jobs:
-  publish:
+  pack:
     if: github.repository == 'google/docsy'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: 'Sanity check: toolchain and tag guards'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/publish-guards.mjs
+
+      - name: 'Sanity check: pack contract'
+        run: node --test scripts/npm-pack.test.mjs
+
+      - name: Pack @docsy/theme
+        working-directory: theme
+        # Scripts stay on for the theme prepack (it materializes LICENSE),
+        # under any npm config; safe here since packing a local directory
+        # installs nothing, so only this repo's own lifecycle can run.
+        run: npm pack --ignore-scripts=false --pack-destination "$RUNNER_TEMP"
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/*.tgz
+          if-no-files-found: error
+
+  publish:
+    needs: pack
     runs-on: ubuntu-latest
     # Approval boundary: publishes wait on this environment's required
     # reviewers, and the npmjs trusted-publisher registration binds to it.
     environment: npm-publish
     permissions:
-      contents: read
+      contents: read # For the checkout, which only feeds setup-node .nvmrc.
       id-token: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -50,21 +79,17 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: 'Sanity check: toolchain and tag guards'
-        env:
-          TAG: ${{ github.ref_name }}
-        run: node scripts/publish-guards.mjs
-
-      - name: 'Sanity check: pack contract'
-        run: node --test scripts/npm-pack.test.mjs
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: npm-tarball
+          path: ${{ runner.temp }}/npm-tarball
 
       - name: Publish @docsy/theme
-        working-directory: theme
+        working-directory: ${{ runner.temp }}/npm-tarball
         # Deliberate CLI flags: they outrank manifest publishConfig (pinned by
-        # the guards) and any config layer. Scripts stay on for the theme
-        # prepack (it materializes LICENSE); provenance is implicit under
+        # the guards) and any config layer; provenance is implicit under
         # trusted publishing, but requiring it fails loudly if it can't be
         # attested.
         run: >-
-          npm publish --access public --provenance --tag latest
-          --ignore-scripts=false --registry https://registry.npmjs.org
+          npm publish ./*.tgz --access public --provenance --tag latest
+          --registry https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,9 +2,9 @@
 #
 # Auth is npm trusted publishing (OIDC): the job's id-token permission lets
 # npm mint a short-lived, workflow-scoped credential at publish time, so no
-# long-lived npm token exists to leak or rotate, and npm attaches provenance
-# automatically. The registration binding this repo + workflow filename to the
-# package lives in the package's settings on npmjs.com.
+# long-lived npm token exists to leak or rotate. The registration binding this
+# repo + workflow filename + environment to the package lives in the package's
+# settings on npmjs.com.
 #
 # The job installs nothing: the pack contract and `npm publish` need only
 # Node/npm built-ins, so no dependency code runs with the OIDC grant.
@@ -13,7 +13,9 @@ name: publish
 
 on:
   push:
-    tags: ['v[0-9]*'] # Release tags; theme/v* Go-module tags don't match.
+    # Stable release tags only; prereleases publish manually, and theme/v*
+    # Go-module tags don't match.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
 
 permissions: {}
 
@@ -38,28 +40,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - name: 'Sanity check: npm meets the trusted-publishing floor'
-        run: |
-          node -e '
-            const { execSync } = require("node:child_process");
-            const floor = "11.5.1"; // first npm CLI with OIDC support
-            const v = execSync("npm --version", { encoding: "utf8" }).trim();
-            const [a, b, c] = v.split(".").map(Number);
-            const ok = a > 11 || (a === 11 && (b > 5 || (b === 5 && c >= 1)));
-            console.log(`npm ${v} (trusted-publishing floor: ${floor})`);
-            process.exit(ok ? 0 : 1);
-          '
-
-      - name: 'Sanity check: tag matches the stamped theme version'
+      - name: 'Sanity check: toolchain and tag guards'
         env:
           TAG: ${{ github.ref_name }}
-        run: |
-          node -e '
-            const { version } = require("./theme/package.json");
-            const { TAG } = process.env;
-            console.log(`tag ${TAG}, @docsy/theme version ${version}`);
-            process.exit(TAG === `v${version}` ? 0 : 1);
-          '
+        run: node scripts/publish-guards.mjs
 
       - name: 'Sanity check: pack contract'
         run: node --test scripts/npm-pack.test.mjs
@@ -67,10 +51,7 @@ jobs:
       - name: Publish @docsy/theme
         working-directory: theme
         env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          if [[ "${TAG#v}" == *-* ]]; then
-            npm publish --tag next # Prereleases; stables take latest.
-          else
-            npm publish
-          fi
+          # Provenance is automatic under trusted publishing; requiring it
+          # explicitly fails the publish loudly if it can't be attested.
+          NPM_CONFIG_PROVENANCE: true
+        run: npm publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,6 +22,12 @@ on:
 
 permissions: {}
 
+# One publish at a time, queued in trigger order: concurrent tag pushes could
+# otherwise be approved out of order, leaving `latest` on the older version.
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
 jobs:
   pack:
     if: github.repository == 'google/docsy'
@@ -87,9 +93,11 @@ jobs:
       - name: Publish @docsy/theme
         working-directory: ${{ runner.temp }}/npm-tarball
         # Deliberate CLI flags: they outrank manifest publishConfig (pinned by
-        # the guards) and any config layer; provenance is implicit under
-        # trusted publishing, but requiring it fails loudly if it can't be
-        # attested.
+        # the guards) and same-key config-file entries; provenance is implicit
+        # under trusted publishing, but requiring it fails loudly if it can't
+        # be attested. (A scope-specific `@docsy:registry` mapping would still
+        # outrank --registry, but no config layer here defines one: setup-node
+        # writes a fresh userconfig and the job cwd is outside the checkout.)
         run: >-
           npm publish ./*.tgz --access public --provenance --tag latest
           --registry https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@
 #
 # Two jobs split the concerns: pack guards and builds the tarball without the
 # OIDC grant; publish holds the grant and runs no lifecycle scripts
-# (publishing a tarball, unlike a directory, executes none) -- its checkout
+# (publishing a tarball, unlike a directory, executes none); its checkout
 # only feeds setup-node's .nvmrc read. Neither job installs dependencies.
 
 name: publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,8 +96,9 @@ jobs:
         # the guards) and same-key config-file entries; provenance is implicit
         # under trusted publishing, but requiring it fails loudly if it can't
         # be attested. (A scope-specific `@docsy:registry` mapping would still
-        # outrank --registry, but no config layer here defines one: setup-node
-        # writes a fresh userconfig and the job cwd is outside the checkout.)
+        # outrank --registry, but none applies here: setup-node writes a fresh
+        # userconfig, and this cwd is outside the checkout, so the repo's own
+        # .npmrc pin is out of scope too.)
         run: >-
           npm publish ./*.tgz --access public --provenance --tag latest
           --registry https://registry.npmjs.org

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,10 @@
 # this repo + workflow filename + environment to the package lives in the
 # package's settings on npmjs.com.
 #
-# Two jobs split the trust: pack guards and builds the tarball without the
-# OIDC grant; publish holds the grant but executes no repo code (publishing a
-# tarball, unlike a directory, runs no lifecycle scripts). Neither job
-# installs dependencies.
+# Two jobs split the concerns: pack guards and builds the tarball without the
+# OIDC grant; publish holds the grant and runs no lifecycle scripts
+# (publishing a tarball, unlike a directory, executes none) -- its checkout
+# only feeds setup-node's .nvmrc read. Neither job installs dependencies.
 
 name: publish
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,17 +42,16 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-          # Full history: the release-branch ancestor check below needs it.
+          # Full history: the main-ancestry check below needs it.
           fetch-depth: 0
 
-      - name: 'Sanity check: tag commit is on a release branch'
+      - name: 'Sanity check: tag commit is on main'
         # The guards check the tag's own content for consistency; this pins
-        # the tagged commit to main/release history (reviewed history only if
-        # those branches are push-protected: owner-checklist gates), so a tag
-        # on an unmerged commit fails before packing.
-        run: >-
-          git merge-base --is-ancestor HEAD origin/main || git merge-base
-          --is-ancestor HEAD origin/release
+        # the tagged commit to main's history (reviewed history as long as
+        # main is push-protected), so a tag on an unmerged commit fails
+        # before packing. Release tags come from main only (owner decision
+        # 2026-08-09); widen deliberately if a release-branch flow returns.
+        run: git merge-base --is-ancestor HEAD origin/main
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,9 @@
 # install-time failure.
 engine-strict=true
 strict-allow-scripts=true
+
+# Pin the @docsy scope registry for manual publish/dist-tag/view commands run
+# from within the repo: a user-level @docsy:registry mapping outranks even
+# --registry, but this project-level pin outranks the user level. The CI
+# publish is unaffected (its cwd is outside the checkout).
+@docsy:registry=https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -5,8 +5,7 @@
 engine-strict=true
 strict-allow-scripts=true
 
-# Pin the @docsy scope registry for manual publish/dist-tag/view commands run
-# from within the repo: a user-level @docsy:registry mapping outranks even
-# --registry, but this project-level pin outranks the user level. The CI
-# publish is unaffected (its cwd is outside the checkout).
+# Pin the @docsy scope registry for manual publish/dist-tag/view commands: a
+# user-level @docsy:registry mapping would outrank even --registry, but this
+# project-level pin outranks the user level. Applies to in-repo cwds only.
 @docsy:registry=https://registry.npmjs.org/

--- a/docsy.dev/.lycheecache
+++ b/docsy.dev/.lycheecache
@@ -188,6 +188,7 @@ https://github.com/google/docsy-example/pull/221,200,1782498240
 https://github.com/google/docsy-example/releases/new,200,1782498230
 https://github.com/google/docsy-example/tree/main/content/en,200,1782498230
 https://github.com/google/docsy-example/tree/main/content/en/blog,200,1782498242
+https://github.com/google/docsy/actions/workflows/publish.yaml,200,1786217951
 https://github.com/google/docsy/blob/main/.github/workflows,200,1782498239
 https://github.com/google/docsy/blob/main/CONTRIBUTING.md,200,1782563368
 https://github.com/google/docsy/blob/main/LICENSE,200,1782563368

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -450,7 +450,10 @@ If not adjust accordingly.
 15. **Verify the npm publish**. Pushing the release tag to `upstream` triggers
     the [publish workflow][], which publishes `@docsy/theme` from the tagged
     commit through npm [trusted publishing][] (OIDC; no npm token involved) once
-    a maintainer approves the run (the `npm-publish` environment).
+    a maintainer approves the run (the `npm-publish` environment). The workflow
+    only publishes tags on `main`'s history: a patch release tagged on the
+    `release` branch needs the workflow's ancestry check deliberately widened
+    first.
     - **Before approving** the waiting `npm-publish` deployment. The guards
       re-verify content and registry order mechanically (an out-of-order or
       inconsistent run fails instead of publishing), and the approval prompt

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -457,8 +457,8 @@ If not adjust accordingly.
       - the pack job is green and its log shows the expected version;
       - the version is above the registry's current `latest` and no other
         publish run is pending (runs queue one at a time, and a publish-job
-        guard rejects a candidate below the registry's `latest`; approving in
-        version order keeps the queue itself honest).
+        guard rejects a candidate below the registry's `latest`, so an
+        out-of-order approval fails rather than regressing `latest`).
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -472,8 +472,7 @@ If not adjust accordingly.
       bullet), then re-verify the dist-tags:
 
       ```sh
-      npm dist-tag add @docsy/theme@${REL#v} next \
-        --@docsy:registry=https://registry.npmjs.org
+      npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
     - **Manual publishes** (prereleases only): the workflow triggers only on
@@ -483,22 +482,20 @@ If not adjust accordingly.
       fails, revoke the access token from your npm account settings:
 
       ```sh
-      npm publish --ignore-scripts=false --tag next \
-        --@docsy:registry=https://registry.npmjs.org
+      npm publish --ignore-scripts=false --tag next
       ```
 
       `--ignore-scripts=false` is required: the theme `prepack` must run (it
-      materializes the LICENSE), even under a script-disabling npm config. The
-      scope-registry pin guards against a local `@docsy:registry` override,
-      which outranks even `--registry`.
+      materializes the LICENSE), even under a script-disabling npm config. Run
+      manual npm commands from within the repo: the root `.npmrc` pins the
+      `@docsy` scope registry against local overrides.
 
     - **If the CI publish is broken for a stable**, prefer fixing CI over a
       laptop publish: a manual publish carries no provenance attestation. As a
       deliberate exception, mirror the workflow's release choices exactly:
 
       ```sh
-      npm publish --ignore-scripts=false --access public --tag latest \
-        --@docsy:registry=https://registry.npmjs.org
+      npm publish --ignore-scripts=false --access public --tag latest
       ```
 
 16. Update the [deploy/prod][] branch from `$BASE`.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -465,9 +465,8 @@ If not adjust accordingly.
       npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
-    - Prerelease tags publish automatically too, under the `next` dist-tag; the
-      routine prerelease (RC) flow stays untagged and manual, though (next
-      bullet).
+    - The workflow triggers only on stable `vX.Y.Z` tags; prereleases publish
+      manually (next bullet).
     - **Manual fallback** (CI publish unavailable) and untagged prereleases:
       publish from `theme/` inside a narrow auth window. Run `npm login` right
       before and `npm logout` right after, whether or not publishing succeeded;

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -454,9 +454,13 @@ If not adjust accordingly.
     - **Before approving** the waiting `npm-publish` deployment. The guards
       re-verify content and registry order mechanically (an out-of-order or
       inconsistent run fails instead of publishing), and the approval prompt
-      only appears after the pack job succeeded, so approval owns **intent**:
-      - the run's commit is the tip of `$BASE`, and the tag actor is the release
-        driver you expect; anything else: reject and ask;
+      only appears after the pack job succeeded, so approval owns **intent**.
+      Note that on tag pushes the workflow definition itself comes from the
+      tagged commit, so for an unexpected tag don't trust the run's green
+      checks; the two checks below are the real barrier:
+      - the run's commit is the release commit you drove (the tip of `$BASE` at
+        tag time; an unrelated merge landing since is fine), and the tag actor
+        is the release driver you expect; anything else: reject and ask;
       - the run is `publish.yaml` on `google/docsy` (another workflow could
         reference the same environment).
     - Check that the workflow run succeeded and that the registry version

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -449,7 +449,8 @@ If not adjust accordingly.
 
 15. **Verify the npm publish**. Pushing the release tag to `upstream` triggers
     the [publish workflow][], which publishes `@docsy/theme` from the tagged
-    commit through npm [trusted publishing][] (OIDC; no npm token involved).
+    commit through npm [trusted publishing][] (OIDC; no npm token involved) once
+    a maintainer approves the run (the `npm-publish` environment).
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 
@@ -464,11 +465,14 @@ If not adjust accordingly.
       npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
-    - **Manual fallback** (CI publish unavailable) and prereleases: publish from
-      `theme/` inside a narrow auth window. Run `npm login` right before and
-      `npm logout` right after, whether or not publishing succeeded; if logout
-      fails, revoke the access token from your npm account settings. Prereleases
-      take `--tag next`.
+    - Prerelease tags publish automatically too, under the `next` dist-tag; the
+      routine prerelease (RC) flow stays untagged and manual, though (next
+      bullet).
+    - **Manual fallback** (CI publish unavailable) and untagged prereleases:
+      publish from `theme/` inside a narrow auth window. Run `npm login` right
+      before and `npm logout` right after, whether or not publishing succeeded;
+      if logout fails, revoke the access token from your npm account settings.
+      Prereleases take `--tag next`.
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -459,7 +459,9 @@ If not adjust accordingly.
       ```
 
     - Re-point the `next` dist-tag at the new stable (dist-tags never move on
-      their own, and `next` must stay `>= latest`):
+      their own, and `next` must stay `>= latest`). OIDC covers only the publish
+      itself, so run this inside a narrow auth window (login/logout, next
+      bullet), then re-verify the dist-tags:
 
       ```sh
       npm dist-tag add @docsy/theme@${REL#v} next

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -451,14 +451,14 @@ If not adjust accordingly.
     the [publish workflow][], which publishes `@docsy/theme` from the tagged
     commit through npm [trusted publishing][] (OIDC; no npm token involved) once
     a maintainer approves the run (the `npm-publish` environment).
-    - **Before approving** the waiting `npm-publish` deployment, verify:
-      - the tag points at the intended release commit on `$BASE`;
-      - the run is `publish.yaml` on `google/docsy`, triggered by that tag;
-      - the pack job is green and its log shows the expected version;
-      - the version is above the registry's current `latest` and no other
-        publish run is pending (runs queue one at a time, and a publish-job
-        guard rejects a candidate below the registry's `latest`, so an
-        out-of-order approval fails rather than regressing `latest`).
+    - **Before approving** the waiting `npm-publish` deployment. The guards
+      re-verify content and registry order mechanically (an out-of-order or
+      inconsistent run fails instead of publishing), and the approval prompt
+      only appears after the pack job succeeded, so approval owns **intent**:
+      - the run's commit is the tip of `$BASE`, and the tag actor is the release
+        driver you expect; anything else: reject and ask;
+      - the run is `publish.yaml` on `google/docsy` (another workflow could
+        reference the same environment).
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -447,14 +447,28 @@ If not adjust accordingly.
 
     </details>
 
-15. **Publish the theme package**:
-    - Until [trusted publishing][] is adopted, authenticate for a narrow publish
-      window only: `npm login` right before publishing, `npm logout` right after
-      (whether or not publishing succeeded). If logout fails, revoke the access
-      token from your npm account settings.
-    - Publish to the npm registry from `theme/` at the tagged release commit.
-    - Verify the published version.
-    - Verify that the `latest` and `next` dist-tags point at it.
+15. **Verify the npm publish**. Pushing the release tag to `upstream` triggers
+    the [publish workflow][], which publishes `@docsy/theme` from the tagged
+    commit through npm [trusted publishing][] (OIDC; no npm token involved).
+    - Check that the workflow run succeeded and that the registry version
+      matches the tag:
+
+      ```sh
+      npm view @docsy/theme version dist-tags
+      ```
+
+    - Re-point the `next` dist-tag at the new stable -- dist-tags never move on
+      their own, and `next` must stay `>= latest`:
+
+      ```sh
+      npm dist-tag add @docsy/theme@${REL#v} next
+      ```
+
+    - **Manual fallback** (CI publish unavailable) and prereleases: publish from
+      `theme/` inside a narrow auth window -- `npm login` right before,
+      `npm logout` right after, whether or not publishing succeeded (if logout
+      fails, revoke the access token from your npm account settings).
+      Prereleases take `--tag next`.
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 
@@ -725,6 +739,7 @@ To test a Docsy branch or release from a consumer site, for each site:
 [officially supports]: /project/about/changelog/#official-support
 [opentelemetry.io]: https://github.com/open-telemetry/opentelemetry.io
 [package.json]: <{{% param github_repo %}}/blob/main/package.json>
+[publish workflow]: <{{% param github_repo %}}/actions/workflows/publish.yaml>
 [Release notes]: <{{% param github_repo %}}/releases>
 [theme/hugo.yaml]: <{{% param github_repo %}}/blob/main/theme/hugo.yaml>
 [theme/package.json]: <{{% param github_repo %}}/blob/main/theme/package.json>

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -472,7 +472,9 @@ If not adjust accordingly.
       Publish from `theme/` inside a narrow auth window: run `npm login` right
       before and `npm logout` right after, whether or not publishing succeeded;
       if logout fails, revoke the access token from your npm account settings.
-      Prereleases take `--tag next`.
+      Prereleases take `--tag next`. Always pass `--ignore-scripts=false`: the
+      theme `prepack` must run (it materializes the LICENSE), even under a
+      script-disabling npm config.
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -454,7 +454,11 @@ If not adjust accordingly.
     - **Before approving** the waiting `npm-publish` deployment, verify:
       - the tag points at the intended release commit on `$BASE`;
       - the run is `publish.yaml` on `google/docsy`, triggered by that tag;
-      - the pack job is green and its log shows the expected version.
+      - the pack job is green and its log shows the expected version;
+      - the version is above the registry's current `latest` and no other
+        publish run is pending (approvals out of order would leave `latest` on
+        the older version; runs queue one at a time, but the queue can't see the
+        registry).
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 
@@ -468,7 +472,8 @@ If not adjust accordingly.
       bullet), then re-verify the dist-tags:
 
       ```sh
-      npm dist-tag add @docsy/theme@${REL#v} next
+      npm dist-tag add @docsy/theme@${REL#v} next \
+        --@docsy:registry=https://registry.npmjs.org
       ```
 
     - **Manual publishes** (prereleases only): the workflow triggers only on
@@ -478,11 +483,14 @@ If not adjust accordingly.
       fails, revoke the access token from your npm account settings:
 
       ```sh
-      npm publish --ignore-scripts=false --tag next
+      npm publish --ignore-scripts=false --tag next \
+        --@docsy:registry=https://registry.npmjs.org
       ```
 
       `--ignore-scripts=false` is required: the theme `prepack` must run (it
-      materializes the LICENSE), even under a script-disabling npm config.
+      materializes the LICENSE), even under a script-disabling npm config. The
+      scope-registry pin guards against a local `@docsy:registry` override,
+      which outranks even `--registry`.
 
     - **If the CI publish is broken for a stable**, prefer fixing CI over a
       laptop publish: a manual publish carries no provenance attestation. As a
@@ -490,7 +498,7 @@ If not adjust accordingly.
 
       ```sh
       npm publish --ignore-scripts=false --access public --tag latest \
-        --registry https://registry.npmjs.org
+        --@docsy:registry=https://registry.npmjs.org
       ```
 
 16. Update the [deploy/prod][] branch from `$BASE`.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -467,10 +467,9 @@ If not adjust accordingly.
       npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
-    - The workflow triggers only on stable `vX.Y.Z` tags; prereleases publish
-      manually (next bullet).
-    - **Manual fallback** (CI publish unavailable) and untagged prereleases:
-      publish from `theme/` inside a narrow auth window. Run `npm login` right
+    - **Manual publishes** (prereleases, or CI fallback): the workflow triggers
+      only on stable `vX.Y.Z` tags, so prereleases always publish manually.
+      Publish from `theme/` inside a narrow auth window: run `npm login` right
       before and `npm logout` right after, whether or not publishing succeeded;
       if logout fails, revoke the access token from your npm account settings.
       Prereleases take `--tag next`.

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -451,6 +451,10 @@ If not adjust accordingly.
     the [publish workflow][], which publishes `@docsy/theme` from the tagged
     commit through npm [trusted publishing][] (OIDC; no npm token involved) once
     a maintainer approves the run (the `npm-publish` environment).
+    - **Before approving** the waiting `npm-publish` deployment, verify:
+      - the tag points at the intended release commit on `$BASE`;
+      - the run is `publish.yaml` on `google/docsy`, triggered by that tag;
+      - the pack job is green and its log shows the expected version.
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 
@@ -467,14 +471,27 @@ If not adjust accordingly.
       npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
-    - **Manual publishes** (prereleases, or CI fallback): the workflow triggers
-      only on stable `vX.Y.Z` tags, so prereleases always publish manually.
-      Publish from `theme/` inside a narrow auth window: run `npm login` right
-      before and `npm logout` right after, whether or not publishing succeeded;
-      if logout fails, revoke the access token from your npm account settings.
-      Prereleases take `--tag next`. Always pass `--ignore-scripts=false`: the
-      theme `prepack` must run (it materializes the LICENSE), even under a
-      script-disabling npm config.
+    - **Manual publishes** (prereleases only): the workflow triggers only on
+      stable `vX.Y.Z` tags, so prereleases always publish manually. Publish from
+      `theme/` inside a narrow auth window: run `npm login` right before and
+      `npm logout` right after, whether or not publishing succeeded; if logout
+      fails, revoke the access token from your npm account settings:
+
+      ```sh
+      npm publish --ignore-scripts=false --tag next
+      ```
+
+      `--ignore-scripts=false` is required: the theme `prepack` must run (it
+      materializes the LICENSE), even under a script-disabling npm config.
+
+    - **If the CI publish is broken for a stable**, prefer fixing CI over a
+      laptop publish: a manual publish carries no provenance attestation. As a
+      deliberate exception, mirror the workflow's release choices exactly:
+
+      ```sh
+      npm publish --ignore-scripts=false --access public --tag latest \
+        --registry https://registry.npmjs.org
+      ```
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -457,18 +457,18 @@ If not adjust accordingly.
       npm view @docsy/theme version dist-tags
       ```
 
-    - Re-point the `next` dist-tag at the new stable -- dist-tags never move on
-      their own, and `next` must stay `>= latest`:
+    - Re-point the `next` dist-tag at the new stable (dist-tags never move on
+      their own, and `next` must stay `>= latest`):
 
       ```sh
       npm dist-tag add @docsy/theme@${REL#v} next
       ```
 
     - **Manual fallback** (CI publish unavailable) and prereleases: publish from
-      `theme/` inside a narrow auth window -- `npm login` right before,
-      `npm logout` right after, whether or not publishing succeeded (if logout
-      fails, revoke the access token from your npm account settings).
-      Prereleases take `--tag next`.
+      `theme/` inside a narrow auth window. Run `npm login` right before and
+      `npm logout` right after, whether or not publishing succeeded; if logout
+      fails, revoke the access token from your npm account settings. Prereleases
+      take `--tag next`.
 
 16. Update the [deploy/prod][] branch from `$BASE`.
 

--- a/docsy.dev/content/en/project/about/maintainer-notes.md
+++ b/docsy.dev/content/en/project/about/maintainer-notes.md
@@ -456,9 +456,9 @@ If not adjust accordingly.
       - the run is `publish.yaml` on `google/docsy`, triggered by that tag;
       - the pack job is green and its log shows the expected version;
       - the version is above the registry's current `latest` and no other
-        publish run is pending (approvals out of order would leave `latest` on
-        the older version; runs queue one at a time, but the queue can't see the
-        registry).
+        publish run is pending (runs queue one at a time, and a publish-job
+        guard rejects a candidate below the registry's `latest`; approving in
+        version order keeps the queue itself honest).
     - Check that the workflow run succeeded and that the registry version
       matches the tag:
 

--- a/scripts/npm-pack.test.mjs
+++ b/scripts/npm-pack.test.mjs
@@ -284,7 +284,7 @@ for (const [name, pkg] of Object.entries(PACKAGES)) {
     const { entries } = packed.get(name);
     const { missing, extra } = packDiff(pkg, entries);
     assert.deepEqual(missing, [], 'all required entries are packed');
-    assert.deepEqual(extra, [], 'only allowed entries are packed');
+    assert.deepEqual(extra, [], 'packed entries clear the forbidden rules');
   });
 
   test(`${name}: npm pack stays within file-count and size limits`, () => {

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -56,8 +56,20 @@ export function checkGuards({
   enginesNpmRange,
   themeVersion,
   themePublishConfig,
+  ignoreScripts,
 }) {
   const problems = [];
+
+  // The theme prepack must run at publish time (it materializes LICENSE), so
+  // any config layer suppressing lifecycle scripts malforms the artifact.
+  // The publish command also forces --ignore-scripts=false; this names the
+  // misconfiguration instead of leaving a missing-LICENSE contract failure.
+  if (ignoreScripts !== 'false') {
+    problems.push(
+      `effective npm ignore-scripts is '${ignoreScripts}', not 'false'; ` +
+        'publishing needs the theme prepack lifecycle',
+    );
+  }
 
   const enginesFloor = floorOfEnginesRange(enginesNpmRange);
   for (const [floor, why] of [
@@ -102,6 +114,14 @@ function main() {
     enginesNpmRange: pkg('.').engines?.npm,
     themeVersion: pkg('theme').version,
     themePublishConfig: pkg('theme').publishConfig,
+    // npm resolves project config at the workspace root even when publishing
+    // from theme/ (workspace members' .npmrc files are ignored, and npm
+    // config refuses workspace cwds with ENOWORKSPACES), so sample from the
+    // repo root.
+    ignoreScripts: execSync('npm config get ignore-scripts', {
+      encoding: 'utf8',
+      cwd: repoRoot,
+    }).trim(),
   };
   console.log(JSON.stringify(input, null, 2));
 

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -113,9 +113,11 @@ export function checkRegistryAdvance(candidate, registryLatest) {
       ];
     }
   } catch {
-    // A non-stable candidate is the stable-version guard's finding; don't
-    // mask the other guards by throwing here.
-    return [`registry check skipped: candidate '${candidate}' is not stable`];
+    // A non-stable candidate is the stable-version guard's finding; report
+    // (fail-closed) without masking it.
+    return [
+      `registry check cannot compare: candidate '${candidate}' is not stable`,
+    ];
   }
   return [];
 }
@@ -141,6 +143,8 @@ function main() {
     themePublishConfig: pkg('theme').publishConfig,
   };
   if (withRegistry) {
+    // `version` resolves to the latest dist-tag's version; keep that true if
+    // this command ever changes.
     input.registryLatest = execSync('npm view @docsy/theme version', {
       encoding: 'utf8',
       cwd: repoRoot,

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -5,7 +5,7 @@
 // exported for the colocated tests; only main() touches the environment.
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -49,55 +49,6 @@ export function floorOfEnginesRange(range) {
 // reviewed shape; the publish command's CLI flags are the outranking backstop.
 const PUBLISH_CONFIG_JSON = '{"access":"public"}';
 
-// The publish workflow's own contract. Running lifecycle scripts at publish
-// time is safe only while the job is install-free (first-party code only),
-// minimally permissioned, and pinned to the two reviewed actions; these
-// checks fail the run loudly if an edit breaks that coupling. Checked in
-// test:tooling at edit time and re-checked by main() in the publish job
-// itself, which also covers tags on commits that skipped PR CI.
-export function checkWorkflowContract(text) {
-  const problems = [];
-  const prose = text
-    .split('\n')
-    .filter((line) => !/^\s*#/.test(line))
-    .join('\n');
-
-  const install =
-    /\b(npm\s+(ci|i|install|update|rebuild|exec)|npx|pnpm|yarn|corepack)\b/.exec(
-      prose,
-    );
-  if (install) problems.push(`workflow runs an install command: ${install[0]}`);
-
-  for (const m of prose.matchAll(/uses:\s*([^\s#]+)/g)) {
-    if (!/^actions\/(checkout|setup-node)@[0-9a-f]{40}$/.test(m[1])) {
-      problems.push(`workflow action not allowlisted + SHA-pinned: ${m[1]}`);
-    }
-  }
-
-  const perms = [...prose.matchAll(/^\s*([\w-]+):\s*(read|write)\s*$/gm)]
-    .map((m) => `${m[1]}: ${m[2]}`)
-    .sort();
-  const wanted = ['contents: read', 'id-token: write'];
-  if (JSON.stringify(perms) !== JSON.stringify(wanted)) {
-    problems.push(`workflow permissions [${perms}] != [${wanted}]`);
-  }
-
-  for (const required of [
-    'permissions: {}',
-    'environment: npm-publish',
-    'persist-credentials: false',
-    'package-manager-cache: false',
-    '--ignore-scripts=false',
-    'npm publish',
-  ]) {
-    if (!prose.includes(required)) {
-      problems.push(`workflow is missing '${required}'`);
-    }
-  }
-
-  return problems;
-}
-
 // Returns problem descriptions; an empty array means all guards hold.
 export function checkGuards({
   tag,
@@ -105,30 +56,8 @@ export function checkGuards({
   enginesNpmRange,
   themeVersion,
   themePublishConfig,
-  ignoreScripts,
-  installFree,
 }) {
   const problems = [];
-
-  // Lifecycle-scripts-on is safe only while nothing third-party can run:
-  // the two invariants below and the workflow contract travel together.
-  if (!installFree) {
-    problems.push(
-      'dependencies are installed (node_modules present); ' +
-        'the publish job must stay install-free',
-    );
-  }
-
-  // The theme prepack must run at publish time (it materializes LICENSE), so
-  // any config layer suppressing lifecycle scripts malforms the artifact.
-  // The publish command also forces --ignore-scripts=false; this names the
-  // misconfiguration instead of leaving a missing-LICENSE contract failure.
-  if (ignoreScripts !== 'false') {
-    problems.push(
-      `effective npm ignore-scripts is '${ignoreScripts}', not 'false'; ` +
-        'publishing needs the theme prepack lifecycle',
-    );
-  }
 
   const enginesFloor = floorOfEnginesRange(enginesNpmRange);
   for (const [floor, why] of [
@@ -173,29 +102,10 @@ function main() {
     enginesNpmRange: pkg('.').engines?.npm,
     themeVersion: pkg('theme').version,
     themePublishConfig: pkg('theme').publishConfig,
-    // npm resolves project config at the workspace root even when publishing
-    // from theme/ (workspace members' .npmrc files are ignored, and npm
-    // config refuses workspace cwds with ENOWORKSPACES), so sample from the
-    // repo root.
-    ignoreScripts: execSync('npm config get ignore-scripts', {
-      encoding: 'utf8',
-      cwd: repoRoot,
-    }).trim(),
-    installFree: ['node_modules', 'theme/node_modules'].every(
-      (d) => !existsSync(path.join(repoRoot, d)),
-    ),
   };
   console.log(JSON.stringify(input, null, 2));
 
-  const problems = [
-    ...checkGuards(input),
-    ...checkWorkflowContract(
-      readFileSync(
-        path.join(repoRoot, '.github/workflows/publish.yaml'),
-        'utf8',
-      ),
-    ),
-  ];
+  const problems = checkGuards(input);
   for (const p of problems) console.error(`GUARD FAILED: ${p}`);
   process.exit(problems.length ? 1 : 0);
 }

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -14,12 +14,18 @@ import { fileURLToPath } from 'node:url';
 // could legitimately move without this publish-specific bound in mind.
 export const OIDC_NPM_FLOOR = '11.5.1';
 
-const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+const STABLE_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 export function parseVersion(v) {
-  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
-  if (!m) throw new Error(`unparseable version: '${v}'`);
-  return m.slice(1).map(Number);
+  const s = v.trim();
+  // Strict semver normal form: no leading zeros; npm also caps versions at
+  // 256 characters and rejects components beyond the safe-integer range.
+  const m = s.length <= 256 && STABLE_VERSION_RE.exec(s);
+  const parts = m ? m.slice(1).map(Number) : [];
+  if (!m || !parts.every(Number.isSafeInteger)) {
+    throw new Error(`unparseable version: '${v}'`);
+  }
+  return parts;
 }
 
 export function cmpVersions(a, b) {
@@ -38,12 +44,18 @@ export function floorOfEnginesRange(range) {
   return m[1];
 }
 
+// publishConfig may carry any npm config key (registry, tag, provenance, ...)
+// and outranks env-level config at publish time, so pin it to the one
+// reviewed shape; the publish command's CLI flags are the outranking backstop.
+const PUBLISH_CONFIG_JSON = '{"access":"public"}';
+
 // Returns problem descriptions; an empty array means all guards hold.
 export function checkGuards({
   tag,
   npmVersion,
   enginesNpmRange,
   themeVersion,
+  themePublishConfig,
 }) {
   const problems = [];
 
@@ -68,6 +80,11 @@ export function checkGuards({
     problems.push(`tag '${tag}' != stamped theme version 'v${themeVersion}'`);
   }
 
+  const pcJson = JSON.stringify(themePublishConfig);
+  if (pcJson !== PUBLISH_CONFIG_JSON) {
+    problems.push(`theme publishConfig ${pcJson} != ${PUBLISH_CONFIG_JSON}`);
+  }
+
   return problems;
 }
 
@@ -84,6 +101,7 @@ function main() {
     npmVersion: execSync('npm --version', { encoding: 'utf8' }).trim(),
     enginesNpmRange: pkg('.').engines?.npm,
     themeVersion: pkg('theme').version,
+    themePublishConfig: pkg('theme').publishConfig,
   };
   console.log(JSON.stringify(input, null, 2));
 

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -5,7 +5,7 @@
 // exported for the colocated tests; only main() touches the environment.
 
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -49,6 +49,55 @@ export function floorOfEnginesRange(range) {
 // reviewed shape; the publish command's CLI flags are the outranking backstop.
 const PUBLISH_CONFIG_JSON = '{"access":"public"}';
 
+// The publish workflow's own contract. Running lifecycle scripts at publish
+// time is safe only while the job is install-free (first-party code only),
+// minimally permissioned, and pinned to the two reviewed actions; these
+// checks fail the run loudly if an edit breaks that coupling. Checked in
+// test:tooling at edit time and re-checked by main() in the publish job
+// itself, which also covers tags on commits that skipped PR CI.
+export function checkWorkflowContract(text) {
+  const problems = [];
+  const prose = text
+    .split('\n')
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+
+  const install =
+    /\b(npm\s+(ci|i|install|update|rebuild|exec)|npx|pnpm|yarn|corepack)\b/.exec(
+      prose,
+    );
+  if (install) problems.push(`workflow runs an install command: ${install[0]}`);
+
+  for (const m of prose.matchAll(/uses:\s*([^\s#]+)/g)) {
+    if (!/^actions\/(checkout|setup-node)@[0-9a-f]{40}$/.test(m[1])) {
+      problems.push(`workflow action not allowlisted + SHA-pinned: ${m[1]}`);
+    }
+  }
+
+  const perms = [...prose.matchAll(/^\s*([\w-]+):\s*(read|write)\s*$/gm)]
+    .map((m) => `${m[1]}: ${m[2]}`)
+    .sort();
+  const wanted = ['contents: read', 'id-token: write'];
+  if (JSON.stringify(perms) !== JSON.stringify(wanted)) {
+    problems.push(`workflow permissions [${perms}] != [${wanted}]`);
+  }
+
+  for (const required of [
+    'permissions: {}',
+    'environment: npm-publish',
+    'persist-credentials: false',
+    'package-manager-cache: false',
+    '--ignore-scripts=false',
+    'npm publish',
+  ]) {
+    if (!prose.includes(required)) {
+      problems.push(`workflow is missing '${required}'`);
+    }
+  }
+
+  return problems;
+}
+
 // Returns problem descriptions; an empty array means all guards hold.
 export function checkGuards({
   tag,
@@ -57,8 +106,18 @@ export function checkGuards({
   themeVersion,
   themePublishConfig,
   ignoreScripts,
+  installFree,
 }) {
   const problems = [];
+
+  // Lifecycle-scripts-on is safe only while nothing third-party can run:
+  // the two invariants below and the workflow contract travel together.
+  if (!installFree) {
+    problems.push(
+      'dependencies are installed (node_modules present); ' +
+        'the publish job must stay install-free',
+    );
+  }
 
   // The theme prepack must run at publish time (it materializes LICENSE), so
   // any config layer suppressing lifecycle scripts malforms the artifact.
@@ -122,10 +181,21 @@ function main() {
       encoding: 'utf8',
       cwd: repoRoot,
     }).trim(),
+    installFree: ['node_modules', 'theme/node_modules'].every(
+      (d) => !existsSync(path.join(repoRoot, d)),
+    ),
   };
   console.log(JSON.stringify(input, null, 2));
 
-  const problems = checkGuards(input);
+  const problems = [
+    ...checkGuards(input),
+    ...checkWorkflowContract(
+      readFileSync(
+        path.join(repoRoot, '.github/workflows/publish.yaml'),
+        'utf8',
+      ),
+    ),
+  ];
   for (const p of problems) console.error(`GUARD FAILED: ${p}`);
   process.exit(problems.length ? 1 : 0);
 }

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -69,7 +69,16 @@ export function checkGuards({
     }
   }
 
-  if (!STABLE_VERSION_RE.test(themeVersion)) {
+  // Validate via parseVersion so the safe-integer and length bounds apply,
+  // not just the regex shape.
+  let stableVersion = false;
+  try {
+    parseVersion(themeVersion);
+    stableVersion = true;
+  } catch {
+    // fall through to the problem report
+  }
+  if (!stableVersion) {
     problems.push(
       `theme version '${themeVersion}' is not a stable X.Y.Z version; ` +
         'prereleases are published manually, not from CI',

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -97,6 +97,29 @@ export function checkGuards({
   return problems;
 }
 
+// The registry's `latest` may be a prerelease (e.g. 0.16.0-rc.1), so compare
+// numeric cores only. Equal cores pass: the first stable shares its RC's
+// core, and a true duplicate version already fails at the registry.
+export function checkRegistryAdvance(candidate, registryLatest) {
+  const m = /^(\d+\.\d+\.\d+)(?:[-+]|$)/.exec(registryLatest.trim());
+  if (!m) {
+    return [`unparseable registry latest version: '${registryLatest}'`];
+  }
+  try {
+    if (cmpVersions(candidate, m[1]) < 0) {
+      return [
+        `candidate ${candidate} is below the registry latest ` +
+          `${registryLatest}; publishing would regress the latest dist-tag`,
+      ];
+    }
+  } catch {
+    // A non-stable candidate is the stable-version guard's finding; don't
+    // mask the other guards by throwing here.
+    return [`registry check skipped: candidate '${candidate}' is not stable`];
+  }
+  return [];
+}
+
 function main() {
   const repoRoot = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -105,6 +128,11 @@ function main() {
   const pkg = (p) =>
     JSON.parse(readFileSync(path.join(repoRoot, p, 'package.json'), 'utf8'));
 
+  // --registry additionally asserts the candidate doesn't regress the
+  // registry's latest (network read; run it in the publish job, post-approval,
+  // where the answer is freshest). The root .npmrc scope pin applies via cwd.
+  const withRegistry = process.argv[2] === '--registry';
+
   const input = {
     tag: process.env.TAG ?? '',
     npmVersion: execSync('npm --version', { encoding: 'utf8' }).trim(),
@@ -112,9 +140,20 @@ function main() {
     themeVersion: pkg('theme').version,
     themePublishConfig: pkg('theme').publishConfig,
   };
+  if (withRegistry) {
+    input.registryLatest = execSync('npm view @docsy/theme version', {
+      encoding: 'utf8',
+      cwd: repoRoot,
+    }).trim();
+  }
   console.log(JSON.stringify(input, null, 2));
 
-  const problems = checkGuards(input);
+  const problems = [
+    ...checkGuards(input),
+    ...(withRegistry
+      ? checkRegistryAdvance(input.themeVersion, input.registryLatest)
+      : []),
+  ];
   for (const p of problems) console.error(`GUARD FAILED: ${p}`);
   process.exit(problems.length ? 1 : 0);
 }

--- a/scripts/publish-guards.mjs
+++ b/scripts/publish-guards.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Guards for the publish workflow (.github/workflows/publish.yaml): fail
+// before `npm publish` on toolchain or tag mistakes that would otherwise
+// surface as cryptic registry errors or an immutable mispublish. Pure checks
+// exported for the colocated tests; only main() touches the environment.
+
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Below this, the npm CLI cannot mint OIDC credentials for trusted
+// publishing. The engines floor is stricter today, but it serves installs and
+// could legitimately move without this publish-specific bound in mind.
+export const OIDC_NPM_FLOOR = '11.5.1';
+
+const STABLE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+export function parseVersion(v) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v.trim());
+  if (!m) throw new Error(`unparseable version: '${v}'`);
+  return m.slice(1).map(Number);
+}
+
+export function cmpVersions(a, b) {
+  const [pa, pb] = [parseVersion(a), parseVersion(b)];
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+// The engines entries use the plain '>=X.Y.Z' form; anything else means the
+// manifest changed shape and this parser needs updating: fail, don't guess.
+export function floorOfEnginesRange(range) {
+  const m = /^>=\s*(\d+\.\d+\.\d+)$/.exec(range ?? '');
+  if (!m) throw new Error(`unsupported engines range: '${range}'`);
+  return m[1];
+}
+
+// Returns problem descriptions; an empty array means all guards hold.
+export function checkGuards({
+  tag,
+  npmVersion,
+  enginesNpmRange,
+  themeVersion,
+}) {
+  const problems = [];
+
+  const enginesFloor = floorOfEnginesRange(enginesNpmRange);
+  for (const [floor, why] of [
+    [OIDC_NPM_FLOOR, 'the OIDC trusted-publishing floor'],
+    [enginesFloor, 'the engines floor'],
+  ]) {
+    if (cmpVersions(npmVersion, floor) < 0) {
+      problems.push(`npm ${npmVersion} < ${floor} (${why})`);
+    }
+  }
+
+  if (!STABLE_VERSION_RE.test(themeVersion)) {
+    problems.push(
+      `theme version '${themeVersion}' is not a stable X.Y.Z version; ` +
+        'prereleases are published manually, not from CI',
+    );
+  }
+
+  if (tag !== `v${themeVersion}`) {
+    problems.push(`tag '${tag}' != stamped theme version 'v${themeVersion}'`);
+  }
+
+  return problems;
+}
+
+function main() {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+  );
+  const pkg = (p) =>
+    JSON.parse(readFileSync(path.join(repoRoot, p, 'package.json'), 'utf8'));
+
+  const input = {
+    tag: process.env.TAG ?? '',
+    npmVersion: execSync('npm --version', { encoding: 'utf8' }).trim(),
+    enginesNpmRange: pkg('.').engines?.npm,
+    themeVersion: pkg('theme').version,
+  };
+  console.log(JSON.stringify(input, null, 2));
+
+  const problems = checkGuards(input);
+  for (const p of problems) console.error(`GUARD FAILED: ${p}`);
+  process.exit(problems.length ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   OIDC_NPM_FLOOR,
   checkGuards,
+  checkRegistryAdvance,
   cmpVersions,
   floorOfEnginesRange,
   parseVersion,
@@ -119,6 +120,28 @@ test('checkGuards flags a tag that does not match the stamped version', () => {
   const problems = checkGuards({ ...good, tag: 'v0.17.1' });
   assert.equal(problems.length, 1);
   assert.match(problems[0], /!= stamped theme version/);
+});
+
+test('checkRegistryAdvance compares numeric cores, prerelease-safe', () => {
+  // First stable over its own RC: equal cores, allowed (a true duplicate
+  // version already fails at the registry).
+  assert.deepEqual(checkRegistryAdvance('0.16.0', '0.16.0-rc.1'), []);
+  assert.deepEqual(checkRegistryAdvance('0.17.0', '0.16.0'), []);
+  assert.deepEqual(checkRegistryAdvance('0.17.0', '0.17.0'), []);
+
+  const regress = checkRegistryAdvance('0.17.0', '0.17.1');
+  assert.equal(regress.length, 1);
+  assert.match(regress[0], /regress/);
+
+  const garbage = checkRegistryAdvance('0.17.0', 'not-a-version');
+  assert.equal(garbage.length, 1);
+  assert.match(garbage[0], /unparseable registry/);
+
+  // A non-stable candidate reports instead of throwing (the stable-version
+  // guard owns that finding; a throw would mask it).
+  const dev = checkRegistryAdvance('0.16.1-dev', '0.16.0');
+  assert.equal(dev.length, 1);
+  assert.match(dev[0], /not stable/);
 });
 
 test('repo engines npm floor parses and covers the OIDC floor', () => {

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -10,7 +10,6 @@ import { fileURLToPath } from 'node:url';
 import {
   OIDC_NPM_FLOOR,
   checkGuards,
-  checkWorkflowContract,
   cmpVersions,
   floorOfEnginesRange,
   parseVersion,
@@ -62,8 +61,6 @@ const good = {
   enginesNpmRange: '>=11.16.0',
   themeVersion: '0.17.0',
   themePublishConfig: { access: 'public' },
-  ignoreScripts: 'false',
-  installFree: true,
 };
 
 test('checkGuards passes a consistent stable release', () => {
@@ -109,75 +106,6 @@ test('checkGuards pins publishConfig to the reviewed shape', () => {
     const problems = checkGuards({ ...good, themePublishConfig: bad });
     assert.equal(problems.length, 1, JSON.stringify(bad));
     assert.match(problems[0], /publishConfig/);
-  }
-});
-
-test('checkGuards requires lifecycle scripts to be enabled', () => {
-  for (const bad of ['true', 'undefined', '']) {
-    const problems = checkGuards({ ...good, ignoreScripts: bad });
-    assert.equal(problems.length, 1, `ignoreScripts '${bad}'`);
-    assert.match(problems[0], /ignore-scripts/);
-  }
-});
-
-test('checkGuards requires the job to be install-free', () => {
-  const problems = checkGuards({ ...good, installFree: false });
-  assert.equal(problems.length, 1);
-  assert.match(problems[0], /install-free/);
-});
-
-const workflowText = fs.readFileSync(
-  path.join(repoRoot, '.github/workflows/publish.yaml'),
-  'utf8',
-);
-
-test('publish workflow meets its contract', () => {
-  assert.deepEqual(checkWorkflowContract(workflowText), []);
-});
-
-test('checkWorkflowContract flags contract breaks', () => {
-  // Each mutation of the real workflow must produce a finding, proving the
-  // checks carry signal rather than passing vacuously.
-  const mutations = {
-    'install command': [
-      workflowText + '\n      - run: npm ci\n',
-      /install command/,
-    ],
-    'unpinned action': [
-      workflowText.replace(/uses: actions\/checkout@[0-9a-f]{40}/, () => {
-        return 'uses: actions/checkout@v6';
-      }),
-      /allowlisted \+ SHA-pinned/,
-    ],
-    'foreign action': [
-      workflowText.replace(/uses: actions\/checkout@/, () => {
-        return 'uses: someorg/action@';
-      }),
-      /allowlisted \+ SHA-pinned/,
-    ],
-    'widened permissions': [
-      workflowText.replace(
-        'id-token: write',
-        'id-token: write\n      packages: write',
-      ),
-      /permissions/,
-    ],
-    'missing environment': [
-      workflowText.replace('environment: npm-publish', ''),
-      /npm-publish/,
-    ],
-    'scripts not forced on': [
-      workflowText.replace('--ignore-scripts=false', ''),
-      /ignore-scripts=false/,
-    ],
-  };
-  for (const [name, [text, re]] of Object.entries(mutations)) {
-    const problems = checkWorkflowContract(text);
-    assert.ok(problems.length >= 1, `${name} is flagged`);
-    assert.ok(
-      problems.some((p) => re.test(p)),
-      `${name}: [${problems}] matches ${re}`,
-    );
   }
 });
 

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -86,13 +86,19 @@ test('checkGuards flags a prerelease version', () => {
 });
 
 test('checkGuards flags npm-invalid stable-looking versions', () => {
-  const problems = checkGuards({
-    ...good,
-    tag: 'v01.2.3',
-    themeVersion: '01.2.3',
-  });
-  assert.equal(problems.length, 1);
-  assert.match(problems[0], /not a stable/);
+  for (const bad of [
+    '01.2.3', // leading zeros
+    '9007199254740993.0.0', // beyond Number.isSafeInteger
+    `1.2.${'3'.repeat(260)}`, // beyond npm's 256-char cap
+  ]) {
+    const problems = checkGuards({
+      ...good,
+      tag: `v${bad}`,
+      themeVersion: bad,
+    });
+    assert.equal(problems.length, 1, bad);
+    assert.match(problems[0], /not a stable/);
+  }
 });
 
 test('checkGuards pins publishConfig to the reviewed shape', () => {

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -20,10 +20,21 @@ const repoRoot = path.resolve(
   '..',
 );
 
-test('parseVersion handles stable versions only', () => {
+test('parseVersion handles strict stable versions only', () => {
   assert.deepEqual(parseVersion('11.5.1'), [11, 5, 1]);
   assert.deepEqual(parseVersion(' 24.0.0 '), [24, 0, 0]);
-  for (const bad of ['11.5', '11.5.1-beta.1', 'lts/*', '']) {
+  assert.deepEqual(parseVersion('1.0.0'), [1, 0, 0]);
+  for (const bad of [
+    '11.5',
+    '11.5.1-beta.1',
+    'lts/*',
+    '',
+    '01.2.3', // leading zeros: npm-invalid semver
+    '1.02.3',
+    '1.2.03',
+    '9007199254740993.0.0', // beyond Number.isSafeInteger
+    `1.2.${'3'.repeat(260)}`, // beyond npm's 256-char cap
+  ]) {
     assert.throws(() => parseVersion(bad), /unparseable/, bad);
   }
 });
@@ -49,6 +60,7 @@ const good = {
   npmVersion: '11.16.0',
   enginesNpmRange: '>=11.16.0',
   themeVersion: '0.17.0',
+  themePublishConfig: { access: 'public' },
 };
 
 test('checkGuards passes a consistent stable release', () => {
@@ -71,6 +83,30 @@ test('checkGuards flags a prerelease version', () => {
   });
   assert.equal(problems.length, 1);
   assert.match(problems[0], /not a stable/);
+});
+
+test('checkGuards flags npm-invalid stable-looking versions', () => {
+  const problems = checkGuards({
+    ...good,
+    tag: 'v01.2.3',
+    themeVersion: '01.2.3',
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /not a stable/);
+});
+
+test('checkGuards pins publishConfig to the reviewed shape', () => {
+  for (const bad of [
+    { access: 'public', tag: 'next' },
+    { access: 'public', provenance: false },
+    { access: 'restricted' },
+    {},
+    undefined,
+  ]) {
+    const problems = checkGuards({ ...good, themePublishConfig: bad });
+    assert.equal(problems.length, 1, JSON.stringify(bad));
+    assert.match(problems[0], /publishConfig/);
+  }
 });
 
 test('checkGuards flags a tag that does not match the stamped version', () => {

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -123,8 +123,7 @@ test('checkGuards flags a tag that does not match the stamped version', () => {
 });
 
 test('checkRegistryAdvance compares numeric cores, prerelease-safe', () => {
-  // First stable over its own RC: equal cores, allowed (a true duplicate
-  // version already fails at the registry).
+  // Equal-core cases (rationale at checkRegistryAdvance).
   assert.deepEqual(checkRegistryAdvance('0.16.0', '0.16.0-rc.1'), []);
   assert.deepEqual(checkRegistryAdvance('0.17.0', '0.16.0'), []);
   assert.deepEqual(checkRegistryAdvance('0.17.0', '0.17.0'), []);
@@ -137,8 +136,7 @@ test('checkRegistryAdvance compares numeric cores, prerelease-safe', () => {
   assert.equal(garbage.length, 1);
   assert.match(garbage[0], /unparseable registry/);
 
-  // A non-stable candidate reports instead of throwing (the stable-version
-  // guard owns that finding; a throw would mask it).
+  // Non-stable candidate: reports instead of throwing.
   const dev = checkRegistryAdvance('0.16.1-dev', '0.16.0');
   assert.equal(dev.length, 1);
   assert.match(dev[0], /not stable/);

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -1,0 +1,91 @@
+// Tests for the publish-workflow guards (publish-guards.mjs); picked up by
+// test:tooling.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  OIDC_NPM_FLOOR,
+  checkGuards,
+  cmpVersions,
+  floorOfEnginesRange,
+  parseVersion,
+} from './publish-guards.mjs';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+test('parseVersion handles stable versions only', () => {
+  assert.deepEqual(parseVersion('11.5.1'), [11, 5, 1]);
+  assert.deepEqual(parseVersion(' 24.0.0 '), [24, 0, 0]);
+  for (const bad of ['11.5', '11.5.1-beta.1', 'lts/*', '']) {
+    assert.throws(() => parseVersion(bad), /unparseable/, bad);
+  }
+});
+
+test('cmpVersions compares numerically per position', () => {
+  assert.equal(cmpVersions('11.5.1', '11.5.1'), 0);
+  assert.equal(cmpVersions('11.4.9', '11.5.1'), -1);
+  assert.equal(cmpVersions('11.10.0', '11.9.0'), 1); // numeric, not lexical
+  assert.equal(cmpVersions('12.0.0', '11.99.99'), 1);
+  assert.equal(cmpVersions('11.5.0', '11.5.1'), -1);
+});
+
+test('floorOfEnginesRange accepts only the >=X.Y.Z form', () => {
+  assert.equal(floorOfEnginesRange('>=11.16.0'), '11.16.0');
+  assert.equal(floorOfEnginesRange('>= 11.16.0'), '11.16.0');
+  for (const bad of ['^11.0.0', '11.16.0', '>=11.16', undefined]) {
+    assert.throws(() => floorOfEnginesRange(bad), /unsupported/, String(bad));
+  }
+});
+
+const good = {
+  tag: 'v0.17.0',
+  npmVersion: '11.16.0',
+  enginesNpmRange: '>=11.16.0',
+  themeVersion: '0.17.0',
+};
+
+test('checkGuards passes a consistent stable release', () => {
+  assert.deepEqual(checkGuards(good), []);
+});
+
+test('checkGuards flags npm below the floors', () => {
+  const below = checkGuards({ ...good, npmVersion: '11.4.0' });
+  assert.equal(below.length, 2, 'both floors flagged');
+  const between = checkGuards({ ...good, npmVersion: '11.6.0' });
+  assert.equal(between.length, 1, 'engines floor flagged');
+  assert.match(between[0], /engines floor/);
+});
+
+test('checkGuards flags a prerelease version', () => {
+  const problems = checkGuards({
+    ...good,
+    tag: 'v0.17.0-rc.1',
+    themeVersion: '0.17.0-rc.1',
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /not a stable/);
+});
+
+test('checkGuards flags a tag that does not match the stamped version', () => {
+  const problems = checkGuards({ ...good, tag: 'v0.17.1' });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /!= stamped theme version/);
+});
+
+test('repo engines npm floor parses and covers the OIDC floor', () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'),
+  );
+  const floor = floorOfEnginesRange(pkg.engines.npm);
+  assert.ok(
+    cmpVersions(floor, OIDC_NPM_FLOOR) >= 0,
+    `engines floor ${floor} covers OIDC floor ${OIDC_NPM_FLOOR}`,
+  );
+});

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   OIDC_NPM_FLOOR,
   checkGuards,
+  checkWorkflowContract,
   cmpVersions,
   floorOfEnginesRange,
   parseVersion,
@@ -62,6 +63,7 @@ const good = {
   themeVersion: '0.17.0',
   themePublishConfig: { access: 'public' },
   ignoreScripts: 'false',
+  installFree: true,
 };
 
 test('checkGuards passes a consistent stable release', () => {
@@ -115,6 +117,67 @@ test('checkGuards requires lifecycle scripts to be enabled', () => {
     const problems = checkGuards({ ...good, ignoreScripts: bad });
     assert.equal(problems.length, 1, `ignoreScripts '${bad}'`);
     assert.match(problems[0], /ignore-scripts/);
+  }
+});
+
+test('checkGuards requires the job to be install-free', () => {
+  const problems = checkGuards({ ...good, installFree: false });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /install-free/);
+});
+
+const workflowText = fs.readFileSync(
+  path.join(repoRoot, '.github/workflows/publish.yaml'),
+  'utf8',
+);
+
+test('publish workflow meets its contract', () => {
+  assert.deepEqual(checkWorkflowContract(workflowText), []);
+});
+
+test('checkWorkflowContract flags contract breaks', () => {
+  // Each mutation of the real workflow must produce a finding, proving the
+  // checks carry signal rather than passing vacuously.
+  const mutations = {
+    'install command': [
+      workflowText + '\n      - run: npm ci\n',
+      /install command/,
+    ],
+    'unpinned action': [
+      workflowText.replace(/uses: actions\/checkout@[0-9a-f]{40}/, () => {
+        return 'uses: actions/checkout@v6';
+      }),
+      /allowlisted \+ SHA-pinned/,
+    ],
+    'foreign action': [
+      workflowText.replace(/uses: actions\/checkout@/, () => {
+        return 'uses: someorg/action@';
+      }),
+      /allowlisted \+ SHA-pinned/,
+    ],
+    'widened permissions': [
+      workflowText.replace(
+        'id-token: write',
+        'id-token: write\n      packages: write',
+      ),
+      /permissions/,
+    ],
+    'missing environment': [
+      workflowText.replace('environment: npm-publish', ''),
+      /npm-publish/,
+    ],
+    'scripts not forced on': [
+      workflowText.replace('--ignore-scripts=false', ''),
+      /ignore-scripts=false/,
+    ],
+  };
+  for (const [name, [text, re]] of Object.entries(mutations)) {
+    const problems = checkWorkflowContract(text);
+    assert.ok(problems.length >= 1, `${name} is flagged`);
+    assert.ok(
+      problems.some((p) => re.test(p)),
+      `${name}: [${problems}] matches ${re}`,
+    );
   }
 });
 

--- a/scripts/publish-guards.test.mjs
+++ b/scripts/publish-guards.test.mjs
@@ -61,6 +61,7 @@ const good = {
   enginesNpmRange: '>=11.16.0',
   themeVersion: '0.17.0',
   themePublishConfig: { access: 'public' },
+  ignoreScripts: 'false',
 };
 
 test('checkGuards passes a consistent stable release', () => {
@@ -106,6 +107,14 @@ test('checkGuards pins publishConfig to the reviewed shape', () => {
     const problems = checkGuards({ ...good, themePublishConfig: bad });
     assert.equal(problems.length, 1, JSON.stringify(bad));
     assert.match(problems[0], /publishConfig/);
+  }
+});
+
+test('checkGuards requires lifecycle scripts to be enabled', () => {
+  for (const bad of ['true', 'undefined', '']) {
+    const problems = checkGuards({ ...good, ignoreScripts: bad });
+    assert.equal(problems.length, 1, `ignoreScripts '${bad}'`);
+    assert.match(problems[0], /ignore-scripts/);
   }
 });
 


### PR DESCRIPTION
- **Publish workflow** (new, tag-triggered): a stable `vX.Y.Z` tag runs a two-job pipeline; prereleases stay manual.
  - `pack` (no OIDC grant, install-free): tag-on-main ancestry check, guards, pack contract, tarball build.
  - `publish` (gated on the `npm-publish` environment, 15-minute timeout): re-runs the guards against the registry, then publishes the tarball through [trusted publishing](https://docs.npmjs.com/trusted-publishers), so no npm token exists anywhere and no lifecycle script runs with the OIDC grant.
- **Guards** (`scripts/publish-guards.mjs`, tested, wired into `test:tooling`): fail before an immutable mispublish, on
  - a tag off `main`'s history (release tags come from `main` only; a `release`-branch patch flow needs a deliberate widening first)
  - a tag/stamped-version mismatch
  - a non-stable or npm-invalid version
  - npm below the OIDC floor
  - an unreviewed `publishConfig`
  - a candidate below the registry's current `latest` (publish job)
- **Maintainer notes step 15**: reworked around the CI flow; start review there (pre-approval runbook, dist-tag auth window, manual prerelease and fallback commands, the main-only constraint).
- **Root `.npmrc`**: pins the `@docsy` scope registry for manual commands (a user-level scope mapping outranks `--registry`).
- **One-time maintainer setup** — hard prerequisites, not suggestions: the in-repo guards bind against mistakes only (on tag pushes the workflow definition travels with the tag), so these controls are what bound malice. No release tag until all are done.
  - Before merge: create the protected `npm-publish` environment (required reviewers, self-review prevented, admin bypass off) — GitHub auto-creates a bare, unprotected environment on first workflow reference otherwise.
  - Before merge: a ruleset restricting `v*` tag creation to maintainers; confirm `main`'s protection stays.
  - After merge: register the npmjs trusted publisher (workflow `publish.yaml`, environment `npm-publish`, allowed actions `npm publish` only; the form requires the workflow file to exist on the repo).
- **Preview**: [maintainer notes § Publishing a release](https://deploy-preview-2708--docsydocs.netlify.app/project/about/maintainer-notes/#publishing-a-release)