### PR TITLE
Renovate: exclude hugo-extended, updated manually in batch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
   "labels": ["dependencies"],
   "enabledManagers": ["custom.jsonata"],
   "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "hugo-extended is intentionally pinned; updated manually via `npm run update:hugo`",
+      "matchPackageNames": ["hugo-extended"],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "jsonata",


### PR DESCRIPTION
- Encodes the manual-batch decision before it can bite: today only the JSONata Mermaid manager is enabled, so nothing touches hugo-extended yet -- but enabling the npm manager (the config anticipates growth) would silently put the Hugo pin on Renovate's schedule. A Hugo bump moves several files together (version declarations, `allowScripts`, draft-post freezes), which `npm run update:hugo` + the batch flow own.
- Mirrors opentelemetry.io's Renovate rule for the same package.